### PR TITLE
Added option to download zenith delays virtually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup (name = 'RAiDER',
                     'RAiDER.models': 'tools/RAiDER/models'},
        packages=['tools', 'RAiDER', 'RAiDER.models'],
        ext_modules = cythonize(extensions, quiet = True, compiler_directives={'language_level': 3}),
-       scripts=['tools/bin/raiderDelay.py', 'tools/bin/raiderStats.py'])
+       scripts=['tools/bin/raiderDelay.py', 'tools/bin/raiderStats.py', 'tools/bin/raiderDownloadGNSS.py'])
 

--- a/tools/RAiDER/downloadGNSSDelays.py
+++ b/tools/RAiDER/downloadGNSSDelays.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+import os
+import sys
+import requests
+import argparse
+import itertools
+import pandas as pd
+from RAiDER.getStationDelays import getStationData
+
+
+#base URL for UNR repository
+_UNR_URL = "http://geodesy.unr.edu/"
+
+
+def download_UNR(statID, year, writeDir = '.', baseURL = _UNR_URL, download = False, verbose = False):
+    '''
+    Download a zip file containing tropospheric delays for a given station and year
+    The URL format is http://geodesy.unr.edu/gps_timeseries/trop/<ssss>/<ssss>.<yyyy>.trop.zip
+    Inputs:
+        statID   - 4-character station identifier
+        year     - 4-numeral year
+    '''
+    URL = "{0}gps_timeseries/trop/{1}/{1}.{2}.trop.zip".format(baseURL, statID.upper(), year)
+    if download:
+        saveLoc = os.path.abspath(os.path.join(writeDir, '{0}.{1}.trop.zip'.format(statID.upper(), year)))
+        filepath = download_url(URL, saveLoc, verbose=verbose)
+    else:
+        filepath = check_url(URL, verbose=verbose)
+    return filepath
+
+
+def getStatsByllh(llhBox = None, baseURL = _UNR_URL, userstatList = None):
+    '''
+    Function to pull lat, lon, height, beginning date, end date, and number of solutions for stations inside the bounding box llhBox. 
+    llhBox should be a tuple with format (lat1, lat2, lon1, lon2), where lat1, lon1 define the lower left-hand corner and lat2, lon2 
+    define the upper right corner. 
+    '''
+    import pandas as pd
+    from urllib.request import urlopen 
+
+    if llhBox is None:
+        llhBox = [-90, 90, 0, 360]
+
+    stationHoldings = '{}NGLStationPages/DataHoldings.txt'.format(baseURL)
+    data = urlopen(stationHoldings) # it's a file like object and works just like a file
+    stations = []
+    for ind, line in enumerate(data): # files are iterable
+        if ind == 0:
+            continue
+        statID, lat, lon = getID(line)
+        # Only pass if in bbox
+        # And if user list of stations specified, only pass info for stations within list
+        if inBox(lat, lon, llhBox) and (not userstatList or statID in userstatList):
+            #convert lon into range [-180,180]
+            lon = fix_lons(lon)
+            stations.append({'ID': statID, 'Lat': lat, 'Lon': lon})
+    
+    print('{} stations were found'.format(len(stations)))
+    stations = pd.DataFrame(stations)
+    # Report stations from user's list that do not cover bbox
+    if userstatList:
+        userstatList=[i for i in userstatList if i not in stations['ID'].to_list()]
+        if userstatList:
+            print("Warning: The following user-input stations are not covered by the input bounding box {0}: {1}" \
+                .format(str(llhBox).strip('[]'),str(userstatList).strip('[]')))
+        
+    return stations
+
+
+def check_url(url, verbose = False):
+    '''
+    Check whether a file exists at a URL. Modified from 
+    https://stackoverflow.com/questions/9419162/download-returned-zip-file-from-url
+    '''
+    r = requests.get(url, stream=True)
+    if r.status_code==404:
+        return ''
+    else:
+        return url
+
+
+def download_url(url, save_path, verbose = False, chunk_size=128):
+    '''
+    Download a file from a URL. Modified from 
+    https://stackoverflow.com/questions/9419162/download-returned-zip-file-from-url
+    '''
+    r = requests.get(url, stream=True)
+    if r.status_code==404:
+        return ''
+    else:
+        if verbose:
+            print('Beginning download of {} to {}'.format(url, save_path))
+        with open(save_path, 'wb') as fd:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                fd.write(chunk)
+        if verbose:
+            print('Completed download of {} to {}'.format(url, save_path))
+        return save_path
+
+
+def readStationFile(filename):
+    '''
+    Read a list of GNSS station names from a plain text file
+    '''
+    statList = []
+    with open(filename, 'r') as f:
+        for line in f:
+            statList.append(line.strip())
+    return statList 
+
+
+def writeStationList(statList, filename = 'gnssStationList_overbbox.txt'):
+    '''
+    Write a python list of GNSS station names to a simple text file
+    '''
+    with open(filename, 'w') as f:
+        for stat in statList:
+            f.write('{}\n'.format(stat))
+
+
+def getStationList(bbox = None, writeLoc = None, userstatList = None):
+    '''
+    Creates a list of stations inside a lat/lon bounding box from a source
+    Inputs: 
+        bbox    - length-4 list of floats that describes a bounding box. Format is 
+                  S N W E
+    '''
+    if writeLoc is None:
+        writeLoc = os.path.join(os.getcwd(), 'gnssStationList_overbbox.csv')
+    else:
+        writeLoc = os.path.join(writeLoc, 'gnssStationList_overbbox.csv')
+
+    if userstatList:
+        with open(userstatList) as f:
+            userstatList = [line.rstrip('\n') for line in f]
+
+    statList = getStatsByllh(llhBox = bbox, userstatList = userstatList)
+
+    # write to file and pass final stations list
+    statList.to_csv(writeLoc, index=False)
+    stations = list(statList['ID'].values)
+
+    return stations, writeLoc
+
+
+def inBox(lat, lon, llhbox):
+    '''
+    Checks whether the given lat, lon pair are inside the bounding box llhbox
+    '''
+    lattest = lat < llhbox[1] and lat > llhbox[0]    
+    lontest = lon < llhbox[3] and lon > llhbox[2]
+    if lattest and lontest:
+        return True
+    else:
+        return False
+
+
+def fix_lons(lon):
+    """
+    Fix the given longitudes into the range ``[-180, 180]``.
+
+    """
+    fixed_lon = ((lon + 180) % 360) - 180
+    # Make the positive 180s positive again.
+    if fixed_lon == -180 and lon > 0:
+        fixed_lon *= -1
+
+    return fixed_lon
+
+
+def getID(line):
+    '''
+    Pulls the station ID, lat, and lon for a given entry in the UNR text file
+    '''
+    statID = str(line.split()[0].decode('utf-8'))
+    lat = float(line.split()[1].decode('utf-8'))
+    lon = float(line.split()[2].decode('utf-8'))
+
+    return statID, lat, lon
+
+
+def downloadTropoDelays(stats, years, writeDir = '.', download = False, verbose = False):
+    '''
+    Check for and download GNSS tropospheric delays from an archive. If download is True then 
+    files will be physically downloaded, which again is not necessary as data can be virtually accessed. 
+    '''
+
+    # argument checking
+    if not isinstance(stats, list):
+        if not isinstance(stats, str):
+            raise TypeError('stats should be a string or a list of strings')
+        stats = [stats]
+    if not isinstance(years, list):
+        if not isinstance(years, int):
+            try:
+                years = list(int(years))
+            except TypeError:
+                raise TypeError('years should be an int or a list of ints')
+        years = [years]
+
+    # Iterate over stations and years and check or download data
+    results = []
+    stat_year_tup = itertools.product(stats, years)
+    for s, y in stat_year_tup:
+        if verbose:
+            print('Currently checking station {} in {}'.format(s, y))
+        fileurl = download_UNR(s, y, writeDir = writeDir, download = download, verbose = verbose)
+        # only record valid path
+        if fileurl:
+            results.append({'ID': s, 'year': y, 'path': fileurl})
+    return pd.DataFrame(results).set_index('ID')
+            
+
+def parse_years(input):
+    '''
+    Takes string input and returns a list of years as integers
+    '''
+    test = len(input.split(',')) > 1
+    if test:
+        years = [int(y) for y in input.split(',')]
+        if years[1] > years[0] + 1:
+            years = [years[0] + k for k in range(years[1] - years[0] + 1)]
+    else:
+        years = [int(input)]
+    return years
+    
+
+def parse_args():
+    """Parse command line arguments using argparse."""
+    p = argparse.ArgumentParser(
+          formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Check for and download tropospheric zenith delays for a set of GNSS stations from UNR
+Usage examples: 
+downloadGNSSdelay.py -y 2010 --check
+downloadGNSSdelay.py -y 2010 -b 40 -79 39 -78 -v
+downloadGNSSdelay.py -y 2010 -f station_list.txt --out products
+""")
+ 
+    p.add_argument(
+        '--years', '-y', dest='years', nargs='+',
+        help="""Year to check or download delays (format YYYY).
+Can be a single value or a comma-separated list. If two years non-consecutive years are given, download each year in between as well. 
+""", type=parse_years, required=True)
+
+    # Stations to check/download
+    area = p.add_argument_group('Stations to check/download. Can be a lat/lon bounding box or file, or will run the whole world if not specified')
+    area.add_argument(
+        '--station_file', '-f', default = None, dest='station_file',
+        help=('Text file containing a list of 4-char station IDs separated by newlines'))
+    area.add_argument(
+        '--BBOX', '-b', dest='bounding_box', type=str, default=None,
+        help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
+
+    misc = p.add_argument_group("Run parameters")
+    misc.add_argument(
+        '--outformat', 
+        help='GDAL-compatible file format if surface delays are requested.',
+        default=None)
+
+    misc.add_argument(
+        '--out', dest='out',
+        help='Directory to download products', 
+        default='.')
+
+    misc.add_argument(
+        '--returntime', dest='returnTime',
+        help="Return delays closest to this specified time. If not specified, the GPS delays for all times will be returned. Input in 'HH:MM:SS', e.g. '16:00:00'", 
+        default=None)
+
+    misc.add_argument(
+        '--download',
+        help='Physically download data. Note this is not necessary to proceed with statistical analysis, as data can be handled virtually in the program.',
+        action='store_true',dest='download', default = False)
+
+    misc.add_argument(
+        '--verbose', '-v',
+        help='Run in verbose (debug) mode? Default False',
+        action='store_true',dest='verbose', default = False)
+
+    return p.parse_args(), p
+
+
+def parseCMD():
+    """
+    Parse command-line arguments and pass to tropo_delay
+    We'll parse arguments and call delay.py.
+    """
+    args, p = parse_args()
+
+    # Create specified output directory if it does not exist.
+    if not os.path.exists(args.out):
+        os.mkdir(args.out)
+
+    # Setup bounding box
+    if args.bounding_box:
+        if isinstance ([str(val) for val in args.bounding_box.split()], list) and not os.path.isfile(args.bounding_box):
+            try:
+                bbox = [float(val) for val in args.bounding_box.split()]
+            except:
+                raise Exception('Cannot understand the --bbox argument. String input is incorrect or path does not exist.')
+            #if necessary, convert negative longitudes to positive
+            if bbox[2]<0:
+                bbox[2]+=360
+            if bbox[3]<0:
+                bbox[3]+=360
+    # If bbox not specified, query stations across the entire globe
+    else:
+        bbox = [-90, 90, 0, 360]
+
+    # Handle station query
+    stats, origstatsFile = getStationList(bbox = bbox, writeLoc = args.out, userstatList = args.station_file)
+
+    # iterate over years
+    for yr in args.years:
+        statDF = downloadTropoDelays(stats, yr, writeDir = args.out, download = args.download, verbose = args.verbose)
+        statDF.to_csv(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'))
+
+    # Add lat/lon info
+    origstatsFile = pd.read_csv(origstatsFile)
+    statsFile = pd.read_csv(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'))
+    statsFile = pd.merge(left=statsFile, right=origstatsFile, how='left', left_on='ID', right_on='ID')
+    statsFile.to_csv(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'), index=False)
+    del statDF, origstatsFile, statsFile
+
+    # Extract delays for each station
+    getStationData(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'), outDir = args.out, returnTime = args.returnTime)
+
+    if args.verbose:
+        print('Completed processing')

--- a/tools/RAiDER/downloadGNSSDelays.py
+++ b/tools/RAiDER/downloadGNSSDelays.py
@@ -1,234 +1,28 @@
 #!/usr/bin/env python3
-import os
-import sys
-import requests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Author: Jeremy Maurer, Simran Sangha, & David Bekaert
+# Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 import argparse
 import itertools
+import os
+import sys
+
 import pandas as pd
+import requests
 from RAiDER.getStationDelays import getStationData
 
-
-#base URL for UNR repository
+# base URL for UNR repository
 _UNR_URL = "http://geodesy.unr.edu/"
-
-
-def download_UNR(statID, year, writeDir = '.', baseURL = _UNR_URL, download = False, verbose = False):
-    '''
-    Download a zip file containing tropospheric delays for a given station and year
-    The URL format is http://geodesy.unr.edu/gps_timeseries/trop/<ssss>/<ssss>.<yyyy>.trop.zip
-    Inputs:
-        statID   - 4-character station identifier
-        year     - 4-numeral year
-    '''
-    URL = "{0}gps_timeseries/trop/{1}/{1}.{2}.trop.zip".format(baseURL, statID.upper(), year)
-    if download:
-        saveLoc = os.path.abspath(os.path.join(writeDir, '{0}.{1}.trop.zip'.format(statID.upper(), year)))
-        filepath = download_url(URL, saveLoc, verbose=verbose)
-    else:
-        filepath = check_url(URL, verbose=verbose)
-    return filepath
-
-
-def getStatsByllh(llhBox = None, baseURL = _UNR_URL, userstatList = None):
-    '''
-    Function to pull lat, lon, height, beginning date, end date, and number of solutions for stations inside the bounding box llhBox. 
-    llhBox should be a tuple with format (lat1, lat2, lon1, lon2), where lat1, lon1 define the lower left-hand corner and lat2, lon2 
-    define the upper right corner. 
-    '''
-    import pandas as pd
-    from urllib.request import urlopen 
-
-    if llhBox is None:
-        llhBox = [-90, 90, 0, 360]
-
-    stationHoldings = '{}NGLStationPages/DataHoldings.txt'.format(baseURL)
-    data = urlopen(stationHoldings) # it's a file like object and works just like a file
-    stations = []
-    for ind, line in enumerate(data): # files are iterable
-        if ind == 0:
-            continue
-        statID, lat, lon = getID(line)
-        # Only pass if in bbox
-        # And if user list of stations specified, only pass info for stations within list
-        if inBox(lat, lon, llhBox) and (not userstatList or statID in userstatList):
-            #convert lon into range [-180,180]
-            lon = fix_lons(lon)
-            stations.append({'ID': statID, 'Lat': lat, 'Lon': lon})
-    
-    print('{} stations were found'.format(len(stations)))
-    stations = pd.DataFrame(stations)
-    # Report stations from user's list that do not cover bbox
-    if userstatList:
-        userstatList=[i for i in userstatList if i not in stations['ID'].to_list()]
-        if userstatList:
-            print("Warning: The following user-input stations are not covered by the input bounding box {0}: {1}" \
-                .format(str(llhBox).strip('[]'),str(userstatList).strip('[]')))
-        
-    return stations
-
-
-def check_url(url, verbose = False):
-    '''
-    Check whether a file exists at a URL. Modified from 
-    https://stackoverflow.com/questions/9419162/download-returned-zip-file-from-url
-    '''
-    r = requests.get(url, stream=True)
-    if r.status_code==404:
-        return ''
-    else:
-        return url
-
-
-def download_url(url, save_path, verbose = False, chunk_size=128):
-    '''
-    Download a file from a URL. Modified from 
-    https://stackoverflow.com/questions/9419162/download-returned-zip-file-from-url
-    '''
-    r = requests.get(url, stream=True)
-    if r.status_code==404:
-        return ''
-    else:
-        if verbose:
-            print('Beginning download of {} to {}'.format(url, save_path))
-        with open(save_path, 'wb') as fd:
-            for chunk in r.iter_content(chunk_size=chunk_size):
-                fd.write(chunk)
-        if verbose:
-            print('Completed download of {} to {}'.format(url, save_path))
-        return save_path
-
-
-def readStationFile(filename):
-    '''
-    Read a list of GNSS station names from a plain text file
-    '''
-    statList = []
-    with open(filename, 'r') as f:
-        for line in f:
-            statList.append(line.strip())
-    return statList 
-
-
-def writeStationList(statList, filename = 'gnssStationList_overbbox.txt'):
-    '''
-    Write a python list of GNSS station names to a simple text file
-    '''
-    with open(filename, 'w') as f:
-        for stat in statList:
-            f.write('{}\n'.format(stat))
-
-
-def getStationList(bbox = None, writeLoc = None, userstatList = None):
-    '''
-    Creates a list of stations inside a lat/lon bounding box from a source
-    Inputs: 
-        bbox    - length-4 list of floats that describes a bounding box. Format is 
-                  S N W E
-    '''
-    if writeLoc is None:
-        writeLoc = os.path.join(os.getcwd(), 'gnssStationList_overbbox.csv')
-    else:
-        writeLoc = os.path.join(writeLoc, 'gnssStationList_overbbox.csv')
-
-    if userstatList:
-        with open(userstatList) as f:
-            userstatList = [line.rstrip('\n') for line in f]
-
-    statList = getStatsByllh(llhBox = bbox, userstatList = userstatList)
-
-    # write to file and pass final stations list
-    statList.to_csv(writeLoc, index=False)
-    stations = list(statList['ID'].values)
-
-    return stations, writeLoc
-
-
-def inBox(lat, lon, llhbox):
-    '''
-    Checks whether the given lat, lon pair are inside the bounding box llhbox
-    '''
-    lattest = lat < llhbox[1] and lat > llhbox[0]    
-    lontest = lon < llhbox[3] and lon > llhbox[2]
-    if lattest and lontest:
-        return True
-    else:
-        return False
-
-
-def fix_lons(lon):
-    """
-    Fix the given longitudes into the range ``[-180, 180]``.
-
-    """
-    fixed_lon = ((lon + 180) % 360) - 180
-    # Make the positive 180s positive again.
-    if fixed_lon == -180 and lon > 0:
-        fixed_lon *= -1
-
-    return fixed_lon
-
-
-def getID(line):
-    '''
-    Pulls the station ID, lat, and lon for a given entry in the UNR text file
-    '''
-    statID = str(line.split()[0].decode('utf-8'))
-    lat = float(line.split()[1].decode('utf-8'))
-    lon = float(line.split()[2].decode('utf-8'))
-
-    return statID, lat, lon
-
-
-def downloadTropoDelays(stats, years, writeDir = '.', download = False, verbose = False):
-    '''
-    Check for and download GNSS tropospheric delays from an archive. If download is True then 
-    files will be physically downloaded, which again is not necessary as data can be virtually accessed. 
-    '''
-
-    # argument checking
-    if not isinstance(stats, list):
-        if not isinstance(stats, str):
-            raise TypeError('stats should be a string or a list of strings')
-        stats = [stats]
-    if not isinstance(years, list):
-        if not isinstance(years, int):
-            try:
-                years = list(int(years))
-            except TypeError:
-                raise TypeError('years should be an int or a list of ints')
-        years = [years]
-
-    # Iterate over stations and years and check or download data
-    results = []
-    stat_year_tup = itertools.product(stats, years)
-    for s, y in stat_year_tup:
-        if verbose:
-            print('Currently checking station {} in {}'.format(s, y))
-        fileurl = download_UNR(s, y, writeDir = writeDir, download = download, verbose = verbose)
-        # only record valid path
-        if fileurl:
-            results.append({'ID': s, 'year': y, 'path': fileurl})
-    return pd.DataFrame(results).set_index('ID')
-            
-
-def parse_years(input):
-    '''
-    Takes string input and returns a list of years as integers
-    '''
-    test = len(input.split(',')) > 1
-    if test:
-        years = [int(y) for y in input.split(',')]
-        if years[1] > years[0] + 1:
-            years = [years[0] + k for k in range(years[1] - years[0] + 1)]
-    else:
-        years = [int(input)]
-    return years
-    
 
 def parse_args():
     """Parse command line arguments using argparse."""
     p = argparse.ArgumentParser(
-          formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
 Check for and download tropospheric zenith delays for a set of GNSS stations from UNR
 Usage examples: 
@@ -236,7 +30,7 @@ downloadGNSSdelay.py -y 2010 --check
 downloadGNSSdelay.py -y 2010 -b 40 -79 39 -78 -v
 downloadGNSSdelay.py -y 2010 -f station_list.txt --out products
 """)
- 
+
     p.add_argument(
         '--years', '-y', dest='years', nargs='+',
         help="""Year to check or download delays (format YYYY).
@@ -244,9 +38,10 @@ Can be a single value or a comma-separated list. If two years non-consecutive ye
 """, type=parse_years, required=True)
 
     # Stations to check/download
-    area = p.add_argument_group('Stations to check/download. Can be a lat/lon bounding box or file, or will run the whole world if not specified')
+    area = p.add_argument_group(
+        'Stations to check/download. Can be a lat/lon bounding box or file, or will run the whole world if not specified')
     area.add_argument(
-        '--station_file', '-f', default = None, dest='station_file',
+        '--station_file', '-f', default=None, dest='station_file',
         help=('Text file containing a list of 4-char station IDs separated by newlines'))
     area.add_argument(
         '--BBOX', '-b', dest='bounding_box', type=str, default=None,
@@ -254,29 +49,29 @@ Can be a single value or a comma-separated list. If two years non-consecutive ye
 
     misc = p.add_argument_group("Run parameters")
     misc.add_argument(
-        '--outformat', 
+        '--outformat',
         help='GDAL-compatible file format if surface delays are requested.',
         default=None)
 
     misc.add_argument(
         '--out', dest='out',
-        help='Directory to download products', 
+        help='Directory to download products',
         default='.')
 
     misc.add_argument(
         '--returntime', dest='returnTime',
-        help="Return delays closest to this specified time. If not specified, the GPS delays for all times will be returned. Input in 'HH:MM:SS', e.g. '16:00:00'", 
+        help="Return delays closest to this specified time. If not specified, the GPS delays for all times will be returned. Input in 'HH:MM:SS', e.g. '16:00:00'",
         default=None)
 
     misc.add_argument(
         '--download',
         help='Physically download data. Note this is not necessary to proceed with statistical analysis, as data can be handled virtually in the program.',
-        action='store_true',dest='download', default = False)
+        action='store_true', dest='download', default=False)
 
     misc.add_argument(
         '--verbose', '-v',
         help='Run in verbose (debug) mode? Default False',
-        action='store_true',dest='verbose', default = False)
+        action='store_true', dest='verbose', default=False)
 
     return p.parse_args(), p
 
@@ -294,37 +89,223 @@ def parseCMD():
 
     # Setup bounding box
     if args.bounding_box:
-        if isinstance ([str(val) for val in args.bounding_box.split()], list) and not os.path.isfile(args.bounding_box):
+        if isinstance([str(val) for val in args.bounding_box.split()], list) and not os.path.isfile(args.bounding_box):
             try:
                 bbox = [float(val) for val in args.bounding_box.split()]
             except:
-                raise Exception('Cannot understand the --bbox argument. String input is incorrect or path does not exist.')
-            #if necessary, convert negative longitudes to positive
-            if bbox[2]<0:
-                bbox[2]+=360
-            if bbox[3]<0:
-                bbox[3]+=360
+                raise Exception(
+                    'Cannot understand the --bbox argument. String input is incorrect or path does not exist.')
+            # if necessary, convert negative longitudes to positive
+            if bbox[2] < 0:
+                bbox[2] += 360
+            if bbox[3] < 0:
+                bbox[3] += 360
     # If bbox not specified, query stations across the entire globe
     else:
         bbox = [-90, 90, 0, 360]
 
     # Handle station query
-    stats, origstatsFile = getStationList(bbox = bbox, writeLoc = args.out, userstatList = args.station_file)
+    stats, origstatsFile = getStationList(
+        bbox=bbox, writeLoc=args.out, userstatList=args.station_file)
 
     # iterate over years
     for yr in args.years:
-        statDF = downloadTropoDelays(stats, yr, writeDir = args.out, download = args.download, verbose = args.verbose)
-        statDF.to_csv(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'))
+        statDF = downloadTropoDelays(
+            stats, yr, writeDir=args.out, download=args.download, verbose=args.verbose)
+        statDF.to_csv(os.path.join(
+            args.out, 'gnssStationList_overbbox_withpaths.csv'))
 
     # Add lat/lon info
     origstatsFile = pd.read_csv(origstatsFile)
-    statsFile = pd.read_csv(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'))
-    statsFile = pd.merge(left=statsFile, right=origstatsFile, how='left', left_on='ID', right_on='ID')
-    statsFile.to_csv(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'), index=False)
+    statsFile = pd.read_csv(os.path.join(
+        args.out, 'gnssStationList_overbbox_withpaths.csv'))
+    statsFile = pd.merge(left=statsFile, right=origstatsFile,
+                         how='left', left_on='ID', right_on='ID')
+    statsFile.to_csv(os.path.join(
+        args.out, 'gnssStationList_overbbox_withpaths.csv'), index=False)
     del statDF, origstatsFile, statsFile
 
     # Extract delays for each station
-    getStationData(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'), outDir = args.out, returnTime = args.returnTime)
+    getStationData(os.path.join(args.out, 'gnssStationList_overbbox_withpaths.csv'),
+                   outDir=args.out, returnTime=args.returnTime)
 
     if args.verbose:
         print('Completed processing')
+
+
+def getStationList(bbox=None, writeLoc=None, userstatList=None):
+    '''
+    Creates a list of stations inside a lat/lon bounding box from a source
+    Inputs: 
+        bbox    - length-4 list of floats that describes a bounding box. Format is 
+                  S N W E
+    '''
+    writeLoc = os.path.join(writeLoc or os.getcwd(), 'gnssStationList_overbbox.csv')
+
+    if userstatList:
+        userstatList = readTextFile(userstatList)
+
+    statList = getStatsByllh(llhBox=bbox, userstatList=userstatList)
+
+    # write to file and pass final stations list
+    statList.to_csv(writeLoc, index=False)
+    stations = list(statList['ID'].values)
+
+    return stations, writeLoc
+
+
+def getStatsByllh(llhBox=None, baseURL=_UNR_URL, userstatList=None):
+    '''
+    Function to pull lat, lon, height, beginning date, end date, and number of solutions for stations inside the bounding box llhBox. 
+    llhBox should be a tuple with format (lat1, lat2, lon1, lon2), where lat1, lon1 define the lower left-hand corner and lat2, lon2 
+    define the upper right corner. 
+    '''
+    if llhBox is None:
+        llhBox = [-90, 90, 0, 360]
+
+    stationHoldings = '{}NGLStationPages/DataHoldings.txt'.format(baseURL)
+    # it's a file like object and works just like a file
+    data = requests.get(stationHoldings)
+    stations = []
+    for ind, line in enumerate(data):  # files are iterable
+        if ind == 0:
+            continue
+        statID, lat, lon = getID(line)
+        # Only pass if in bbox
+        # And if user list of stations specified, only pass info for stations within list
+        if inBox(lat, lon, llhBox) and (not userstatList or statID in userstatList):
+            # convert lon into range [-180,180]
+            lon = fix_lons(lon)
+            stations.append({'ID': statID, 'Lat': lat, 'Lon': lon})
+
+    print('{} stations were found'.format(len(stations)))
+    stations = pd.DataFrame(stations)
+    # Report stations from user's list that do not cover bbox
+    if userstatList:
+        userstatList = [
+            i for i in userstatList if i not in stations['ID'].to_list()]
+        if userstatList:
+            print("Warning: The following user-input stations are not covered by the input bounding box {0}: {1}"
+                  .format(str(llhBox).strip('[]'), str(userstatList).strip('[]')))
+
+    return stations
+
+
+def downloadTropoDelays(stats, years, writeDir='.', download=False, verbose=False):
+    '''
+    Check for and download GNSS tropospheric delays from an archive. If download is True then 
+    files will be physically downloaded, which again is not necessary as data can be virtually accessed. 
+    '''
+
+    # argument checking
+    if not isinstance(stats, (list, str)):
+        raise TypeError('stats should be a string or a list of strings')
+    if not isinstance(years, (list, int)):
+        raise TypeError('years should be an int or a list of ints')
+
+    # Iterate over stations and years and check or download data
+    results = []
+    stat_year_tup = itertools.product(stats, years)
+    for s, y in itertools.product(stats, years):
+        if verbose:
+            print('Currently checking station {} in {}'.format(s, y))
+        fileurl = download_UNR(s, y, writeDir=writeDir,
+                               download=download, verbose=verbose)
+        # only record valid path
+        if fileurl:
+            results.append({'ID': s, 'year': y, 'path': fileurl})
+    return pd.DataFrame(results).set_index('ID')
+
+
+def download_UNR(statID, year, writeDir='.', baseURL=_UNR_URL, download=False, verbose=False):
+    '''
+    Download a zip file containing tropospheric delays for a given station and year
+    The URL format is http://geodesy.unr.edu/gps_timeseries/trop/<ssss>/<ssss>.<yyyy>.trop.zip
+    Inputs:
+        statID   - 4-character station identifier
+        year     - 4-numeral year
+    '''
+    URL = "{0}gps_timeseries/trop/{1}/{1}.{2}.trop.zip".format(
+        baseURL, statID.upper(), year)
+    if download:
+        saveLoc = os.path.abspath(os.path.join(
+            writeDir, '{0}.{1}.trop.zip'.format(statID.upper(), year)))
+        filepath = download_url(URL, saveLoc, verbose=verbose)
+    else:
+        filepath = check_url(URL, verbose=verbose)
+    return filepath
+
+
+def download_url(url, save_path, verbose=False, chunk_size=2048):
+    '''
+    Download a file from a URL. Modified from 
+    https://stackoverflow.com/questions/9419162/download-returned-zip-file-from-url
+    '''
+    r = requests.get(url, stream=True)
+    if r.status_code == 404:
+        return ''
+    else:
+        if verbose:
+            print('Beginning download of {} to {}'.format(url, save_path))
+        with open(save_path, 'wb') as fd:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                fd.write(chunk)
+        if verbose:
+            print('Completed download of {} to {}'.format(url, save_path))
+        return save_path
+
+
+def check_url(url, verbose=False):
+    '''
+    Check whether a file exists at a URL. Modified from 
+    https://stackoverflow.com/questions/9419162/download-returned-zip-file-from-url
+    '''
+    r = requests.head(url)
+    if r.status_code == 404:
+        url = ''
+    return url
+
+
+def readTextFile(filename):
+    '''
+    Read a list of GNSS station names from a plain text file
+    '''
+    with open(filename, 'r') as f:
+        return [line.strip() for line in f]
+
+
+def inBox(lat, lon, llhbox):
+    '''
+    Checks whether the given lat, lon pair are inside the bounding box llhbox
+    '''
+    return lat < llhbox[1] and lat > llhbox[0] and lon < llhbox[3] and lon > llhbox[2]
+
+
+def fix_lons(lon):
+    """
+    Fix the given longitudes into the range ``[-180, 180]``.
+    """
+    fixed_lon = ((lon + 180) % 360) - 180
+    # Make the positive 180s positive again.
+    if fixed_lon == -180 and lon > 0:
+        fixed_lon *= -1
+    return fixed_lon
+
+
+def getID(line):
+    '''
+    Pulls the station ID, lat, and lon for a given entry in the UNR text file
+    '''
+    stat_id, lat, lon = line.decode().split()[:3]
+    return stat_id, float(lat), float(lon)
+
+
+def parse_years(timestr):
+    '''
+    Takes string input and returns a list of years as integers
+    '''
+    years = list(map(int, timestr.split(',')))
+    # If two years non-consecutive years are given, query for each year in between
+    if len(years) == 2:
+         years = list(range(years[0],years[1]+1))
+    return years

--- a/tools/RAiDER/getStationDelays.py
+++ b/tools/RAiDER/getStationDelays.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+#
+import copy
+import datetime as dt
+import numpy as np
+import os
+import pandas as pd
+
+def getDate(stationFile):
+    '''
+    extract the date from a station delay file
+    '''
+
+    # find the date info
+    year = int(os.path.basename(stationFile).split('.')[1])
+    doy = int(os.path.basename(stationFile).split('.')[2])
+    date = dt.datetime(year, 1, 1) + dt.timedelta(doy - 1)
+
+    return date, year, doy
+
+
+def getDelays(stationFile, filename, returnTime = None):
+    '''
+    Parses and returns a dictionary containing either (1) all
+    the GPS delays, if returnTime is None, or (2) only the delay
+    at the closest times to to returnTime. 
+    Inputs: 
+         stationFile - a .gz station delay file 
+         returnTime  - specified time of GPS delay
+    Outputs:
+         a dict and CSV file containing the times and delay information
+         (delay in mm, delay uncertainty, delay gradients)
+    '''
+    #import functions
+    import gzip, zipfile, gzip, requests, io
+
+    #Refer to the following sites to interpret stationFile variable names:
+    #ftp://igs.org/pub/data/format/sinex_tropo.txt
+    #http://geodesy.unr.edu/gps_timeseries/README_trop2.txt
+
+    # sort through station zip files
+    allstationTarfiles=[]
+    # if URL
+    if stationFile.startswith('http'):
+        r = requests.get(stationFile)
+        ziprepo = zipfile.ZipFile(io.BytesIO(r.content))
+    # if downloaded file
+    else :
+        ziprepo = zipfile.ZipFile(stationFile)
+    # iterate through tarfiles
+    stationTarlist = ziprepo.namelist()
+    stationTarlist.sort()
+    for j in stationTarlist:
+        f = gzip.open(ziprepo.open(j),'rb')
+        # get the date of the file
+        time, yearFromFile, doyFromFile = getDate(j)
+        # initialize variables
+        d, ngrad, egrad, timesList, Sig = [], [], [],[],[]
+        flag = False
+        for line in f.readlines():
+            try:
+                line = line.decode('utf-8')
+            except:
+                line = line.decode('latin-1')
+            if flag:
+                # Do not attempt to read header
+                if 'SITE' in line:
+                   continue
+                # Attempt to read data
+                try:
+                    #units: mm, mm, mm, deg, deg, deg, deg, mm, mm, K
+                    trotot, trototSD, trwet, tgntot, tgntotSD, tgetot, tgetotSD, wvapor, wvaporSD, mtemp = \
+                        [float(t) for t in line.split()[2:]]
+                except:
+                    continue
+                site = line.split()[0]
+                year, doy, seconds = [int(n) for n in line.split()[1].split(':')]
+                # Break iteration if time from line in file does not match date reported in filename
+                if doy != doyFromFile:
+                   print('WARNING: time %s from line in conflict with time %s from file %s, will continue reading next tarfile(s)' \
+                       %(doy,doyFromFile,j))
+                   continue
+                d.append(trotot)
+                ngrad.append(tgntot)
+                egrad.append(tgetot)
+                timesList.append(seconds)
+                Sig.append(trototSD)
+            if 'TROP/SOLUTION' in line:
+                flag = True
+        del f
+        # Break iteration if file contains no data.
+        if d == []:
+            print('WARNING: file %s for station %s is empty, will continue reading next tarfile(s)'%(j, j.split('.')[0]))
+            continue
+
+        # check for missing times
+        true_times = list(range(0,86400, 300))
+        if len(timesList)!=len(true_times):
+           missing = [True if t not in timesList else False for t in true_times]
+           mask = np.array(missing)
+           delay, sig, east_grad, north_grad = [np.full((288,), np.nan)]*4 
+           delay[~mask] = d
+           sig[~mask] = Sig
+           east_grad[~mask] = egrad
+           north_grad[~mask] = ngrad
+           times = true_times.copy()
+        else:
+           delay     = np.array(d)
+           times     = np.array(timesList)
+           sig       = np.array(Sig)
+           east_grad = np.array(egrad)
+           north_grad= np.array(ngrad)
+
+        # if time not specified, pass all times
+        if returnTime == None:
+            filtoutput = {'ID': [site]*len(north_grad), 'Date': [time]*len(north_grad), 'ZTD': delay, 'north_grad': north_grad, \
+                'east_grad': east_grad, 'doy': times, 'sigZTD': sig}
+            filtoutput = [{key : value[k] for key, value in filtoutput.items()} for k in range(len(filtoutput['ID']))]
+        else:
+            index = np.argmin(np.abs(np.array(timesList) - returnTime))
+            filtoutput = [{'ID': site, 'Date': time, 'ZTD': delay[index], 'north_grad': north_grad[index], \
+                'east_grad': east_grad[index], 'doy': times[index], 'sigZTD': sig[index]}]
+        # setup pandas array and write output to CSV, making sure to update existing CSV.
+        filtoutput = pd.DataFrame(filtoutput)
+        if not os.path.exists(filename):
+            filtoutput.to_csv(filename, index=False)
+        else:
+            filtoutput.to_csv(filename, index=False, mode='a', header=False)
+
+    # record all used tar files
+    allstationTarfiles.extend([os.path.join(stationFile,k) for k in stationTarlist])
+    allstationTarfiles.sort()
+    del ziprepo
+
+    return allstationTarfiles
+
+
+def getStationData(inFile, outDir = None, returnTime = None):
+    '''
+    Pull tropospheric delay data for a given station name
+    '''
+
+    if outDir is None:
+        outDir = os.getcwd()
+
+    pathbase = os.path.join(outDir, 'GPS_delays')
+    if not os.path.exists(pathbase):
+        os.mkdir(pathbase)
+
+    returnTime=(int(returnTime.split(':')[0])*3600)+(int(returnTime.split(':')[1])*60)+int(returnTime.split(':')[2])
+    # print warning if not divisible by 3 seconds
+    if returnTime % 3 != 0:
+        index = np.argmin(np.abs(np.array(list(range(0,86400, 300))) - returnTime))
+        updatedreturnTime = str(dt.timedelta(seconds=list(range(0,86400, 300))[index]))
+        print('Waring: input time %s not divisble by 3 seconds, so next closest time %s will be chosen' \
+            %(returnTime,updatedreturnTime))
+        returnTime = updatedreturnTime
+
+    # get list of station zip files
+    inFile_df = pd.read_csv(inFile)
+    stationFiles = inFile_df['path'].to_list()
+    del inFile_df
+
+    if len(stationFiles)>0:
+        outputfiles=[]
+        for sf in stationFiles:
+            StationID = os.path.basename(sf).split('.')[0]
+            name = os.path.join(pathbase, StationID + '_ztd.csv')
+            result = getDelays(sf, name, returnTime = returnTime)
+            outputfiles.append(name)
+
+    # Consolidate all CSV files into one object
+    name = os.path.join(outDir, 'CombinedGPS_ztd.csv')
+    statsFile = pd.concat([pd.read_csv(i) for i in outputfiles])
+    # Convert the above object into a csv file and export
+    statsFile.to_csv(name, index=False, encoding="utf-8")
+    del statsFile
+
+    # Add lat/lon info
+    origstatsFile = pd.read_csv(inFile)
+    statsFile = pd.read_csv(name)
+    statsFile = pd.merge(left=statsFile, right=origstatsFile[['ID','Lat','Lon']], how='left', left_on='ID', right_on='ID')
+    statsFile.to_csv(name, index=False)
+    del origstatsFile, statsFile

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -7,11 +7,12 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-import os
-import numpy as np
 import datetime as dt
-import pandas as pd
+import os
+
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 from shapely.geometry import Point, Polygon
 
 def createParser():
@@ -38,54 +39,83 @@ raiderStats.py -f <filename> -grid_delay_mean -ti '2016-01-01 2018-01-01' --seas
 """)
 
     # User inputs
-    userinps = parser.add_argument_group('User inputs/options for which especially careful review is recommended')
-    userinps.add_argument('-f', '--file', dest='fname', type=str, required=True, help='csv file')
-    userinps.add_argument('-c', '--column_name', dest='col_name', type=str, default='ZTD', help='Name of the input column to plot. Input assumed to be in units of meters')
-    userinps.add_argument('-u', '--unit', dest='unit', type=str, default='m', help='Specified input unit. Input will be converted into m if not already in m.')
-    userinps.add_argument('-w', '--workdir', dest='workdir', default='./', help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
+    userinps = parser.add_argument_group(
+        'User inputs/options for which especially careful review is recommended')
+    userinps.add_argument('-f', '--file', dest='fname',
+                          type=str, required=True, help='csv file')
+    userinps.add_argument('-c', '--column_name', dest='col_name', type=str, default='ZTD',
+                          help='Name of the input column to plot. Input assumed to be in units of meters')
+    userinps.add_argument('-u', '--unit', dest='unit', type=str, default='m',
+                          help='Specified input unit. Input will be converted into m if not already in m.')
+    userinps.add_argument('-w', '--workdir', dest='workdir', default='./',
+                          help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
 
     # Spatiotemporal subset options
-    dtsubsets = parser.add_argument_group('Controls for spatiotemporal subsetting.')
-    dtsubsets.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
-    dtsubsets.add_argument('-sp', '--spacing', dest='spacing', type=float, default='1', help='Specify spacing of grid-cells for statistical analyses. By default 1 deg.')
-    dtsubsets.add_argument('-ti', '--timeinterval', dest='timeinterval', type=str, default=None, help="Subset in time by specifying earliest YYYY-MM-DD date followed by latest date YYYY-MM-DD. -- Example : '2016-01-01 2019-01-01'.")
-    dtsubsets.add_argument('-si', '--seasonalinterval', dest='seasonalinterval', type=str, default=None, help="Subset in by an specific interval for each year by specifying earliest MM-DD time followed by latest MM-DD time. -- Example : '03-21 06-21'.")
+    dtsubsets = parser.add_argument_group(
+        'Controls for spatiotemporal subsetting.')
+    dtsubsets.add_argument('-b', '--bbox', dest='bbox', type=str, default=None,
+                           help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
+    dtsubsets.add_argument('-sp', '--spacing', dest='spacing', type=float, default='1',
+                           help='Specify spacing of grid-cells for statistical analyses. By default 1 deg.')
+    dtsubsets.add_argument('-ti', '--timeinterval', dest='timeinterval', type=str, default=None,
+                           help="Subset in time by specifying earliest YYYY-MM-DD date followed by latest date YYYY-MM-DD. -- Example : '2016-01-01 2019-01-01'.")
+    dtsubsets.add_argument('-si', '--seasonalinterval', dest='seasonalinterval', type=str, default=None,
+                           help="Subset in by an specific interval for each year by specifying earliest MM-DD time followed by latest MM-DD time. -- Example : '03-21 06-21'.")
 
     # Plot formatting/options
-    pltformat = parser.add_argument_group('Optional controls for plot formatting/options.')
-    pltformat.add_argument('-fmt', '--plot_format', dest='plot_fmt', type=str,default='png', help='Plot format to use for saving figures')
-    pltformat.add_argument('-cb', '--color_bounds', dest='cbounds', type=float,nargs=2, default=None, help='List of two floats to use as color axis bounds')
-    pltformat.add_argument('-cp', '--colorpercentile', dest='colorpercentile', type=float, default=None, nargs=2, help='Set low and upper percentile for plot colorbars. By default 25%% and 95%%, respectively.')
-    pltformat.add_argument('-dt', '--densitythreshold', dest='densitythreshold', type=int, default='10', help='For variogram plots, given grid-cell is only valid if it contains this specified threshold of stations. By default 10 stations.')
-    pltformat.add_argument('-sg', '--stationsongrids', dest='stationsongrids', action='store_true', help='In gridded plots, superimpose your gridded array with a scatterplot of station locations.')
-    pltformat.add_argument('-dg', '--drawgridlines', dest='drawgridlines', action='store_true', help='Draw gridlines on gridded plots.')
-    pltformat.add_argument('-plotall', '--plotall', action='store_true', dest='plotall', help="Generate all supported plots, including variogram plots.")
+    pltformat = parser.add_argument_group(
+        'Optional controls for plot formatting/options.')
+    pltformat.add_argument('-fmt', '--plot_format', dest='plot_fmt', type=str,
+                           default='png', help='Plot format to use for saving figures')
+    pltformat.add_argument('-cb', '--color_bounds', dest='cbounds', type=float,
+                           nargs=2, default=None, help='List of two floats to use as color axis bounds')
+    pltformat.add_argument('-cp', '--colorpercentile', dest='colorpercentile', type=float, default=None, nargs=2,
+                           help='Set low and upper percentile for plot colorbars. By default 25%% and 95%%, respectively.')
+    pltformat.add_argument('-dt', '--densitythreshold', dest='densitythreshold', type=int, default='10',
+                           help='For variogram plots, given grid-cell is only valid if it contains this specified threshold of stations. By default 10 stations.')
+    pltformat.add_argument('-sg', '--stationsongrids', dest='stationsongrids', action='store_true',
+                           help='In gridded plots, superimpose your gridded array with a scatterplot of station locations.')
+    pltformat.add_argument('-dg', '--drawgridlines', dest='drawgridlines',
+                           action='store_true', help='Draw gridlines on gridded plots.')
+    pltformat.add_argument('-plotall', '--plotall', action='store_true', dest='plotall',
+                           help="Generate all supported plots, including variogram plots.")
 
-
-    ###All plot types
+    # All plot types
     # Station scatter-plots
-    pltscatter = parser.add_argument_group('Supported types of individual station scatter-plots.')
-    pltscatter.add_argument('-station_distribution', '--station_distribution', action='store_true', dest='station_distribution', help="Plot station distribution.")
-    pltscatter.add_argument('-station_delay_mean', '--station_delay_mean', action='store_true', dest='station_delay_mean', help="Plot station mean delay.")
-    pltscatter.add_argument('-station_delay_stdev', '--station_delay_stdev', action='store_true', dest='station_delay_stdev', help="Plot station delay stdev.")
+    pltscatter = parser.add_argument_group(
+        'Supported types of individual station scatter-plots.')
+    pltscatter.add_argument('-station_distribution', '--station_distribution',
+                            action='store_true', dest='station_distribution', help="Plot station distribution.")
+    pltscatter.add_argument('-station_delay_mean', '--station_delay_mean',
+                            action='store_true', dest='station_delay_mean', help="Plot station mean delay.")
+    pltscatter.add_argument('-station_delay_stdev', '--station_delay_stdev',
+                            action='store_true', dest='station_delay_stdev', help="Plot station delay stdev.")
 
     # Gridded plots
     pltgrids = parser.add_argument_group('Supported types of gridded plots.')
-    pltgrids.add_argument('-grid_heatmap', '--grid_heatmap', action='store_true', dest='grid_heatmap', help="Plot gridded station heatmap.")
-    pltgrids.add_argument('-grid_delay_mean', '--grid_delay_mean', action='store_true', dest='grid_delay_mean', help="Plot gridded station mean delay.")
-    pltgrids.add_argument('-grid_delay_stdev', '--grid_delay_stdev', action='store_true', dest='grid_delay_stdev', help="Plot gridded station delay stdev.")
+    pltgrids.add_argument('-grid_heatmap', '--grid_heatmap', action='store_true',
+                          dest='grid_heatmap', help="Plot gridded station heatmap.")
+    pltgrids.add_argument('-grid_delay_mean', '--grid_delay_mean', action='store_true',
+                          dest='grid_delay_mean', help="Plot gridded station mean delay.")
+    pltgrids.add_argument('-grid_delay_stdev', '--grid_delay_stdev', action='store_true',
+                          dest='grid_delay_stdev', help="Plot gridded station delay stdev.")
 
     # Variogram plots
     pltvario = parser.add_argument_group('Supported types of variogram plots.')
-    pltvario.add_argument('-variogramplot', '--variogramplot', action='store_true', dest='variogramplot', help="Plot gridded station variogram.")
-    pltvario.add_argument('-binnedvariogram', '--binnedvariogram', action='store_true', dest='binnedvariogram', help="Apply experimental variogram fit to total binned empirical variograms for each time slice. Default is to pass total unbinned empiricial variogram.")
-    pltvario.add_argument('-verbose', '--verbose', action='store_true', dest='verbose', help="Toggle verbose mode on. Must be specified to generate variogram plots per gridded station AND time-slice.")
+    pltvario.add_argument('-variogramplot', '--variogramplot', action='store_true',
+                          dest='variogramplot', help="Plot gridded station variogram.")
+    pltvario.add_argument('-binnedvariogram', '--binnedvariogram', action='store_true', dest='binnedvariogram',
+                          help="Apply experimental variogram fit to total binned empirical variograms for each time slice. Default is to pass total unbinned empiricial variogram.")
+    pltvario.add_argument('-verbose', '--verbose', action='store_true', dest='verbose',
+                          help="Toggle verbose mode on. Must be specified to generate variogram plots per gridded station AND time-slice.")
 
     return parser
+
 
 def cmdLineParse(iargs=None):
     parser = createParser()
     return parser.parse_args(args=iargs)
+
 
 class variogramAnalysis():
     '''
@@ -109,7 +139,8 @@ class variogramAnalysis():
         import random
         import itertools
         if len(data) < self.densitythreshold:
-            print('WARNING: Less than {} points for this gridcell'.format(self.densitythreshold))
+            print('WARNING: Less than {} points for this gridcell'.format(
+                self.densitythreshold))
             print('Will pass empty list')
             d = []
             indpars = []
@@ -149,7 +180,7 @@ class variogramAnalysis():
             from scipy.spatial.distance import cdist
             return np.diag(cdist(XY[:, :, 0], XY[:, :, 1], metric='euclidean'))
         else:
-            return 0.5*np.square(XY - xy)  #XY = 1st col xy= 2nd col
+            return 0.5*np.square(XY - xy)  # XY = 1st col xy= 2nd col
 
     def _empVario(self, x, y, data, Nsamp=1e3):
         '''
@@ -162,7 +193,8 @@ class variogramAnalysis():
 
         samples, indpars = self._getSamples(data)
         x, y = self._getXY(x, y, indpars)
-        dists = self._getDistances(np.array([[x[:, 0], y[:, 0]], [x[:, 1], y[:, 1]]]).T)
+        dists = self._getDistances(
+            np.array([[x[:, 0], y[:, 0]], [x[:, 1], y[:, 1]]]).T)
         vario = self._getDistances(samples[:, 0], samples[:, 1])
 
         return dists, vario
@@ -175,16 +207,15 @@ class variogramAnalysis():
         if xBin is None:
             xBin = np.linspace(0, np.nanmax(hEff)*.67, 20)
 
-        nBins = len(xBin)-1;
+        nBins = len(xBin)-1
         hExp, expVario = [], []
 
         for iBin in range(nBins):
             iBinMask = np.logical_and(xBin[iBin] < hEff, hEff <= xBin[iBin+1])
-            #circumvent indexing
+            # circumvent indexing
             try:
-                #supress mean of empty slice warning
                 with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", category=RuntimeWarning)
+                    warnings.filterwarnings("ignore", message="Mean of empty slice")
                     hExp.append(np.nanmean(hEff[iBinMask]))
                     expVario.append(np.nanmean(rawVario[iBinMask]))
             except:
@@ -207,16 +238,17 @@ class variogramAnalysis():
             return (m(x, d) - v)
 
         if ub is None:
-            ub = np.array([np.nanmax(dists)*0.8, np.nanmax(vario)*0.8, np.nanmax(vario)*0.8])
+            ub = np.array([np.nanmax(dists)*0.8, np.nanmax(vario)
+                           * 0.8, np.nanmax(vario)*0.8])
 
         if x0 is None and Nparm is None:
-            raise RuntimeError('Must specify either x0 or the number of model parameters')
+            raise RuntimeError(
+                'Must specify either x0 or the number of model parameters')
         if x0 is not None:
             lb = np.zeros(len(x0))
         if Nparm is not None:
             lb = np.zeros(Nparm)
             x0 = (ub-lb)/2
-     
         bounds = (lb, ub)
 
         mask = np.isnan(dists) | np.isnan(vario)
@@ -228,7 +260,8 @@ class variogramAnalysis():
                                    args=(d, v, model))
 
         d_test = np.linspace(0, np.nanmax(dists), 100)
-        v_test = model(res_robust.x, d_test)  # v_test is my y., # res_robust.x =a, b, c, where a = range, b = sill, and c = nugget model, d_test=x
+        # v_test is my y., # res_robust.x =a, b, c, where a = range, b = sill, and c = nugget model, d_test=x
+        v_test = model(res_robust.x, d_test)
 
         return res_robust, d_test, v_test
 
@@ -251,39 +284,47 @@ class variogramAnalysis():
         return b*(1 - np.exp(-np.square(h)/(a**2))) + c
 
     def plotVariogram(self, gridID, timeslice, coords, workdir='./', d_test=None, v_test=None, res_robust=None, dists=None, vario=None, dists_binned=None, vario_binned=None, seasonalinterval=None):
-        """ Make empirical and/or experimental variogram fit plots """
-
+        '''
+        Make empirical and/or experimental variogram fit plots
+        '''
         # If specified workdir doesn't exist, create it
         if not os.path.exists(workdir):
             os.mkdir(workdir)
 
         # make plot title
-        title_str = ' \nLat:{:.2f} Lon:{:.2f}\nTime:{}'.format(coords[1], coords[0], str(timeslice))
+        title_str = ' \nLat:{:.2f} Lon:{:.2f}\nTime:{}'.format(
+            coords[1], coords[0], str(timeslice))
         if seasonalinterval:
-            title_str += ' Season(mm/dd): {}/{} – {}/{}'.format(int(timeslice[4:6]), int(timeslice[6:8]), int(timeslice[-4:-2]), int(timeslice[-2:]))
+            title_str += ' Season(mm/dd): {}/{} – {}/{}'.format(int(timeslice[4:6]), int(
+                timeslice[6:8]), int(timeslice[-4:-2]), int(timeslice[-2:]))
 
         if dists is not None and vario is not None:
             plt.scatter(dists, vario, s=1, facecolor='0.5', label='raw')
         if dists_binned is not None and vario_binned is not None:
             plt.plot(dists_binned, vario_binned, 'bo', label='binned')
         if res_robust is not None:
-            plt.axhline(y=res_robust[1], color='g', linestyle='--', label='ɣ\u0332\u00b2(m\u00b2)')
-            plt.axvline(x=res_robust[0], color='c', linestyle='--', label='h\u0332(°)')
+            plt.axhline(y=res_robust[1], color='g',
+                        linestyle='--', label='ɣ\u0332\u00b2(m\u00b2)')
+            plt.axvline(x=res_robust[0], color='c',
+                        linestyle='--', label='h\u0332(°)')
         if d_test is not None and v_test is not None:
             plt.plot(d_test, v_test, 'r-', label='experimental fit')
         plt.xlabel('Distance (°)')
         plt.ylabel('Dissimilarity (m\u00b2)')
-        plt.legend(bbox_to_anchor=(1.02, 1), loc='upper left', borderaxespad=0.)
+        plt.legend(bbox_to_anchor=(1.02, 1),
+                   loc='upper left', borderaxespad=0.)
         # Plot empirical variogram
         if d_test is None and v_test is None:
             plt.title('Empirical variogram'+title_str)
             plt.tight_layout()
-            plt.savefig(os.path.join(workdir, 'grid{}_timeslice{}_justEMPvariogram.eps'.format(gridID, timeslice)))
+            plt.savefig(os.path.join(
+                workdir, 'grid{}_timeslice{}_justEMPvariogram.eps'.format(gridID, timeslice)))
         # Plot just experimental variogram
         else:
             plt.title('Experimental variogram'+title_str)
             plt.tight_layout()
-            plt.savefig(os.path.join(workdir, 'grid{}_timeslice{}_justEXPvariogram.eps'.format(gridID, timeslice)))
+            plt.savefig(os.path.join(
+                workdir, 'grid{}_timeslice{}_justEXPvariogram.eps'.format(gridID, timeslice)))
         plt.close()
 
         return
@@ -301,9 +342,13 @@ class variogramAnalysis():
         # record grid-centers for lookup-table
         gridcenterlist = []
         for i in sorted(list(set(self.df['gridnode']))):
-            dists_arr = []; vario_arr = []
-            dists_binned_arr = []; vario_binned_arr = []
-            res_robust_arr = []; d_test_arr = []; v_test_arr = []
+            dists_arr = []
+            vario_arr = []
+            dists_binned_arr = []
+            vario_binned_arr = []
+            res_robust_arr = []
+            d_test_arr = []
+            v_test_arr = []
             grid_subset = self.df[self.df['gridnode'] == i]
             for j in sorted(list(set(grid_subset['Date']))):
                 # If insufficient sample size, skip slice and record occurence
@@ -311,55 +356,76 @@ class variogramAnalysis():
                     # Record skipped [gridnode, timeslice]
                     skipped_slices.append([i, j.strftime("%Y-%m-%d")])
                 else:
-                    gridcenterlist.append(['grid{} '.format(i)+'Lat:{} Lon:{}'.format(str(self.gridpoints[i][1]), str(self.gridpoints[i][0]))])
-                    lonarr = np.array(grid_subset[grid_subset['Date'] == j]['Lon'])
-                    latarr = np.array(grid_subset[grid_subset['Date'] == j]['Lat'])
-                    delayarray = np.array(grid_subset[grid_subset['Date'] == j][self.col_name])
+                    gridcenterlist.append(['grid{} '.format(
+                        i)+'Lat:{} Lon:{}'.format(str(self.gridpoints[i][1]), str(self.gridpoints[i][0]))])
+                    lonarr = np.array(
+                        grid_subset[grid_subset['Date'] == j]['Lon'])
+                    latarr = np.array(
+                        grid_subset[grid_subset['Date'] == j]['Lat'])
+                    delayarray = np.array(
+                        grid_subset[grid_subset['Date'] == j][self.col_name])
                     # fit empirical variogram for each time AND grid
                     dists, vario = self._empVario(lonarr, latarr, delayarray)
-                    dists_binned, vario_binned = self._binnedVario(dists, vario)
+                    dists_binned, vario_binned = self._binnedVario(
+                        dists, vario)
                     # fit experimental variogram for each time AND grid, model default is exponential
-                    res_robust, d_test, v_test = self._fitVario(dists_binned, vario_binned, model=self.__exponential__, x0=None, Nparm=3)
+                    res_robust, d_test, v_test = self._fitVario(
+                        dists_binned, vario_binned, model=self.__exponential__, x0=None, Nparm=3)
                     # Plot empirical + experimental variogram for this gridnode and timeslice
                     if not os.path.exists(os.path.join(self.workdir, 'variograms/grid{}'.format(i))):
-                        os.makedirs(os.path.join(self.workdir, 'variograms/grid{}'.format(i)))
+                        os.makedirs(os.path.join(
+                            self.workdir, 'variograms/grid{}'.format(i)))
                     # Make variogram plots for each time-slice if verbose mode specified.
                     if self.verbose:
                         # Plot empirical variogram for this gridnode and timeslice
-                        self.plotVariogram(i, j.strftime("%Y%m%d"), [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(self.workdir, 'variograms/grid{}'.format(i)), dists=dists, vario=vario, dists_binned=dists_binned, vario_binned=vario_binned)  # in verbose
+                        self.plotVariogram(i, j.strftime("%Y%m%d"), [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(
+                            self.workdir, 'variograms/grid{}'.format(i)), dists=dists, vario=vario, dists_binned=dists_binned, vario_binned=vario_binned)  # in verbose
                         # Plot experimental variogram for this gridnode and timeslice
-                        self.plotVariogram(i, j.strftime("%Y%m%d"), [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(self.workdir, 'variograms/grid{}'.format(i)), d_test=d_test, v_test=v_test, res_robust=res_robust.x, dists_binned=dists_binned, vario_binned=vario_binned)  # in verbose
+                        self.plotVariogram(i, j.strftime("%Y%m%d"), [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(
+                            self.workdir, 'variograms/grid{}'.format(i)), d_test=d_test, v_test=v_test, res_robust=res_robust.x, dists_binned=dists_binned, vario_binned=vario_binned)  # in verbose
                     # append for plotting
                     good_slices.append([i, j.strftime("%Y%m%d")])
-                    dists_arr.append(dists); vario_arr.append(vario)
-                    dists_binned_arr.append(dists_binned); vario_binned_arr.append(vario_binned)
-                    res_robust_arr.append(res_robust.x); d_test_arr.append(d_test); v_test_arr.append(v_test)
+                    dists_arr.append(dists)
+                    vario_arr.append(vario)
+                    dists_binned_arr.append(dists_binned)
+                    vario_binned_arr.append(vario_binned)
+                    res_robust_arr.append(res_robust.x)
+                    d_test_arr.append(d_test)
+                    v_test_arr.append(v_test)
             # fit experimental variogram for each grid
             if dists_binned_arr != []:
                 # TODO: need to change this from accumulating binned data to raw data
-                dists_arr = np.concatenate(dists_arr).ravel(); vario_arr = np.concatenate(vario_arr).ravel()
+                dists_arr = np.concatenate(dists_arr).ravel()
+                vario_arr = np.concatenate(vario_arr).ravel()
                 # if specified, passed binned empirical variograms
                 if self.binnedvariogram:
-                    dists_binned_arr = np.concatenate(dists_binned_arr).ravel(); vario_binned_arr = np.concatenate(vario_binned_arr).ravel()
+                    dists_binned_arr = np.concatenate(dists_binned_arr).ravel()
+                    vario_binned_arr = np.concatenate(vario_binned_arr).ravel()
                 else:
-                    dists_binned_arr, vario_binned_arr = self._binnedVario(dists_arr, vario_arr)
-                TOT_res_robust, TOT_d_test, TOT_v_test = self._fitVario(dists_binned_arr, vario_binned_arr, model=self.__exponential__, x0=None, Nparm=3)
+                    dists_binned_arr, vario_binned_arr = self._binnedVario(
+                        dists_arr, vario_arr)
+                TOT_res_robust, TOT_d_test, TOT_v_test = self._fitVario(
+                    dists_binned_arr, vario_binned_arr, model=self.__exponential__, x0=None, Nparm=3)
                 # Plot empirical variogram for this gridnode and timeslice
                 tot_timetag = good_slices[0][1]+'–'+good_slices[-1][1]
                 # Append TOT arrays
                 TOT_good_slices.append([i, tot_timetag])
                 TOT_res_robust_arr.append(TOT_res_robust.x)
                 TOT_tot_timetag.append(tot_timetag)
-                self.plotVariogram(i, tot_timetag, [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(self.workdir, 'variograms/grid{}'.format(i)), dists=dists_arr, vario=vario_arr, dists_binned=dists_binned_arr, vario_binned=vario_binned_arr, seasonalinterval=self.seasonalinterval)
+                self.plotVariogram(i, tot_timetag, [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(self.workdir, 'variograms/grid{}'.format(
+                    i)), dists=dists_arr, vario=vario_arr, dists_binned=dists_binned_arr, vario_binned=vario_binned_arr, seasonalinterval=self.seasonalinterval)
                 # Plot experimental variogram for this gridnode and timeslice
-                self.plotVariogram(i, tot_timetag, [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(self.workdir, 'variograms/grid{}'.format(i)), d_test=TOT_d_test, v_test=TOT_v_test, res_robust=TOT_res_robust.x, seasonalinterval=self.seasonalinterval)
+                self.plotVariogram(i, tot_timetag, [self.gridpoints[i][1], self.gridpoints[i][0]], workdir=os.path.join(
+                    self.workdir, 'variograms/grid{}'.format(i)), d_test=TOT_d_test, v_test=TOT_v_test, res_robust=TOT_res_robust.x, seasonalinterval=self.seasonalinterval)
             # Record sparse grids which didn't have sufficient sample size of data through any of the timeslices
             else:
                 sparse_grids.append(i)
 
         # save grid-center lookup table
-        gridcenterlist = [list(i) for i in set(tuple(j) for j in gridcenterlist)]
-        gridcenter = open((os.path.join(self.workdir, 'variograms/gridlocation_lookup.txt')), "w")
+        gridcenterlist = [list(i) for i in set(tuple(j)
+                                               for j in gridcenterlist)]
+        gridcenter = open(
+            (os.path.join(self.workdir, 'variograms/gridlocation_lookup.txt')), "w")
         for element in gridcenterlist:
             gridcenter.writelines("\n".join(element))
             gridcenter.write("\n")
@@ -410,7 +476,8 @@ class raiderStats(object):
                 extent = [np.floor(self.bbox[2]-(self.spacing/2)), np.ceil(self.bbox[-1]+(self.spacing/2)),
                           np.floor(self.bbox[0]-(self.spacing/2)), np.ceil(self.bbox[1]+(self.spacing/2))]
             else:
-                print("WARNING: User-specified bounds do not overlap with dataset bounds, proceeding with the latter.")
+                print(
+                    "WARNING: User-specified bounds do not overlap with dataset bounds, proceeding with the latter.")
             del dfextents_poly, userbbox_poly
 
         # Create corners of rectangle to be transformed to a grid
@@ -418,7 +485,8 @@ class raiderStats(object):
         se = [extent[1]-(self.spacing/2), extent[2]+(self.spacing/2)]
 
         # Store grid dimension [y,x]
-        grid_dim = [int((extent[1]-extent[0])/self.spacing), int((extent[-1]-extent[-2])/self.spacing)]
+        grid_dim = [int((extent[1]-extent[0])/self.spacing),
+                    int((extent[-1]-extent[-2])/self.spacing)]
 
         # Iterate over 2D area
         gridpoints = []
@@ -441,7 +509,7 @@ class raiderStats(object):
         '''
         Convert input to desired units
         '''
-        SI = {'mm':0.001, 'cm':0.01, 'm':1.0, 'km':1000.}
+        SI = {'mm': 0.001, 'cm': 0.01, 'm': 1.0, 'km': 1000.}
 
         return val*SI[unit_in]/SI[unit_out]
 
@@ -450,13 +518,15 @@ class raiderStats(object):
         Read a input file
         '''
         data = pd.read_csv(self.fname)
-        #check if user-specified key is valid
+        # check if user-specified key is valid
         if self.col_name not in data.keys():
-            raise Exception('User-specified key %s not found in inpuit file %s. Must specify valid key.'%(self.col_name,self.fname))
+            raise Exception(
+                'User-specified key {} not found in inpuit file {}. Must specify valid key.' .format(self.col_name, self.fname))
 
-        #convert to m
+        # convert to m
         if self.unit != 'm':
-            data[self.col_name] = self._convertSI(data[self.col_name], self.unit, 'm')
+            data[self.col_name] = self._convertSI(
+                data[self.col_name], self.unit, 'm')
 
         return data
 
@@ -476,18 +546,24 @@ class raiderStats(object):
 
         # time-interval filter
         if self.timeinterval:
-            self.timeinterval = [dt.datetime.strptime(val, '%Y-%m-%d') for val in self.timeinterval.split()]
-            self.df = self.df[(self.df['Date'] >= self.timeinterval[0]) & (self.df['Date'] <= self.timeinterval[-1])]
+            self.timeinterval = [dt.datetime.strptime(
+                val, '%Y-%m-%d') for val in self.timeinterval.split()]
+            self.df = self.df[(self.df['Date'] >= self.timeinterval[0]) & (
+                self.df['Date'] <= self.timeinterval[-1])]
 
         # seasonal filter
         if self.seasonalinterval:
             # get day of year
-            self.seasonalinterval = [dt.datetime.strptime('2001-'+self.seasonalinterval[0], '%Y-%m-%d').timetuple().tm_yday, dt.datetime.strptime('2001-'+self.seasonalinterval[-1], '%Y-%m-%d').timetuple().tm_yday]
+            self.seasonalinterval = [dt.datetime.strptime('2001-'+self.seasonalinterval[0], '%Y-%m-%d').timetuple(
+            ).tm_yday, dt.datetime.strptime('2001-'+self.seasonalinterval[-1], '%Y-%m-%d').timetuple().tm_yday]
             # non leap-year
-            filtered_self = self.df[(self.df['Date'].dt.is_leap_year == False) & (self.df['Date'].dt.dayofyear >= self.seasonalinterval[0]) & (self.df['Date'].dt.dayofyear <= self.seasonalinterval[-1])]
+            filtered_self = self.df[(self.df['Date'].dt.is_leap_year == False) & (
+                self.df['Date'].dt.dayofyear >= self.seasonalinterval[0]) & (self.df['Date'].dt.dayofyear <= self.seasonalinterval[-1])]
             # leap-year
-            self.seasonalinterval = [i+1 if i > 59 else i for i in self.seasonalinterval]
-            self.df = filtered_self.append(self.df[(self.df['Date'].dt.is_leap_year == True) & (self.df['Date'].dt.dayofyear >= self.seasonalinterval[0]) & (self.df['Date'].dt.dayofyear <= self.seasonalinterval[-1])], ignore_index=True)
+            self.seasonalinterval = [i+1 if i >
+                                     59 else i for i in self.seasonalinterval]
+            self.df = filtered_self.append(self.df[(self.df['Date'].dt.is_leap_year == True) & (
+                self.df['Date'].dt.dayofyear >= self.seasonalinterval[0]) & (self.df['Date'].dt.dayofyear <= self.seasonalinterval[-1])], ignore_index=True)
             del filtered_self
 
         # Get bbox, buffered by grid spacing.
@@ -496,24 +572,29 @@ class raiderStats(object):
             try:
                 self.bbox = [float(val) for val in self.bbox.split()]
             except:
-                raise Exception('Cannot understand the --bbox argument. String input is incorrect or path does not exist.')
+                raise Exception(
+                    'Cannot understand the --bbox argument. String input is incorrect or path does not exist.')
         self.plotbbox, self.grid_dim, self.gridpoints = self._getExtent()
 
         # generate list of grid-polygons
         append_poly = []
         for i in self.gridpoints:
-            bbox = [i[1]-(self.spacing/2), i[1]+(self.spacing/2), i[0]-(self.spacing/2), i[0]+(self.spacing/2)]
+            bbox = [i[1]-(self.spacing/2), i[1]+(self.spacing/2),
+                    i[0]-(self.spacing/2), i[0]+(self.spacing/2)]
             append_poly.append(Polygon(np.column_stack((np.array([bbox[2], bbox[3], bbox[3], bbox[2], bbox[2]]),
                                                         np.array([bbox[0], bbox[0], bbox[1], bbox[1], bbox[0]])))))  # Pass lons/lats to create polygon
 
         # check for grid cell intersection with each station (loop through each station).. fast, but assumes station locations don't change
         idtogrid_dict = {}
         unique_points = self.df.groupby(['ID', 'Lon', 'Lat']).size()
-        unique_points = [unique_points.index.get_level_values('ID').tolist(), unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist()]
+        unique_points = [unique_points.index.get_level_values('ID').tolist(), unique_points.index.get_level_values(
+            'Lon').tolist(), unique_points.index.get_level_values('Lat').tolist()]
         for i in unique_points[0]:
             try:
-                coord = Point((unique_points[1][unique_points[0].index(i)], unique_points[2][unique_points[0].index(i)]))
-                idtogrid_dict[i] = [j.intersects(coord) for j in append_poly].index(True)
+                coord = Point((unique_points[1][unique_points[0].index(
+                    i)], unique_points[2][unique_points[0].index(i)]))
+                idtogrid_dict[i] = [j.intersects(
+                    coord) for j in append_poly].index(True)
             except:
                 idtogrid_dict[i] = 'NaN'
         # map gridnode dictionary to dataframe
@@ -522,17 +603,18 @@ class raiderStats(object):
         # sort by grid and date
         self.df.sort_values(['gridnode', 'Date'])
 
-
         # If specified, pass station locations to superimpose on gridplots
         if self.stationsongrids:
             unique_points = self.df.groupby(['Lon', 'Lat']).size()
-            self.stationsongrids = [unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist()]
+            self.stationsongrids = [unique_points.index.get_level_values(
+                'Lon').tolist(), unique_points.index.get_level_values('Lat').tolist()]
 
         # Pass color percentile and check for input error
         if self.colorpercentile is None:
             self.colorpercentile = [25, 95]
         if self.colorpercentile[0] > self.colorpercentile[1]:
-            raise Exception('Input colorpercentile lower threshold {} higher than upper threshold {}'.format(self.colorpercentile[0], self.colorpercentile[1]))
+            raise Exception('Input colorpercentile lower threshold {} higher than upper threshold {}'.format(
+                self.colorpercentile[0], self.colorpercentile[1]))
 
     def __call__(self, gridarr, plottype, workdir='./', drawgridlines=False, colorbarfmt='%.3f', stationsongrids=None, cbounds=None, resValue=5, plotFormat='pdf'):
         '''
@@ -556,11 +638,12 @@ class raiderStats(object):
 
         fig, axes = plt.subplots(subplot_kw={'projection': ccrs.PlateCarree()})
         # by default set background to white
-        axes.add_feature(cfeature.NaturalEarthFeature('physical', 'land', '50m', facecolor='white'), zorder=0)
+        axes.add_feature(cfeature.NaturalEarthFeature(
+            'physical', 'land', '50m', facecolor='white'), zorder=0)
         # reset in case bounds too large
         try:
             axes.set_extent(self.plotbbox, ccrs.PlateCarree())
-        except:
+        except ValueError:
             self.plotbbox = [-179.99, 179.99, -89.99, 89.99]
             axes.set_extent(self.plotbbox, ccrs.PlateCarree())
         # add coastlines
@@ -570,15 +653,20 @@ class raiderStats(object):
         # extract all colors from the hot map
         cmaplist = [cmap(i) for i in range(cmap.N)]
         # create the new map
-        cmap = mpl.colors.LinearSegmentedColormap.from_list('Custom cmap', cmaplist, cmap.N)
+        cmap = mpl.colors.LinearSegmentedColormap.from_list(
+            'Custom cmap', cmaplist, cmap.N)
         axes.set_xlabel('longitude', weight='bold', zorder=2)
         axes.set_ylabel('latitude', weight='bold', zorder=2)
 
         # set ticks
-        axes.set_xticks(np.linspace(self.plotbbox[0], self.plotbbox[1], 5), crs=ccrs.PlateCarree())
-        axes.set_yticks(np.linspace(self.plotbbox[2], self.plotbbox[3], 5), crs=ccrs.PlateCarree())
-        lon_formatter = LongitudeFormatter(number_format='.0f', degree_symbol='')
-        lat_formatter = LatitudeFormatter(number_format='.0f', degree_symbol='')
+        axes.set_xticks(np.linspace(
+            self.plotbbox[0], self.plotbbox[1], 5), crs=ccrs.PlateCarree())
+        axes.set_yticks(np.linspace(
+            self.plotbbox[2], self.plotbbox[3], 5), crs=ccrs.PlateCarree())
+        lon_formatter = LongitudeFormatter(
+            number_format='.0f', degree_symbol='')
+        lat_formatter = LatitudeFormatter(
+            number_format='.0f', degree_symbol='')
         axes.xaxis.set_major_formatter(lon_formatter)
         axes.yaxis.set_major_formatter(lat_formatter)
 
@@ -587,65 +675,83 @@ class raiderStats(object):
             # spatial distribution of stations
             if plottype == "station_distribution":
                 axes.set_title(" ".join(plottype.split('_')), zorder=2)
-                im   = axes.scatter(gridarr[0], gridarr[1], zorder=1, s=0.5, marker='.', color='b', transform=ccrs.PlateCarree())
+                im = axes.scatter(gridarr[0], gridarr[1], zorder=1, s=0.5,
+                                  marker='.', color='b', transform=ccrs.PlateCarree())
 
             # passing 3rd column as z-value
             if len(gridarr) > 2:
                 zvalues = gridarr[2]
                 # define the bins and normalize
                 if cbounds is None:
-                    cbounds = [np.nanpercentile(zvalues, self.colorpercentile[0]), np.nanpercentile(zvalues, self.colorpercentile[1])]
+                    cbounds = [np.nanpercentile(zvalues, self.colorpercentile[0]), np.nanpercentile(
+                        zvalues, self.colorpercentile[1])]
                 colorbounds = np.linspace(cbounds[0], cbounds[1], 11)
 
                 norm = mpl.colors.BoundaryNorm(colorbounds, cmap.N)
                 zvalues = np.ma.masked_where(zvalues == 0, zvalues)
 
                 # plot data and initiate colorbar
-                im   = axes.scatter(gridarr[0], gridarr[1], c=zvalues, cmap=cmap, norm=norm, vmin=cbounds[0], vmax=cbounds[1], zorder=1, s=0.5, marker='.', transform=ccrs.PlateCarree())
+                im = axes.scatter(gridarr[0], gridarr[1], c=zvalues, cmap=cmap, norm=norm, vmin=cbounds[0],
+                                  vmax=cbounds[1], zorder=1, s=0.5, marker='.', transform=ccrs.PlateCarree())
                 # initiate colorbar
-                cbar_ax = fig.colorbar(im, cmap=cmap, norm=norm, spacing='proportional', ticks=colorbounds, boundaries=colorbounds, format=colorbarfmt, pad=0.1)
-                cbar_ax.set_label(" ".join(plottype.split('_')), rotation=-90, labelpad=10)
+                cbar_ax = fig.colorbar(im, cmap=cmap, norm=norm, spacing='proportional',
+                                       ticks=colorbounds, boundaries=colorbounds, format=colorbarfmt, pad=0.1)
+                cbar_ax.set_label(" ".join(plottype.split('_')),
+                                  rotation=-90, labelpad=10)
 
         # If gridded area passed
         else:
             # set land/water background to light gray/blue respectively so grid cells can be seen
-            axes.add_feature(cfeature.NaturalEarthFeature('physical', 'land', '50m', facecolor='#A9A9A9'), zorder=0)
-            axes.add_feature(cfeature.NaturalEarthFeature('physical', 'ocean', '50m', facecolor='#ADD8E6'), zorder=0)
+            axes.add_feature(cfeature.NaturalEarthFeature(
+                'physical', 'land', '50m', facecolor='#A9A9A9'), zorder=0)
+            axes.add_feature(cfeature.NaturalEarthFeature(
+                'physical', 'ocean', '50m', facecolor='#ADD8E6'), zorder=0)
             # define the bins and normalize
             if cbounds is None:
-                cbounds = [np.nanpercentile(gridarr, self.colorpercentile[0]), np.nanpercentile(gridarr, self.colorpercentile[1])]
+                cbounds = [np.nanpercentile(gridarr, self.colorpercentile[0]), np.nanpercentile(
+                    gridarr, self.colorpercentile[1])]
             colorbounds = np.linspace(cbounds[0], cbounds[1], 11)
             norm = mpl.colors.BoundaryNorm(colorbounds, cmap.N)
             gridarr = np.ma.masked_where(gridarr == np.nan, gridarr)
 
             # plot data
-            im   = axes.imshow(gridarr, cmap=cmap, norm=norm, extent=self.plotbbox, vmin=cbounds[0], vmax=cbounds[1], zorder=1, origin='upper', transform=ccrs.PlateCarree())
+            im = axes.imshow(gridarr, cmap=cmap, norm=norm, extent=self.plotbbox,
+                             vmin=cbounds[0], vmax=cbounds[1], zorder=1, origin='upper', transform=ccrs.PlateCarree())
             # initiate colorbar
-            cbar_ax = fig.colorbar(im, cmap=cmap, norm=norm, spacing='proportional', ticks=colorbounds, boundaries=colorbounds, format=colorbarfmt, pad=0.1)
+            cbar_ax = fig.colorbar(im, cmap=cmap, norm=norm, spacing='proportional',
+                                   ticks=colorbounds, boundaries=colorbounds, format=colorbarfmt, pad=0.1)
 
             # superimpose your gridded array with a supplementary list of point, if specified
             if self.stationsongrids:
-                axes.scatter(self.stationsongrids[0], self.stationsongrids[1], zorder=2, s=0.5, marker='.', color='b', transform=ccrs.PlateCarree())
+                axes.scatter(self.stationsongrids[0], self.stationsongrids[1], zorder=2,
+                             s=0.5, marker='.', color='b', transform=ccrs.PlateCarree())
 
             # draw gridlines, if specified
             if drawgridlines:
-                gl = axes.gridlines(crs=ccrs.PlateCarree(), linewidth=2, color='black', alpha=0.5, linestyle='-', zorder=3)
-                gl.xlocator = mticker.FixedLocator(np.arange(self.plotbbox[0], self.plotbbox[1]+self.spacing, self.spacing).tolist())
-                gl.ylocator = mticker.FixedLocator(np.arange(self.plotbbox[2], self.plotbbox[3]+self.spacing, self.spacing).tolist())
+                gl = axes.gridlines(crs=ccrs.PlateCarree(
+                ), linewidth=2, color='black', alpha=0.5, linestyle='-', zorder=3)
+                gl.xlocator = mticker.FixedLocator(np.arange(
+                    self.plotbbox[0], self.plotbbox[1]+self.spacing, self.spacing).tolist())
+                gl.ylocator = mticker.FixedLocator(np.arange(
+                    self.plotbbox[2], self.plotbbox[3]+self.spacing, self.spacing).tolist())
 
-            #experimental variogram fit range heatmap
+            # experimental variogram fit range heatmap
             if plottype == "range_heatmap":
-                cbar_ax.set_label(" ".join(plottype.split('_'))+' (°)', rotation=-90, labelpad=10)
+                cbar_ax.set_label(" ".join(plottype.split(
+                    '_'))+' (°)', rotation=-90, labelpad=10)
 
-            #experimental variogram fit sill heatmap
+            # experimental variogram fit sill heatmap
             elif plottype == "sill_heatmap":
-                cbar_ax.set_label(" ".join(plottype.split('_'))+' (cm\u00b2)', rotation=-90, labelpad=10)
+                cbar_ax.set_label(" ".join(plottype.split(
+                    '_'))+' (cm\u00b2)', rotation=-90, labelpad=10)
 
             else:
-                cbar_ax.set_label(" ".join(plottype.split('_')), rotation=-90, labelpad=10)
+                cbar_ax.set_label(" ".join(plottype.split('_')),
+                                  rotation=-90, labelpad=10)
 
         # save/close figure
-        plt.savefig(os.path.join(workdir, self.col_name + '_' + plottype+'.'+plotFormat), format=plotFormat, bbox_inches='tight')
+        plt.savefig(os.path.join(workdir, self.col_name + '_' + plottype +
+                                 '.'+plotFormat), format=plotFormat, bbox_inches='tight')
         plt.close()
 
         return
@@ -655,7 +761,8 @@ def parseCMD(iargs=None):
     inps = cmdLineParse(iargs)
     print("***Stats Function:***")
     # prep dataframe object for plotting/variogram analysis based off of user specifications
-    df_stats = raiderStats(inps.fname, inps.col_name, inps.unit, inps.workdir, inps.bbox, inps.spacing, inps.timeinterval, inps.seasonalinterval, inps.stationsongrids, inps.colorpercentile, inps.verbose)
+    df_stats = raiderStats(inps.fname, inps.col_name, inps.unit, inps.workdir, inps.bbox, inps.spacing,
+                           inps.timeinterval, inps.seasonalinterval, inps.stationsongrids, inps.colorpercentile, inps.verbose)
 
     # If user requests to generate all plots.
     if inps.plotall:
@@ -673,52 +780,68 @@ def parseCMD(iargs=None):
     if inps.station_distribution:
         print("- Plot spatial distribution of stations.")
         unique_points = df_stats.df.groupby(['Lon', 'Lat']).size()
-        df_stats([unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist()], 'station_distribution', workdir=os.path.join(inps.workdir, 'figures'), plotFormat=inps.plot_fmt, cbounds=inps.cbounds)
+        df_stats([unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist(
+        )], 'station_distribution', workdir=os.path.join(inps.workdir, 'figures'), plotFormat=inps.plot_fmt, cbounds=inps.cbounds)
     # Plot mean delay per station
     if inps.station_delay_mean:
         print("- Plot mean delay for each station.")
-        unique_points = df_stats.df.groupby(['Lon', 'Lat'])[inps.col_name].mean()
+        unique_points = df_stats.df.groupby(
+            ['Lon', 'Lat'])[inps.col_name].mean()
         unique_points.dropna(how='any', inplace=True)
-        df_stats([unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist(), unique_points.values], 'station_delay_mean', workdir=os.path.join(inps.workdir, 'figures'), plotFormat=inps.plot_fmt, cbounds=inps.cbounds)
+        df_stats([unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist(
+        ), unique_points.values], 'station_delay_mean', workdir=os.path.join(inps.workdir, 'figures'), plotFormat=inps.plot_fmt, cbounds=inps.cbounds)
     # Plot delay stdev per station
     if inps.station_delay_stdev:
         print("- Plot delay stdev for each station.")
-        unique_points = df_stats.df.groupby(['Lon', 'Lat'])[inps.col_name].std()
+        unique_points = df_stats.df.groupby(
+            ['Lon', 'Lat'])[inps.col_name].std()
         unique_points.dropna(how='any', inplace=True)
-        df_stats([unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist(), unique_points.values], 'station_delay_stdev', workdir=os.path.join(inps.workdir, 'figures'), plotFormat=inps.plot_fmt, cbounds=inps.cbounds)
+        df_stats([unique_points.index.get_level_values('Lon').tolist(), unique_points.index.get_level_values('Lat').tolist(
+        ), unique_points.values], 'station_delay_stdev', workdir=os.path.join(inps.workdir, 'figures'), plotFormat=inps.plot_fmt, cbounds=inps.cbounds)
 
     # Gridded station plots
     # Plot density of stations for each gridcell
     if inps.grid_heatmap:
         print("- Plot density of stations per gridcell.")
-        gridarr_heatmap = np.array([np.nan if i[0] not in df_stats.df['gridnode'].values[:] else float(len(np.unique(df_stats.df['ID'][df_stats.df['gridnode'] == i[0]]))) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
-        df_stats(gridarr_heatmap.T, 'grid_heatmap', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines, colorbarfmt='%1i', stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
+        gridarr_heatmap = np.array([np.nan if i[0] not in df_stats.df['gridnode'].values[:] else float(len(np.unique(
+            df_stats.df['ID'][df_stats.df['gridnode'] == i[0]]))) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
+        df_stats(gridarr_heatmap.T, 'grid_heatmap', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines,
+                 colorbarfmt='%1i', stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
     # Plot mean delay for each gridcell
     if inps.grid_delay_mean:
         print("- Plot mean delay per gridcell.")
         unique_points = df_stats.df.groupby(['gridnode'])[inps.col_name].mean()
         unique_points.dropna(how='any', inplace=True)
-        gridarr_heatmap = np.array([np.nan if i[0] not in unique_points.index.get_level_values('gridnode').tolist() else unique_points[i[0]] for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
-        df_stats(gridarr_heatmap.T, 'grid_delay_mean', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines, stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
+        gridarr_heatmap = np.array([np.nan if i[0] not in unique_points.index.get_level_values('gridnode').tolist(
+        ) else unique_points[i[0]] for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
+        df_stats(gridarr_heatmap.T, 'grid_delay_mean', workdir=os.path.join(inps.workdir, 'figures'),
+                 drawgridlines=inps.drawgridlines, stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
     # Plot mean delay for each gridcell
     if inps.grid_delay_stdev:
         print("- Plot delay stdev per gridcell.")
         unique_points = df_stats.df.groupby(['gridnode'])[inps.col_name].std()
         unique_points.dropna(how='any', inplace=True)
-        gridarr_heatmap = np.array([np.nan if i[0] not in unique_points.index.get_level_values('gridnode').tolist() else unique_points[i[0]] for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
-        df_stats(gridarr_heatmap.T, 'grid_delay_stdev', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines, stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
+        gridarr_heatmap = np.array([np.nan if i[0] not in unique_points.index.get_level_values('gridnode').tolist(
+        ) else unique_points[i[0]] for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
+        df_stats(gridarr_heatmap.T, 'grid_delay_stdev', workdir=os.path.join(inps.workdir, 'figures'),
+                 drawgridlines=inps.drawgridlines, stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
 
     # Perform variogram analysis
     if inps.variogramplot:
         print("***Variogram Analysis Function:***")
-        make_variograms = variogramAnalysis(df_stats.df, df_stats.gridpoints, inps.col_name, inps.workdir, df_stats.seasonalinterval, inps.densitythreshold, inps.verbose, binnedvariogram=inps.binnedvariogram)
+        make_variograms = variogramAnalysis(df_stats.df, df_stats.gridpoints, inps.col_name, inps.workdir,
+                                            df_stats.seasonalinterval, inps.densitythreshold, inps.verbose, binnedvariogram=inps.binnedvariogram)
         TOT_grids, TOT_res_robust_arr = make_variograms.createVariograms()
         # plot range heatmap
         print("- Plot variogram range per gridcell.")
-        gridarr_range = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(i[0])][0]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
-        df_stats(gridarr_range.T, 'range_heatmap', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines, stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
+        gridarr_range = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
+            i[0])][0]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
+        df_stats(gridarr_range.T, 'range_heatmap', workdir=os.path.join(inps.workdir, 'figures'),
+                 drawgridlines=inps.drawgridlines, stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
         # plot sill heatmap
         print("- Plot variogram sill per gridcell.")
-        gridarr_sill = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(i[0])][1]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
-        gridarr_sill = gridarr_sill*(10^4)  # convert to cm
-        df_stats(gridarr_sill.T, 'sill_heatmap', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines, colorbarfmt='%.3e', stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)
+        gridarr_sill = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
+            i[0])][1]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim)
+        gridarr_sill = gridarr_sill*(10 ^ 4)  # convert to cm
+        df_stats(gridarr_sill.T, 'sill_heatmap', workdir=os.path.join(inps.workdir, 'figures'), drawgridlines=inps.drawgridlines,
+                 colorbarfmt='%.3e', stationsongrids=inps.stationsongrids, cbounds=inps.cbounds, plotFormat=inps.plot_fmt)

--- a/tools/bin/raiderDelay.py
+++ b/tools/bin/raiderDelay.py
@@ -1,4 +1,4 @@
-#!/u/leffe0/ssangha/tools/conda_installation/stable_feb9_2020/envs/RAiDER/bin/python3
+#!/usr/bin/env python3
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Jeremy Maurer, Raymond Hogenson & David Bekaert

--- a/tools/bin/raiderDownloadGNSS.py
+++ b/tools/bin/raiderDownloadGNSS.py
@@ -1,13 +1,15 @@
 #!/u/leffe0/ssangha/tools/conda_installation/stable_feb9_2020/envs/RAiDER/bin/python3
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Author: Jeremy Maurer, Raymond Hogenson & David Bekaert
+# Author: Simran Sangha, Jeremy Maurer, & David Bekaert
 # Copyright 2019, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-from RAiDER.runProgram import parseCMD
+from RAiDER.downloadGNSSDelays import parseCMD
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+
+    # Main engine
     parseCMD()

--- a/tools/bin/raiderDownloadGNSS.py
+++ b/tools/bin/raiderDownloadGNSS.py
@@ -1,4 +1,4 @@
-#!/u/leffe0/ssangha/tools/conda_installation/stable_feb9_2020/envs/RAiDER/bin/python3
+#!/usr/bin/env python3
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Simran Sangha, Jeremy Maurer, & David Bekaert


### PR DESCRIPTION
Added end-to-end option to download/virtually access zenith delay information from the UNR Geodetic Laboratory and derive/plot statistics using the ```raiderStats.py``` program: 
1. To access zenith delay information, run ```raiderDownloadGNSS.py``` and refer to child scripts ```downloadGNSSDelays.py``` and ```getStationDelays.py```. By default, URLs from the UNR Geodetic Laboratory repository are passed to CSV named ```gnssStationList_overbbox_withpaths.csv```, before zenith delay information is accessed virtually and appended to series of CSVs deposited under ```GPS_delays``` subdirectory and then in turn appended to a master CSV entitled ```CombinedGPS_ztd.csv``` that records all zenith delay information for a specified time. This latter CSV may be directly passed to ```raiderStats.py``` to derive statistics for zenith delay information, or alternatively ```gnssStationList_overbbox.csv``` alone may be passed to just display distribution of GNSS stations. 

2. ```—download``` flag must be specified to physically download data, which is no longer necessary as data may be accessed virtually from the UNR Geodetic Laboratory. 

3. Input list of stations supported with ``` --station_file``` flag. In case both the bounding box and list of stations are specified, stations which fall outside the bounding box are printed in a warning message. 


Series of up updates made to ```statsPlot.py``` program: 
1. Gray background plotted behind grid-cells in case gridded arrays are plotted, and clean white backgrounds plotted behind stations in case just stations are plotted. 

2. Following issue #46, help menu/parser better organized. 

3. “PlateCarree” projection passed consistently in all map plot calls to address issues with irregular grid-cells in plots. 

4. Units of column for which statistics will be performed may now be specified in the commandline with argument –unit. 


Example end-to-end subroutine: 
#Call to download all data acquired at midnight UTC over CA spanning between 2016-2018 ```raiderDownloadGNSS.py -y '2016,2018' -b '38.1 38.3 237.4 237.6' -v --out products --returntime 00:00:00'``` 

#Call to plot distribution of stations and gridded station mean delay in a specific time interval: ```raiderStats.py -f products/CombinedGPS_ztd.csv -grid_delay_mean -station_distribution -ti '2016-01-01 2018-01-01'``` 


Changes yet to be implemented: 
1. Add option to explicitly retrieve spatial information for quick station plotting vs also retrieve zenith delay information. Currently the program forces the download of both. 

2. Parallelization for building CSV from remote data and plotting. Advice here in particular appreciated. @dbekaert, I wish to implement something along the lines of what is done to sort through products in the ARIA-tools ```ARIAProduct.py``` script 

3. Allow for shapefile input for spatial subset for download and/or plotting