### PR TITLE
Minimal working example. Codes runs inefficiently. Add "prepFromAria" functionality.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ name: RAiDER
 channels:
  - conda-forge
  - anaconda
- - moble
  - defaults
 dependencies:
  - python>=3
@@ -17,10 +16,8 @@ dependencies:
  - netcdf4
  - cython
  - dask
- - gcc
  - gdal>=3.0
  - h5py
- - h5py-cache
  - jupyterlab
  - libgdal
  - matplotlib

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -90,11 +90,11 @@ def checkArgs(args, p):
     # output file format
     if args.outformat is None:
        if args.heightlvs is not None: 
-          args.outformat = 'hdf5'
+          outformat = 'hdf5'
        elif args.station_file is not None: 
-          args.outformat = 'netcdf'
+          outformat = 'netcdf'
        else:
-          args.outformat = 'ENVI'
+          outformat = 'ENVI'
     else:
        outformat = args.outformat
     # ensuring consistent file extensions
@@ -141,19 +141,19 @@ def checkArgs(args, p):
        wmLoc = os.path.join(args.out, 'weather_files')
 
     if args.heightlvs is not None: 
-       if args.outformat.lower() != 'hdf5':
+       if outformat.lower() != 'hdf5':
           print("WARNING: input arguments require HDF5 output file type; changing outformat to HDF5")
        outformat = 'hdf5'
     elif args.station_file is not None:
-       if args.outformat.lower() != 'netcdf':
+       if outformat.lower() != 'netcdf':
           print("WARNING: input arguments require HDF5 output file type; changing outformat to HDF5")
        outformat = 'netcdf'
     else:
-       if args.outformat.lower() == 'hdf5':
+       if outformat.lower() == 'hdf5':
           print("WARNING: output require raster output file; changing outformat to ENVI")
           outformat = 'ENVI'
        else:
-          outformat = args.outformat.lower()
+          outformat = outformat.lower()
 
     # parallelization
     parallel = True if not args.no_parallel else False

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -211,12 +211,19 @@ def tropo_delay(los, lats, lons, heights, flag, weather_model, wmLoc, zref,
         wmLoc = os.path.join(out, 'weather_files')
 
     # weather model calculation
-    weather_model_file = os.path.join(wmLoc, 'test.h5')
+    wm_filename = '{}_{}.h5'.format(weather_model['name'], time)
+    weather_model_file = os.path.join(wmLoc, wm_filename)
     if not os.path.exists(weather_model_file):
         weather_model, lats, lons = prepareWeatherModel(weather_model, wmLoc, out, lats=lats,  
                         lons=lons, time=time, verbose=verbose, download_only=download_only)
-        weather_model.write2HDF5(weather_model_file)
+        try:
+            weather_model.write2HDF5(weather_model_file)
+        except:
+            pass
         del weather_model
+
+    if download_only:
+        return None, None
 
     pnts_file = os.path.join('geom', 'testx.h5')
     if not os.path.exists(pnts_file):
@@ -256,7 +263,6 @@ def writePnts2HDF5(lats, lons, hgts, los, outName = 'testx.h5', in_shape = None)
     '''
     import datetime
     import h5py
-    import h5py_cache as h5c
     import os
 
     from RAiDER.utilFcns import checkLOS
@@ -272,7 +278,8 @@ def writePnts2HDF5(lats, lons, hgts, los, outName = 'testx.h5', in_shape = None)
     lats, lons, hgts = np.moveaxis(llas, -1, 0)
     los = los.reshape((np.prod(los.shape[:-1]), los.shape[-1]))
 
-    with h5c.File(outName, 'w', chunk_cache_mem_size=1024**2*4000) as f:
+    with h5py.File(outName, 'w') as f:
+    #with h5py.File(outName, 'w', chunk_cache_mem_size=1024**2*4000) as f:
         x = f.create_dataset('lon', data = lons.flatten(), chunks = True)
         y = f.create_dataset('lat', data = lats.flatten(), chunks = x.chunks)
         z = f.create_dataset('hgt', data = hgts.flatten(), chunks = x.chunks)
@@ -285,4 +292,3 @@ def writePnts2HDF5(lats, lons, hgts, los, outName = 'testx.h5', in_shape = None)
         lengths = f.create_dataset('Rays_len',  (len(x),), chunks = x.chunks)
         lengths.attrs['NumRays'] = len(x)
         scaled_look_vecs = f.create_dataset('Rays_SLV',  (len(x),3), chunks = los.chunks)
-

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -30,8 +30,8 @@ def readLL(*args):
     if flag=='files':
         # If they are files, open them
         lat, lon = args
-        lats, latproj = gdal_open(lat, returnProj = True)
-        lons, lonproj = gdal_open(lon, returnProj = True)
+        lats, latproj, lat_gt = gdal_open(lat, returnProj = True)
+        lons, lonproj, lon_gt = gdal_open(lon, returnProj = True)
     elif flag=='bounding_box':
         N,W,S,E = args
         lats = np.array([float(N), float(S)])

--- a/tools/RAiDER/prepFromAria.py
+++ b/tools/RAiDER/prepFromAria.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 
+# Author: Jeremy Maurer
+# Copyright 2020, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged.
+# 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import gdal
+import numpy as np
+from RAiDER.utilFcns import gdal_open, writeArrayToRaster
+
+
+def parse_args():
+    """Parse command line arguments using argparse."""
+    import argparse
+    p = argparse.ArgumentParser(
+        description='Prepare files from ARIA-tools output to use with RAiDER')
+
+    # Line of sight
+    p.add_argument(
+        '--incFile', '-i',type=str,
+        help='GDAL-readable raster image file of inclination',
+        metavar='INC', required=True)
+    p.add_argument(
+        '--azFile', '-a',type=str,
+        help='GDAL-readable raster image file of azimuth',
+        metavar='AZ', required=True)
+
+    p.add_argument(
+        '--los_filename', '-f', default = 'los.rdr', type=str, dest='los_file',
+        help=('Output Line-of-sight filename'))
+    p.add_argument(
+        '--lat_filename', '-l', default = 'lat.rdr', type=str, dest='lat_file',
+        help=('Output latitude filename'))
+    p.add_argument(
+        '--lon_filename', '-L', default = 'lon.rdr', type=str, dest='lon_file',
+        help=('Output longitude filename'))
+
+    p.add_argument(
+        '--format', '-t',default = 'ENVI', type=str, dest='fmt',
+        help=('Output file format'))
+
+    return p.parse_args(), p
+
+
+def makeLatLonGrid(inFile, lonFileName, latFileName, fmt = 'ENVI'):
+    '''
+    Convert the geocoded grids to lat/lon files for input to RAiDER
+    '''
+    ds = gdal.Open(inFile, gdal.GA_ReadOnly)
+    xSize = ds.RasterXSize
+    ySize = ds.RasterYSize
+    gt = ds.GetGeoTransform()
+    proj = ds.GetProjection()
+
+    # Create the xy grid
+    xStart = gt[0]
+    yStart = gt[3]
+    xStep = gt[1]
+    yStep = gt[-1]
+
+    xEnd = xStart + xStep*xSize-xStep
+    yEnd = yStart + yStep*ySize-yStep
+    
+    x = np.arange(xStart, xEnd, xStep)
+    y = np.arange(yStart, yEnd, yStep)
+    X,Y = np.meshgrid(x,y)
+    writeArrayToRaster(X, lonFileName, 0., fmt, proj, gt)
+    writeArrayToRaster(Y, latFileName, 0., fmt, proj, gt)
+
+
+
+def makeLOSFile(incFile, azFile, fmt = 'ENVI', filename = 'los.rdr'):
+    '''
+    Create a line-of-sight file from ARIA-derived azimuth and inclination files
+    '''
+    az, az_proj, az_gt = gdal_open(azFile, returnProj = True)
+    az[az==0]=np.nan
+    inc = gdal_open(incFile)
+
+    heading = 90 - az
+    heading[np.isnan(heading)] = 0.
+
+    array_shp = np.shape(az)[:2]
+    dType = az.dtype
+
+    if 'complex' in str(dType):
+        dType = gdal.GDT_CFloat32
+    elif 'float' in str(dType):
+        dType = gdal.GDT_Float32
+    else:
+        dType = gdal.GDT_Byte
+
+    # Write the data to a file
+    driver = gdal.GetDriverByName(fmt)
+    ds = driver.Create(filename, array_shp[1], array_shp[0],  2, dType)
+    ds.SetProjection(az_proj)
+    ds.SetGeoTransform(az_gt)
+    b1 = ds.GetRasterBand(1)
+    b1.WriteArray(inc)
+    b1.SetNoDataValue(0.)
+    b2 = ds.GetRasterBand(2)
+    b2.WriteArray(heading)
+    b2.SetNoDataValue(0.)
+    ds = None
+    b1 = None
+    b2 = None
+
+    return 0
+
+
+def prepFromAria():
+    '''
+    A command-line utility to convert ARIA standard product outputs from ARIA-tools to 
+    RAiDER-compatible format
+    '''
+    args, p = parse_args()
+    makeLOSFile(args.incFile, args.azFile, args.fmt, args.los_file)
+    makeLatLonGrid(args.incFile, args.lon_file, args.lat_file, args.fmt)

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -68,7 +68,7 @@ def prepareWeatherModel(weatherDict, wmFileLoc, out, lats=None, lons=None, time=
             print('WARNING: download_only flag selected. I will only '
                   'download the weather model, '
                   ' without doing any further processing.')
-            return None, None
+            return None, None, None
 
     # Load the weather model data
     if weather_model_name == 'pickle':

--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -143,9 +143,10 @@ def parseCMD():
     # Loop over each datetime and compute the delay
     for t, wfn, hfn in zip(times, wetNames, hydroNames):
         try:
-            tropo_delay(los, lats, lons, heights, flag, weather_model, wmLoc, zref,
+            (_,_) = tropo_delay(los, lats, lons, heights, flag, weather_model, wmLoc, zref,
                outformat, t, out, download_only, parallel, verbose, wfn, hfn)
-        except RuntimeError:
+        except RuntimeError as e:
             print('Date {} failed'.format(t))
+            print(e)
             continue
 

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -155,6 +155,7 @@ def gdal_open(fname, returnProj = False):
     except:
         raise RuntimeError('File {} could not be opened'.format(fname))
     proj = ds.GetProjection()
+    gt = ds.GetGeoTransform()
 
     val = []
     for band in range(ds.RasterCount):
@@ -178,7 +179,7 @@ def gdal_open(fname, returnProj = False):
     if not returnProj:
         return data
     else:
-        return data, proj
+        return data, proj, gt
 
 
 def pickle_load(f):

--- a/tools/bin/prepARIA.py
+++ b/tools/bin/prepARIA.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Author: Jeremy Maurer, Raymond Hogenson & David Bekaert
+# Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged.
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from RAiDER.prepFromAria import prepFromAria
+
+if __name__ == '__main__':
+    prepFromAria()


### PR DESCRIPTION
- This updates the current version so that it will actually run without breaking for basic inputs
- Code is inefficient but it does not break on large areas due to the HDF5 implementation
- Added functionality to generate useable files for RAiDER from ARIA outputs (results of running ariaExtract.py on standard products)

Apologies for the weird commit history; I didn't realize I have to squash commits before pushing them. :\