### PR TITLE
Some improvements based on profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 CMake*
 Makefile
 dummy*
+weather_files

--- a/test/pytest/__init__.py
+++ b/test/pytest/__init__.py
@@ -1,0 +1,1 @@
+# Nothing special about this directory, it's just to separate old/new tests

--- a/test/pytest/test_integration.py
+++ b/test/pytest/test_integration.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+# The purpose of these tests is to verify that the axis parameter for trapz is
+# equivalent to calling apply_along_axis(trapz, axis).
+
+
+def test_integrate_along_axis():
+    y = np.array([
+        [[0, 1, 2],
+         [1, 2, 3]],
+    ])
+    x = np.array([2, 3, 4])
+
+    for level in range(y.shape[2]):
+        assert np.allclose(
+            np.apply_along_axis(np.trapz, 2, y[..., level:], x=x[level:]),
+            np.trapz(y[..., level:], x[level:], axis=2)
+        )
+
+
+def test_integrate_along_axis_2():
+    y = np.array([
+        [[0, 1, 2],
+         [1, 2, 3]],
+    ])
+    x = np.linspace(1, 5, num=y.shape[2])
+
+    for level in range(y.shape[2]):
+        assert np.allclose(
+            np.apply_along_axis(np.trapz, 2, y[..., level:], x=x[level:]),
+            np.trapz(y[..., level:], x[level:], axis=2)
+        )
+
+
+def test_integrate_along_axis_large():
+    y = np.random.standard_normal(100_000).reshape(100, 100, 10)
+    x = np.linspace(0, 1000, num=y.shape[2])
+
+    for level in range(y.shape[2]):
+        assert np.allclose(
+            np.apply_along_axis(np.trapz, 2, y[..., level:], x=x[level:]),
+            np.trapz(y[..., level:], x[level:], axis=2)
+        )

--- a/test/pytest/test_interpolator.py
+++ b/test/pytest/test_interpolator.py
@@ -1,0 +1,92 @@
+from RAiDER.interpolator import interp_along_axis
+import numpy as np
+
+
+def test_interp_along_axis_1d():
+    def f(x):
+        return 2 * x
+
+    xs = np.array([1, 2, 3, 4])
+    ys = f(xs)
+
+    points = np.array([1.5, 3.1])
+
+    assert np.allclose(
+        interp_along_axis(xs, points, ys, axis=0),
+        2 * points
+    )
+
+
+def test_interp_along_axis_2d():
+    def f(x):
+        return 2 * x
+
+    xs = np.array([
+        [1, 2, 3, 4],
+        [3, 4, 5, 6]
+    ])
+    ys = f(xs)
+
+    points = np.array([
+        [1.5, 3.1, 3.6],
+        [3.5, 5.1, 5.2]
+    ])
+
+    assert np.allclose(
+        interp_along_axis(xs, points, ys, axis=1),
+        2 * points
+    )
+
+
+def test_interp_along_axis_3d():
+    def f(x):
+        return 2 * x
+
+    xs = np.array([
+        [[1, 2, 3, 4],
+         [3, 4, 5, 6]],
+
+        [[10, 11, 12, 13],
+         [21, 22, 23, 24]]
+    ])
+    ys = f(xs)
+
+    points = np.array([
+        [[1.5, 3.1],
+         [3.5, 5.1]],
+
+        [[10.3, 12.9],
+         [22.6, 22.1]]
+    ])
+
+    assert np.allclose(
+        interp_along_axis(xs, points, ys, axis=2),
+        2 * points
+    )
+
+
+def test_interp_along_axis_3d_axis1():
+    def f(x):
+        return 2 * x
+
+    xs = np.array([
+        [[1, 2],
+         [3, 4]],
+
+        [[10, 11],
+         [21, 22]]
+    ])
+    ys = f(xs)
+
+    points = np.array([
+        [[1.5, 3.1],
+         [2.5, 2.1]],
+
+        [[10.3, 12.9],
+         [15, 17]]
+    ])
+
+    assert np.allclose(
+        interp_along_axis(xs, points, ys, axis=1),
+        2 * points
+    )

--- a/test/pytest/test_util.py
+++ b/test/pytest/test_util.py
@@ -1,0 +1,39 @@
+from RAiDER.utilFcns import _least_nonzero
+import numpy as np
+
+
+def test_least_nonzero():
+    a = np.arange(20, dtype="float64").reshape(2, 2, 5)
+    a[0, 0, 0] = np.nan
+    a[1, 1, 0] = np.nan
+
+    assert np.allclose(
+        _least_nonzero(a),
+        np.array([
+            [1, 5],
+            [10, 16]
+        ]),
+        atol=1e-16
+    )
+
+
+def test_least_nonzero_2():
+    a = np.array([
+        [[10., 5., np.nan],
+         [11., np.nan, 1],
+         [18, 17, 16]],
+
+        [[np.nan, 12., 6.],
+         [np.nan, 13., 20.],
+         [np.nan, np.nan, np.nan]]
+    ])
+
+    assert np.allclose(
+        _least_nonzero(a),
+        np.array([
+            [10, 11, 18],
+            [12, 13, np.nan]
+        ]),
+        atol=1e-16,
+        equal_nan=True
+    )

--- a/test/test_fcns.py
+++ b/test/test_fcns.py
@@ -1,6 +1,6 @@
 # Unit and other tests
 import datetime
-import gdal
+from osgeo import gdal
 import math
 import numpy as np
 import os

--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -1,6 +1,6 @@
 # Unit and other tests
 import datetime
-import gdal
+from osgeo import gdal
 import math
 import numpy as np
 import os

--- a/test/test_scenario_0.py
+++ b/test/test_scenario_0.py
@@ -1,6 +1,6 @@
 # Unit and other tests
 import datetime
-import gdal
+from osgeo import gdal
 import numpy as np
 import os
 import pandas as pd

--- a/test/test_scenario_1.py
+++ b/test/test_scenario_1.py
@@ -1,6 +1,6 @@
 # Unit and other tests
 import datetime
-import gdal
+from osgeo import gdal
 import numpy as np
 import os
 import pickle

--- a/test/test_utilFcns.py
+++ b/test/test_utilFcns.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from datetime import time
 
-import gdal
+from osgeo import gdal
 import numpy as np
 
 from RAiDER.utilFcns import makeDelayFileNames

--- a/test/test_weatherModel.py
+++ b/test/test_weatherModel.py
@@ -1,6 +1,6 @@
 # Unit and other tests
 import datetime
-import gdal
+from osgeo import gdal
 import glob
 import math
 import numpy as np

--- a/tools/RAiDER/demdownload.py
+++ b/tools/RAiDER/demdownload.py
@@ -8,7 +8,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import os
 
-import gdal
+from osgeo import gdal
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator as rgi
 

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -15,7 +15,7 @@ from RAiDER.utilFcns import parallel_apply_along_axis
 def interp_along_axis(oldCoord, newCoord, data, axis=2, pad=False):
     '''
     Interpolate an array of 3-D data along one axis. This function
-    assumes that the x-xoordinate increases monotonically.
+    assumes that the x-coordinate increases monotonically.
     '''
     if oldCoord.ndim > 1:
         stackedData = np.concatenate([oldCoord, data, newCoord], axis=axis)

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -61,24 +61,6 @@ def _interp3D(xs, ys, zs, values, zlevels, shape=None):
     return interp
 
 
-def interp_along_axis(oldCoord, newCoord, data, axis=2, pad=False):
-    '''
-    Interpolate an array of 3-D data along one axis. This function
-    assumes that the x-xoordinate increases monotonically.
-    '''
-    if oldCoord.ndim > 1:
-        stackedData = np.concatenate([oldCoord, data, newCoord], axis=axis)
-        try:
-            out = parallel_apply_along_axis(interpVector, arr=stackedData, axis=axis, Nx=oldCoord.shape[axis])
-        except:
-            out = np.apply_along_axis(interpVector, axis=axis, arr=stackedData, Nx=oldCoord.shape[axis])
-    else:
-        out = np.apply_along_axis(interpV, axis=axis, arr=data, old_x=oldCoord, new_x=newCoord,
-                                  left=np.nan, right=np.nan)
-
-    return out
-
-
 def fillna3D(array, axis=-1):
     '''
     Fcn to fill in NaNs in a 3D array by interpolating over one axis only

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -10,6 +10,7 @@
 import numpy as np
 
 from RAiDER.utilFcns import parallel_apply_along_axis
+from scipy.interpolate import interp1d
 
 
 def interp_along_axis(oldCoord, newCoord, data, axis=2, pad=False):
@@ -43,7 +44,6 @@ def interpVector(vec, Nx):
     x, the original y, and the new x, in that order. Nx tells the
     number of original x-points.
     '''
-    from scipy.interpolate import interp1d
     x = vec[:Nx]
     y = vec[Nx:2*Nx]
     xnew = vec[2*Nx:]

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -47,7 +47,7 @@ def interpVector(vec, Nx):
     x = vec[:Nx]
     y = vec[Nx:2*Nx]
     xnew = vec[2*Nx:]
-    f = interp1d(x, y, bounds_error=False)
+    f = interp1d(x, y, bounds_error=False, copy=False, assume_sorted=True)
     return f(xnew)
 
 

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -9,6 +9,7 @@ from RAiDER.models.weatherModel import WeatherModel
 def Model():
     return HRRR()
 
+
 class HRRR(WeatherModel):
     # I took this from
     # https://www.ecmwf.int/en/forecasts/documentation-and-support/137-model-levels.

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -206,8 +206,8 @@ class WeatherModel(ABC):
             # TODO: This returns zero for the last level because of the way trapz handles single points.
             # Should probably try to re-implement the integral function
             for level in range(wet.shape[2]):
-                wet_total[..., level] = 1e-6*np.apply_along_axis(np.trapz, 2, wet[..., level:], x=self._zs[level:])
-                hydro_total[..., level] = 1e-6*np.apply_along_axis(np.trapz, 2, hydro[..., level:], x=self._zs[level:])
+                wet_total[..., level] = 1e-6 * np.trapz(wet[..., level:], x=self._zs[level:], axis=2)
+                hydro_total[..., level] = 1e-6 * np.trapz(hydro[..., level:], x=self._zs[level:], axis=2)
             self._hydrostatic_total = hydro_total
             self._wet_total = wet_total
 

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -530,7 +530,7 @@ class WeatherModel():
         '''
         Pull the grid info (x,y) from a gdal-readable file
         '''
-        import gdal
+        from osgeo import gdal
         ds = gdal.Open(filename, gdal.GA_ReadOnly)
         xSize, ySize = ds.RasterXSize, ds.RasterYSize
         trans = ds.GetGeoTransform()

--- a/tools/RAiDER/prepFromAria.py
+++ b/tools/RAiDER/prepFromAria.py
@@ -6,7 +6,7 @@
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import gdal
+from osgeo import gdal
 import numpy as np
 
 from RAiDER.utilFcns import gdal_open, writeArrayToRaster

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -6,9 +6,10 @@
 #  RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+import contextlib
 import os
 import sys
+from datetime import datetime
 
 
 def getWMFilename(weather_model_name, time, outLoc, verbose=False):
@@ -16,13 +17,15 @@ def getWMFilename(weather_model_name, time, outLoc, verbose=False):
     Check whether the output weather model exists, and
     if not, download it.
     '''
-    from datetime import datetime as dt
-    from RAiDER.utilFcns import mkdir
-
-    mkdir('weather_files')
-    f = os.path.join(outLoc,
-                     '{}_{}.nc'.format(weather_model_name,
-                                       dt.strftime(time, '%Y_%m_%d_T%H_%M_%S')))
+    with contextlib.suppress(FileExistsError):
+        os.mkdir('weather_files')
+    f = os.path.join(
+        outLoc,
+        '{}_{}.nc'.format(
+            weather_model_name,
+            datetime.strftime(time, '%Y_%m_%d_T%H_%M_%S')
+        )
+    )
 
     if verbose:
         print('Storing weather model at: {}'.format(f))
@@ -42,8 +45,9 @@ def prepareWeatherModel(weatherDict, wmFileLoc, out, lats=None, lons=None,
     Parse inputs to download and prepare a weather model grid for interpolation
     '''
     import numpy as np
+
     from RAiDER.models.allowed import checkIfImplemented
-    from RAiDER.utilFcns import writeLL, getTimeFromFile
+    from RAiDER.utilFcns import getTimeFromFile, writeLL
 
     # Make weather
     weather_model, weather_files, weather_model_name = \

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -279,20 +279,12 @@ def round_date(date, precision):
 
 
 def _least_nonzero(a):
-    """Fill in a flat array with the lowest nonzero value.
+    """Fill in a flat array with the first non-nan value in the last dimension.
 
     Useful for interpolation below the bottom of the weather model.
     """
-    out = np.full(a.shape[:2], np.nan)
-    xlim, ylim, zlim = np.shape(a)
-    for x in range(xlim):
-        for y in range(ylim):
-            for z in range(zlim):
-                val = a[x][y][z]
-                if not np.isnan(val):
-                    out[x][y] = val
-                    break
-    return out
+    mgrid_index = tuple(slice(None, d) for d in a.shape[:-1])
+    return a[tuple(np.mgrid[mgrid_index]) + ((~np.isnan(a)).argmax(-1),)]
 
 
 def robmin(a):

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -424,13 +424,6 @@ def make_weather_model_filename(name, time, ll_bounds):
     )
 
 
-def mkdir(dirName):
-    try:
-        os.mkdir(dirName)
-    except FileExistsError:
-        pass
-
-
 def writeLL(time, lats, lons, llProj, weather_model_name, out):
     '''
     If the weather model grid nodes are used, write the lat/lon values


### PR DESCRIPTION
# Refactoring
- Needed to change all `import gdal` to `from osgeo import gdal` because `pygdal` doesn't support the former anymore.
- Deleted duplicate definition of `interp_along_axis`
- Moved some imports to the top of files (actually saved about 20 seconds doing this because some of those functions are very hot)

# Optimization
- Use the `np.trapz` feature of integrating across a different axis. Please verify that this is the intended behavior. There aren't any unit tests that check the behavior of `_runLOS` so I don't know if it still works. (95% of the savings)
  **Edit:** I added some tests for comparing the output of the two methods and I think the results are completely identical
- Rewrote `least_nonzero` to leverage numpy (4% of the savings)
- Tell interp1d not to copy input data and assume it is sorted (1% of the savings)

There is definitely still a long way to go, even just for the model pre-processing, but this should already provide a huge improvement. The one caveat is that I can't be entirely sure that I didn't break anything because of the lack of testing. Nonetheless here are some numbers:

All optimizations were done on the command
```
raiderDelay.py --date 20180101 --time 23:00:00 -b 40 -110 25 -95 --model HRRR --zref 30000 -v
```
which simply downloads an `HRRR` model and queries the model points for delay values. The first time I ran this, it took about 23 minutes. After making the `np.trapz` optimization this went down to about 5 minutes, and after the rest I got it down to about 3 minutes. Here are the exact numbers summarized in a table:

| optimization done | total run time (seconds)
| ------------- | --------------------: | 
| none | 1400 |
| trapz fix | 327 | 
| least_nonzero rewrite | 286 |
| interp1d params | 239 |

Now the biggest bottleneck is `interp_along_axis`, and in fact I found that generally `np.apply_along_axis` causes massive slowdowns whenever it is used. This is mostly due to the number of python function calls that it ends up generating, every one of which is an interruption to the fast native processing which adds up to absolutely huge performance costs. I think in the future it would be smart to avoid calling `apply_along_axis` unless absolutely necessary. I haven't yet been able to figure out how to do 1D interpolation along an axis on 3d data without calling `apply_along_axis`, so I might end up writing a function for that in C (in a separate PR).