### PR TITLE
Speed up interpolation by implementing it in C++

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ pybind_extensions = [
             # Path to pybind11 headers
             get_pybind_include(),
         ],
+        extra_compile_args=['-std=c++11'],
         language='c++'
     ),
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: David Bekaert, Jeremy Maurer, and Piyush Agram
 # Copyright 2019, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged.
 #
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 import glob
 import os
 import re
@@ -13,6 +14,8 @@ import re
 import numpy as np
 from setuptools import Extension, setup
 
+# Cythonize should be imported after setuptools. See:
+# https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#configuring-the-c-build
 from Cython.Build import cythonize  # isort:skip
 
 # Parameter defs
@@ -23,7 +26,7 @@ CYTHON_DIR = os.path.join(GEOMETRY_DIR, "cython", "Geo2rdr")
 UTIL_DIR = os.path.join(CWD, 'tools', 'bindings', 'utils')
 
 
-def getVersion():
+def get_version():
     with open('version.txt', 'r') as f:
         m = re.match("""version=['"](.*)['"]""", f.read())
 
@@ -63,28 +66,32 @@ pybind_extensions = [
 
 
 cython_extensions = [
-     Extension(
-       name="RAiDER.Geo2rdr",
-       sources=glob.glob(os.path.join(CPP_DIR, "*/*.cc")) +
-               glob.glob(os.path.join(CYTHON_DIR, "*.pyx")),
-       include_dirs=[np.get_include()] +
-                    [os.path.join(CPP_DIR, "Geometry"),
-                     os.path.join(CPP_DIR, "Utility"),
-                     os.path.join(CPP_DIR, "Orbit")],
-       extra_compile_args=['-std=c++11'],
-       extra_link_args=['-lm'],
-       language="c++"
-     ),
-     Extension(
-       name="RAiDER.makePoints",
-       sources=glob.glob(os.path.join(UTIL_DIR, "*.pyx")),
-       include_dirs=[np.get_include()]
-     ),
+    Extension(
+        name="RAiDER.Geo2rdr",
+        sources=[
+            *glob.glob(os.path.join(CPP_DIR, "*/*.cc")),
+            *glob.glob(os.path.join(CYTHON_DIR, "*.pyx"))
+        ],
+        include_dirs=[
+            np.get_include(),
+            os.path.join(CPP_DIR, "Geometry"),
+            os.path.join(CPP_DIR, "Utility"),
+            os.path.join(CPP_DIR, "Orbit")
+        ],
+        extra_compile_args=['-std=c++11'],
+        extra_link_args=['-lm'],
+        language="c++"
+    ),
+    Extension(
+        name="RAiDER.makePoints",
+        sources=glob.glob(os.path.join(UTIL_DIR, "*.pyx")),
+        include_dirs=[np.get_include()]
+    ),
 ]
 
 setup(
     name='RAiDER',
-    version=getVersion(),
+    version=get_version(),
     description='This is the RAiDER package',
     package_dir={
         'tools': 'tools',

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ pybind_extensions = [
             # Path to pybind11 headers
             get_pybind_include(),
         ],
-        extra_compile_args=['-std=c++11'],
+        extra_compile_args=['-std=c++17'],
         language='c++'
     ),
 ]

--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -136,7 +136,7 @@ def test_interpolate_along_axis():
     with pytest.raises(TypeError):
         interpolate_along_axis(
             np.zeros((2, 2)), np.zeros((2, 2)), np.zeros((2, 3)),
-            axis=0
+            axis=0, max_threads=1
         )
 
 
@@ -154,8 +154,29 @@ def test_interp_along_axis_1d():
         2 * points
     )
     assert np.allclose(
-        interpolate_along_axis(xs, ys, points, axis=0),
+        interpolate_along_axis(xs, ys, points, axis=0, max_threads=1),
         2 * points
+    )
+
+
+def test_interp_along_axis_1d_out_of_bounds():
+    def f(x):
+        return 2 * x
+
+    xs = np.array([1, 2, 3, 4])
+    ys = f(xs)
+
+    points = np.array([0, 5])
+
+    assert np.allclose(
+        interp_along_axis(xs, points, ys, axis=0),
+        np.array([np.nan, np.nan]),
+        equal_nan=True
+    )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=0, max_threads=1, fill_value=np.nan),
+        np.array([np.nan, np.nan]),
+        equal_nan=True
     )
 
 

--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from scipy.interpolate import RegularGridInterpolator
 
-from RAiDER.interpolate import interpolate
+from RAiDER.interpolate import interpolate, interpolate_along_axis
 from RAiDER.interpolator import (
     _interp3D, fillna3D, interp_along_axis, interpVector
 )
@@ -92,6 +92,49 @@ def test_interp_along_axis():
     assert np.allclose(interp_along_axis(z2, newz, zvals, axis=2), corz)
 
 
+def test_interpolate_along_axis():
+    # Rejects scalar values
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.array(0), np.array(0), np.array(0))
+
+    # Rejects mismatched number of dimensions
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros(1), np.zeros(1), np.zeros((1, 1)))
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros(1), np.zeros((1, 1)), np.zeros(1))
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros((1, 1)), np.zeros(1), np.zeros(1))
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros(1), np.zeros((1, 1)), np.zeros((1, 1)))
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros((1, 1)), np.zeros((1, 1)), np.zeros(1))
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros((1, 1)), np.zeros(1), np.zeros((1, 1)))
+
+    # Rejects mismatched shape for points and values
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros(1), np.zeros(2), np.zeros(1))
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros((9, 2)), np.zeros((9, 3)), np.zeros(1))
+
+    # Rejects bad axis
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros(1), np.zeros(1), np.zeros(1), axis=1)
+    with pytest.raises(TypeError):
+        interpolate_along_axis(np.zeros(1), np.zeros(1), np.zeros(1), axis=-2)
+
+    # Rejects bad interp_points shape
+    with pytest.raises(TypeError):
+        interpolate_along_axis(
+            np.zeros((2, 2)), np.zeros((2, 2)), np.zeros((3, 2))
+        )
+    with pytest.raises(TypeError):
+        interpolate_along_axis(
+            np.zeros((2, 2)), np.zeros((2, 2)), np.zeros((2, 3)),
+            axis=0
+        )
+
+
 def test_interp_along_axis_1d():
     def f(x):
         return 2 * x
@@ -103,6 +146,10 @@ def test_interp_along_axis_1d():
 
     assert np.allclose(
         interp_along_axis(xs, points, ys, axis=0),
+        2 * points
+    )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=0),
         2 * points
     )
 
@@ -124,6 +171,10 @@ def test_interp_along_axis_2d():
 
     assert np.allclose(
         interp_along_axis(xs, points, ys, axis=1),
+        2 * points
+    )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=1),
         2 * points
     )
 
@@ -151,6 +202,10 @@ def test_interp_along_axis_3d():
 
     assert np.allclose(
         interp_along_axis(xs, points, ys, axis=2),
+        2 * points
+    )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=2),
         2 * points
     )
 

--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -235,6 +235,38 @@ def test_interp_along_axis_3d_axis1():
         interp_along_axis(xs, points, ys, axis=1),
         2 * points
     )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=1),
+        2 * points
+    )
+
+
+def test_interp_along_axis_3d_large():
+    def f(x):
+        return 2 * x
+
+    # To scale values along axis 0 of a 3 dimensional array
+    scale = np.arange(1, 101).reshape((100, 1, 1))
+    axis1 = np.arange(100)
+    axis2 = np.repeat(np.array([axis1]), 100, axis=0)
+    xs = np.repeat(np.array([axis2]), 100, axis=0) * scale
+    ys = f(xs)
+
+    points = np.array([np.linspace(0, 99, num=200)]).repeat(100, axis=0)
+    points = np.repeat(np.array([points]), 100, axis=0) * scale
+
+    assert np.allclose(
+        interp_along_axis(xs, points, ys, axis=2),
+        2 * points
+    )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=2),
+        2 * points
+    )
+    assert np.allclose(
+        interpolate_along_axis(xs, ys, points, axis=2, assume_sorted=True),
+        2 * points
+    )
 
 
 def test_grid_dim_mismatch():

--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
+from scipy.interpolate import RegularGridInterpolator
 
+from RAiDER.interpolate import interpolate
 from RAiDER.interpolator import (
     _interp3D, fillna3D, interp_along_axis, interpVector
 )
@@ -178,3 +180,409 @@ def test_interp_along_axis_3d_axis1():
         interp_along_axis(xs, points, ys, axis=1),
         2 * points
     )
+
+
+def test_grid_dim_mismatch():
+    with pytest.raises(TypeError):
+        interpolate(
+            points=(np.zeros((10,)), np.zeros((5,))),
+            values=np.zeros((1,)),
+            interp_points=np.zeros((1,))
+        )
+
+
+def test_basic():
+    ans = interpolate(
+        points=(np.array([0, 1]),),
+        values=np.array([0, 1]),
+        interp_points=np.array([[0.5]]),
+        max_threads=1,
+        assume_sorted=True
+    )
+
+    assert ans == np.array([0.5])
+
+
+def test_small():
+    ans = interpolate(
+        points=(np.array([1, 2, 3, 4, 5, 6]),),
+        values=np.array([10, 9, 30, 10, 6, 1]),
+        interp_points=np.array([1.25, 2.9, 3.01, 5.7]).reshape(-1, 1)
+    )
+
+    assert ans.shape == (4,)
+    assert np.allclose(ans, np.array([9.75, 27.9, 29.8, 2.5]), atol=1e-15)
+
+
+def test_small_not_sorted():
+    ans = interpolate(
+        points=(np.array([1, 2, 3, 4, 5, 6]),),
+        values=np.array([10, 9, 30, 10, 6, 1]),
+        interp_points=np.array([2.9, 1.25, 5.7, 3.01]).reshape(-1, 1),
+    )
+
+    assert ans.shape == (4,)
+    assert np.allclose(ans, np.array([27.9, 9.75, 2.5, 29.8]), atol=1e-15)
+
+
+def test_exact_points():
+    ans = interpolate(
+        points=(np.array([1, 2, 3, 4, 5, 6]),),
+        values=np.array([10, 9, 30, 10, 6, 1]),
+        interp_points=np.array([1, 2, 3, 4, 5, 6]).reshape(-1, 1)
+    )
+
+    assert ans.shape == (6,)
+    assert np.allclose(ans, np.array([10, 9, 30, 10, 6, 1]), atol=1e-15)
+
+
+def test_2d_basic():
+    xs = np.array([0, 1])
+    ys = np.array([0, 1])
+
+    values = (lambda x, y: x + y)(*np.meshgrid(xs, ys, indexing="ij", sparse=True))
+
+    ans = interpolate(
+        points=(xs, ys),
+        values=values,
+        interp_points=np.array([[0.5, 0.5]])
+    )
+
+    assert ans == np.array([1])
+
+
+def test_2d_square_small():
+    def f(x, y):
+        return x ** 2 + 3 * y
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, atol=1e-15)
+
+
+def test_2d_rectangle_small():
+    def f(x, y):
+        return x ** 2 + 3 * y
+
+    xs = np.linspace(0, 2000, 200)
+    ys = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, atol=1e-15)
+
+
+def test_2d_rectangle_small_2():
+    def f(x, y):
+        return x ** 2 + 3 * y
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 2000, 200)
+
+    values = f(*np.meshgrid(xs, ys, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, atol=1e-15)
+
+
+def test_2d_square_large():
+    def f(x, y):
+        return x ** 2 + 3 * y
+
+    xs = np.linspace(-10_000, 10_000, num=1_000)
+    ys = np.linspace(0, 20_000, num=1_000)
+
+    values = f(*np.meshgrid(xs, ys, indexing="ij", sparse=True))
+    num_points = 2_000_000
+    points = np.stack((
+        np.linspace(10, 990, num_points),
+        np.linspace(10, 890, num_points)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, atol=1e-15)
+
+
+def test_3d_basic():
+    xs = np.array([0, 1])
+    ys = np.array([0, 1])
+    zs = np.array([0, 1])
+
+    values = (lambda x, y, z: x + y + z)(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=np.array([[0.5, 0.5, 0.5]]),
+        assume_sorted=True
+    )
+
+    assert ans == np.array([1.5])
+
+
+def test_3d_cube_small():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 1000, 100)
+    zs = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5),
+        np.linspace(10, 780, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_3d_cube_small_not_sorted():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 1000, 100)
+    zs = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    points = np.stack((
+        np.random.uniform(10, 990, 10),
+        np.random.uniform(10, 890, 10),
+        np.random.uniform(10, 780, 10)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=points,
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_3d_prism_small():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 2000, 200)
+    ys = np.linspace(0, 1000, 100)
+    zs = np.linspace(0, 1000, 50)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5),
+        np.linspace(10, 780, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_3d_prism_small_2():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 2000, 100)
+    ys = np.linspace(0, 1000, 200)
+    zs = np.linspace(0, 1000, 50)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5),
+        np.linspace(10, 780, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_3d_prism_small_3():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 2000, 50)
+    ys = np.linspace(0, 1000, 200)
+    zs = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5),
+        np.linspace(10, 780, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_3d_cube_large():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 1000, 100)
+    zs = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    num_points = 2_000_000
+    points = np.stack((
+        np.linspace(10, 990, num_points),
+        np.linspace(10, 890, num_points),
+        np.linspace(10, 780, num_points)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_4d_basic():
+    xs = np.array([0, 1])
+    ys = np.array([0, 1])
+    zs = np.array([0, 1])
+    ws = np.array([0, 1])
+
+    values = (lambda x, y, z, w: x + y + z + w)(*np.meshgrid(xs, ys, zs, ws, indexing="ij", sparse=True))
+
+    ans = interpolate(
+        points=(xs, ys, zs, ws),
+        values=values,
+        interp_points=np.array([[0.5, 0.5, 0.5, 0.5]])
+    )
+
+    assert ans == np.array([2])
+
+
+def test_4d_cube_small():
+    def f(x, y, z, w):
+        return x ** 2 + 3 * y - z * w
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 1000, 100)
+    zs = np.linspace(0, 1000, 100)
+    ws = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, zs, ws, indexing="ij", sparse=True))
+    points = np.stack((
+        np.linspace(10, 990, 5),
+        np.linspace(10, 890, 5),
+        np.linspace(10, 780, 5),
+        np.linspace(10, 670, 5)
+    ), axis=-1)
+
+    ans = interpolate(
+        points=(xs, ys, zs, ws),
+        values=values,
+        interp_points=points,
+        assume_sorted=True
+    )
+
+    rgi = RegularGridInterpolator((xs, ys, zs, ws), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)

--- a/test/weather_model/test_weather_model.py
+++ b/test/weather_model/test_weather_model.py
@@ -1,0 +1,97 @@
+"""
+Testing the base WeatherModel class
+"""
+import operator
+from functools import reduce
+
+import numpy as np
+import pytest
+from numpy import nan
+
+from RAiDER.models.weatherModel import WeatherModel
+
+
+def product(iterable):
+    return reduce(operator.mul, iterable, 1)
+
+
+class MockWeatherModel(WeatherModel):
+    """Implement abstract methods for testing."""
+
+    def __init__(self):
+        super().__init__()
+
+        self._Name = "MOCK"
+
+    def _fetch(self, lats, lons, time, out):
+        pass
+
+    def load_weather(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def model():
+    return MockWeatherModel()
+
+
+def test_uniform_in_z_small(model):
+    # Uneven z spacing, but averages to [1, 2]
+    model._zs = np.array([
+        [[1., 2.],
+         [0.9, 1.1]],
+
+        [[1., 2.6],
+         [1.1, 2.3]]
+    ])
+    model._xs = np.array([1, 2, 2])
+    model._ys = np.array([2, 3, 2])
+    model._p = np.arange(8).reshape(2, 2, 2)
+    model._t = model._p * 2
+    model._e = model._p * 3
+
+    model._uniform_in_z()
+
+    interpolated = np.array([
+        # Note that when the lower bound is exactly equal we get a value, but
+        # when the upper bound is exactly equal we get the fill
+        [[0, nan],
+         [2.5, nan]],
+
+        [[4., 4.625],
+         [nan, 6.75]]
+    ])
+
+    assert np.allclose(model._p, interpolated, equal_nan=True, rtol=0)
+    assert np.allclose(model._t, interpolated * 2, equal_nan=True, rtol=0)
+    assert np.allclose(model._e, interpolated * 3, equal_nan=True, rtol=0)
+
+    assert np.allclose(model._zs, np.array([1, 2]), rtol=0)
+    assert np.allclose(model._xs, np.array([1, 2]), rtol=0)
+    assert np.allclose(model._ys, np.array([2, 3]), rtol=0)
+
+
+def test_uniform_in_z_large(model):
+    shape = (400, 500, 40)
+    x, y, z = shape
+    size = product(shape)
+
+    # Uneven spacing that averages to approximately [1, 2, ..., 39, 40]
+    zlevels = np.arange(1, shape[-1] + 1)
+    model._zs = np.random.normal(1, 0.1, size).reshape(shape) * zlevels
+    model._xs = np.empty(0)  # Doesn't matter
+    model._ys = np.empty(0)  # Doesn't matter
+    model._p = np.tile(np.arange(y).reshape(-1, 1) * np.ones(z), (x, 1, 1))
+    model._t = model._p * 2
+    model._e = model._p * 3
+
+    assert model._p.shape == shape
+    model._uniform_in_z()
+
+    interpolated = np.tile(np.arange(y), (x, 1))
+
+    assert np.allclose(np.nanmean(model._p, axis=-1), interpolated, equal_nan=True, rtol=0)
+    assert np.allclose(np.nanmean(model._t, axis=-1), interpolated * 2, equal_nan=True, rtol=0)
+    assert np.allclose(np.nanmean(model._e, axis=-1), interpolated * 3, equal_nan=True, rtol=0)
+
+    assert np.allclose(model._zs, zlevels, atol=0.05, rtol=0)

--- a/tools/RAiDER/__init__.py
+++ b/tools/RAiDER/__init__.py
@@ -1,0 +1,13 @@
+"""
+Raytracing Atmospheric Delay Estimation for RADAR
+
+Copyright (c) 2019-2020, California Institute of Technology ("Caltech"). All rights reserved.
+"""
+
+# Import compiled modules so we can do something like
+#
+# import RAiDER
+# RAiDER.Geo2rdr
+from RAiDER import Geo2rdr, interpolate, makePoints
+
+__copyright__ = 'Copyright (c) 2019-2020, California Institute of Technology ("Caltech"). All rights reserved.'

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -204,7 +204,7 @@ def interpolate2(fun, x, y, z):
     helper function to make the interpolation step cleaner
     '''
     in_shape = x.shape
-    out = fun((y.flatten(), x.flatten(), z.flatten()))
+    out = fun((y.ravel(), x.ravel(), z.ravel()))
     outData = out.reshape(in_shape)
     return outData
 

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -106,9 +106,6 @@ class WeatherModel(ABC):
     def Model(self):
         return self._Name
 
-    def ModelObj(self):
-        return self
-
     def fetch(self, lats, lons, time, out):
         '''
         Checks the input datetime against the valid date range for the model and then

--- a/tools/bindings/interpolate/src/interpolate.cpp
+++ b/tools/bindings/interpolate/src/interpolate.cpp
@@ -3,6 +3,7 @@
 #include "interpolate.h"
 
 #include <iostream>
+#include <optional>
 
 // data_zs must have length data_x_N * data_y_N
 // out must have length N
@@ -245,6 +246,7 @@ void interpolate_1d_along_axis(
     const py::buffer_info interp_points,
     py::buffer_info out,
     size_t axis,
+    std::optional<double> fill_value,
     bool assume_sorted
 ) {
     size_t dimensions = interp_points.ndim;
@@ -268,8 +270,6 @@ void interpolate_1d_along_axis(
     // the dimension 'axis'.
     bool done = false;
     while (!done) {
-        /* Do the interpolation */
-
         // precompute the strided offsets
         size_t interp_offset_base = 0;
         size_t grid_offset_base = 0;
@@ -293,10 +293,11 @@ void interpolate_1d_along_axis(
             interp_begin_axis,
             out_begin_axis,
             interp_axis_size,
+            fill_value,
             assume_sorted
         );
-        /* End interpolation */
 
+        // Find the next index
         done = true;
         for (size_t i = dimensions; i > 0; i--) {
             size_t dim = i - 1;

--- a/tools/bindings/interpolate/src/interpolate.cpp
+++ b/tools/bindings/interpolate/src/interpolate.cpp
@@ -1,0 +1,287 @@
+#include "assert.h"
+#include "stdio.h"
+#include "interpolate.h"
+
+#include <iostream>
+
+
+// TODO, just take start and size
+inline size_t bisect_left(double * data, size_t data_N, double x, size_t left, size_t right) {
+    assert(left > 0);
+    assert(right < data_N);
+
+    while (right - left > 1) {
+        size_t mid = left + (right - left) / 2;
+        if (x < data[mid]) {
+            right = mid;
+        } else {
+            left = mid;
+        }
+    }
+
+    return right;
+}
+
+
+// Like bisect_left but optimized for when we expect the target to appear near
+// the start of the array.
+//
+// Tries a small scan first and then switches to bisection
+inline size_t find_left(double * data, size_t data_N, double x, size_t left, size_t right) {
+    for (size_t i = 0; i < 5; i++) {
+        if (left == data_N || x < data[left]) {
+            return left;
+        }
+        left += 1;
+    }
+
+    return bisect_left(data, data_N, x, left, right);
+}
+
+
+void interpolate_1d(
+    double * data_xs,
+    size_t data_N,
+    double * data_ys,
+    double * xs,
+    double * out,
+    size_t N
+) {
+    size_t lo = 0;
+    size_t hi = 0;
+    for (size_t i = 0; i < N; i++) {
+        double x = xs[i];
+        hi = find_left(data_xs, data_N, x, lo, data_N);
+        if (hi < 1) {
+            hi = 1;
+        } else if (hi > data_N - 1) {
+            hi = data_N - 1;
+        }
+
+        lo = hi - 1;
+
+        double x0 = data_xs[lo],
+               x1 = data_xs[hi],
+               // Output
+               y0 = data_ys[lo],
+               y1 = data_ys[hi];
+
+        double slope = (y1 - y0) / (x1 - x0);
+        out[i] = y0 + slope * (x - x0);
+    }
+}
+
+
+// data_zs must have length data_x_N * data_y_N
+// out must have length N
+// interpolation_points must have length 2N
+void interpolate_2d(
+    double * data_xs,
+    size_t data_x_N,
+    double * data_ys,
+    size_t data_y_N,
+    double * data_zs,
+    double * interpolation_points,
+    double * out,
+    size_t N
+) {
+    size_t lox = 0;
+    size_t loy = 0;
+    for (size_t i = 0; i < N; i++) {
+        double x = interpolation_points[i * 2];
+        double y = interpolation_points[i * 2 + 1];
+        size_t hix = find_left(data_xs, data_x_N, x, lox, data_x_N);
+        size_t hiy = find_left(data_ys, data_y_N, y, loy, data_y_N);
+        if (hix < 1) {
+            hix = 1;
+        } else if (hix > data_x_N - 1) {
+            hix = data_x_N - 1;
+        }
+        if (hiy < 1) {
+            hiy = 1;
+        } else if (hiy > data_y_N - 1) {
+            hiy = data_y_N - 1;
+        }
+
+        lox = hix - 1;
+        loy = hiy - 1;
+
+        // https://en.wikipedia.org/wiki/Bilinear_interpolation
+        double x0 = data_xs[lox],
+               y0 = data_ys[loy],
+               x1 = data_xs[hix],
+               y1 = data_ys[hiy],
+               // Outputs
+               z00 = data_zs[lox * data_y_N + loy],
+               z01 = data_zs[lox * data_y_N + hiy],
+               z10 = data_zs[hix * data_y_N + loy],
+               z11 = data_zs[hix * data_y_N + hiy];
+
+        double dx = x1 - x0,
+               dy = y1 - y0,
+               dist_x0 = x - x0,
+               dist_x1 = x1 - x,
+               dist_y0 = y - y0,
+               dist_y1 = y1 - y;
+
+        out[i] = (
+            dist_x1 * (z00 * dist_y1 + z01 * dist_y0) +
+            dist_x0 * (z10 * dist_y1 + z11 * dist_y0)
+        ) / (dx * dy);
+    }
+}
+
+void interpolate_3d(
+    double * data_xs,
+    size_t data_x_N,
+    double * data_ys,
+    size_t data_y_N,
+    double * data_zs,
+    size_t data_z_N,
+    double * data_ws,
+    double * interpolation_points,
+    double * out,
+    size_t N
+) {
+    size_t lox = 0;
+    size_t loy = 0;
+    size_t loz = 0;
+    for (size_t i = 0; i < N; i++) {
+        double x = interpolation_points[i * 3];
+        double y = interpolation_points[i * 3 + 1];
+        double z = interpolation_points[i * 3 + 2];
+        size_t hix = find_left(data_xs, data_x_N, x, lox, data_x_N);
+        size_t hiy = find_left(data_ys, data_y_N, y, loy, data_y_N);
+        size_t hiz = find_left(data_zs, data_z_N, z, loz, data_z_N);
+        if (hix < 1) {
+            hix = 1;
+        } else if (hix > data_x_N - 1) {
+            hix = data_x_N - 1;
+        }
+        if (hiy < 1) {
+            hiy = 1;
+        } else if (hiy > data_y_N - 1) {
+            hiy = data_y_N - 1;
+        }
+        if (hiz < 1) {
+            hiz = 1;
+        } else if (hiz > data_z_N - 1) {
+            hiz = data_z_N - 1;
+        }
+
+        lox = hix - 1;
+        loy = hiy - 1;
+        loz = hiz - 1;
+
+        // https://en.wikipedia.org/wiki/Trilinear_interpolation
+        size_t data_yz_N = data_y_N * data_z_N;
+        double x0 = data_xs[lox],
+               y0 = data_ys[loy],
+               z0 = data_zs[loz],
+               x1 = data_xs[hix],
+               y1 = data_ys[hiy],
+               z1 = data_zs[hiz],
+               // Outputs
+               w000 = data_ws[lox * data_yz_N + loy * data_z_N + loz],
+               w001 = data_ws[lox * data_yz_N + loy * data_z_N + hiz],
+               w010 = data_ws[lox * data_yz_N + hiy * data_z_N + loz],
+               w011 = data_ws[lox * data_yz_N + hiy * data_z_N + hiz],
+               w100 = data_ws[hix * data_yz_N + loy * data_z_N + loz],
+               w101 = data_ws[hix * data_yz_N + loy * data_z_N + hiz],
+               w110 = data_ws[hix * data_yz_N + hiy * data_z_N + loz],
+               w111 = data_ws[hix * data_yz_N + hiy * data_z_N + hiz];
+
+        double dx = x1 - x0,
+               dy = y1 - y0,
+               dz = z1 - z0,
+               dist_x0 = x - x0,
+               dist_x1 = x1 - x,
+               dist_y0 = y - y0,
+               dist_y1 = y1 - y,
+               dist_z0 = z - z0,
+               dist_z1 = z1 - z;
+
+        out[i] = (
+            dist_x1 * (
+                dist_y1 * (dist_z1 * w000 + dist_z0 * w001) +
+                dist_y0 * (dist_z1 * w010 + dist_z0 * w011)
+            ) +
+            dist_x0 * (
+                dist_y1 * (dist_z1 * w100 + dist_z0 * w101) +
+                dist_y0 * (dist_z1 * w110 + dist_z0 * w111)
+            )
+        ) / (dx * dy * dz);
+    }
+}
+
+void interpolate(
+    const std::vector<slice<double>> &grid,
+    const slice<double> &values,
+    const slice<double> &interpolation_points,
+    slice<double> &out
+) {
+    // Only up to 64 dimensions is supported
+    assert(grid.size() < 64);
+
+    size_t dimensions = grid.size();
+    size_t num_points = out.size;
+
+    std::vector<size_t> los(dimensions);
+    std::vector<size_t> his(dimensions);
+
+    std::vector<double> lower_bounds(dimensions);
+    std::vector<double> upper_bounds(dimensions);
+    std::vector<double> lower_dist(dimensions);
+    std::vector<double> upper_dist(dimensions);
+
+
+    std::vector<double> corner_points(1 << dimensions);
+
+
+    for (size_t i = 0; i < num_points; i++) {
+        double total_volume = 1;
+        for (size_t dim = 0; dim < dimensions; dim++) {
+            auto xs = grid[dim];
+            double x = interpolation_points.ptr[i * dimensions + dim];
+            size_t hi = find_left(xs.ptr, xs.size, x, los[dim], xs.size);
+            if (hi < 1) {
+                hi = 1;
+            } else if (hi > xs.size - 1) {
+                hi = xs.size - 1;
+            }
+            size_t lo = hi - 1;
+
+            los[dim] = lo;
+            his[dim] = hi;
+
+            double x0 = xs.ptr[lo];
+            double x1 = xs.ptr[hi];
+
+            lower_bounds[dim] = x0;
+            upper_bounds[dim] = x1;
+            total_volume *= x1 - x0;
+            lower_dist[dim] = x - x0;
+            upper_dist[dim] = x1 - x;
+        }
+
+        out.ptr[i] = 0;
+        for (unsigned long j = 0; j < corner_points.size(); j++) {
+            size_t index = 0;
+            // lox * data_y * data_z + loy * data_z + loz
+            // (data_z (data_y * (lox) + loy) + loz) * 1
+            for (size_t dim = 0; dim < dimensions; dim++) {
+                index += (
+                    (j >> (dim)) & 1 ? his[dim] : los[dim]
+                );
+                index *= (dim + 1 < dimensions ? grid[dim + 1].size : 1);
+            }
+            double term = values.ptr[index];
+            for (size_t dim = 0; dim < dimensions; dim++) {
+                term *= (j >> (dim)) & 1 ? lower_dist[dim] : upper_dist[dim];
+            }
+            out.ptr[i] += term;
+        }
+
+        out.ptr[i] /= total_volume;
+    }
+}

--- a/tools/bindings/interpolate/src/interpolate.cpp
+++ b/tools/bindings/interpolate/src/interpolate.cpp
@@ -240,29 +240,29 @@ void interpolate(
 }
 
 void interpolate_1d_along_axis(
-    const py::array_t<double> grid,
-    const py::array_t<double> values,
-    const py::array_t<double> interp_points,
-    py::array_t<double> out,
+    const py::buffer_info grid,
+    const py::buffer_info values,
+    const py::buffer_info interp_points,
+    py::buffer_info out,
     size_t axis,
     bool assume_sorted
 ) {
-    size_t dimensions = interp_points.ndim();
-    auto interp_shape = interp_points.shape();
-    auto interp_strides = interp_points.strides();
+    size_t dimensions = interp_points.ndim;
+    const std::vector<ssize_t> &interp_shape = interp_points.shape;
+    const std::vector<ssize_t> &interp_strides = interp_points.strides;
     ssize_t interp_axis_stride = interp_strides[axis];
     size_t interp_axis_size = (size_t) interp_shape[axis];
 
-    auto grid_strides = grid.strides();
+    auto grid_strides = grid.strides;
     ssize_t grid_axis_stride = grid_strides[axis];
-    size_t grid_axis_size = (size_t) grid.shape(axis);
+    size_t grid_axis_size = (size_t) grid.shape[axis];
 
     std::vector<size_t> index(dimensions);
 
-    const double *grid_ptr = grid.data();
-    const double *values_ptr = values.data();
-    const double *interp_ptr = interp_points.data();
-    double *out_ptr = out.mutable_data();
+    const double *grid_ptr = (double*) grid.ptr;
+    const double *values_ptr = (double*) values.ptr;
+    const double *interp_ptr = (double*) interp_points.ptr;
+    double *out_ptr = (double*) out.ptr;
 
     // Iterate over the starting indices. This counts over the shape skipping
     // the dimension 'axis'.

--- a/tools/bindings/interpolate/src/interpolate.cpp
+++ b/tools/bindings/interpolate/src/interpolate.cpp
@@ -192,9 +192,7 @@ void interpolate(
     std::vector<double> lower_dist(dimensions);
     std::vector<double> upper_dist(dimensions);
 
-
     std::vector<double> corner_points(1 << dimensions);
-
 
     for (size_t i = 0; i < num_points; i++) {
         double total_volume = 1;

--- a/tools/bindings/interpolate/src/interpolate.cpp
+++ b/tools/bindings/interpolate/src/interpolate.cpp
@@ -1,8 +1,15 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Author: Rohan Weeden
+// Copyright 2020, by the California Institute of Technology. ALL RIGHTS
+// RESERVED. United States Government Sponsorship acknowledged.
+//
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 #include "assert.h"
 #include "stdio.h"
 #include "interpolate.h"
 
-#include <iostream>
 #include <optional>
 
 // data_zs must have length data_x_N * data_y_N

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -16,7 +16,8 @@ void interpolate_1d(
     double * data_ys,
     double * xs,
     double * out,
-    size_t N
+    size_t N,
+    bool assume_sorted
 );
 
 void interpolate_2d(
@@ -27,7 +28,8 @@ void interpolate_2d(
     double * data_zs,
     double * interpolation_points,
     double * out,
-    size_t N
+    size_t N,
+    bool assume_sorted
 );
 
 void interpolate_3d(
@@ -40,7 +42,8 @@ void interpolate_3d(
     double * data_ws,
     double * interpolation_points,
     double * out,
-    size_t N
+    size_t N,
+    bool assume_sorted
 );
 
 template <typename T>
@@ -54,7 +57,8 @@ void interpolate(
     const std::vector<slice<double>> &grid,
     const slice<double> &values,
     const slice<double> &interpolation_points,
-    slice<double> &out
+    slice<double> &out,
+    bool assume_sorted
 );
 
 #endif

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -145,15 +145,6 @@ void interpolate(
     bool assume_sorted
 );
 
-template <typename T>
-inline size_t offset(const ssize_t *strides, const std::vector<size_t> &index) {
-    size_t offset = 0;
-    for (size_t dim = 0; dim < index.size(); dim++) {
-        offset += index[dim] * strides[dim];
-    }
-    return offset / sizeof(T);
-}
-
 // Helper for handling the striding required to iterate along a given axis
 template<typename T>
 class axis_iterator {

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include "sys/types.h"
+
+#ifndef PY_FAST_INTERP_H
+#define PY_FAST_INTERP_H
+
+namespace py = pybind11;
+
+// TODO: Don't store grid points as an array, just derive them from a formula?
+// TODO: Same for interpolation points?
+void interpolate_1d(
+    double * data_xs,
+    size_t data_N,
+    double * data_ys,
+    double * xs,
+    double * out,
+    size_t N
+);
+
+void interpolate_2d(
+    double * data_xs,
+    size_t data_x_N,
+    double * data_ys,
+    size_t data_y_N,
+    double * data_zs,
+    double * interpolation_points,
+    double * out,
+    size_t N
+);
+
+void interpolate_3d(
+    double * data_xs,
+    size_t data_x_N,
+    double * data_ys,
+    size_t data_y_N,
+    double * data_zs,
+    size_t data_z_N,
+    double * data_ws,
+    double * interpolation_points,
+    double * out,
+    size_t N
+);
+
+template <typename T>
+struct slice {
+    size_t size;
+    T * ptr;
+};
+
+// Any dimension, but slower
+void interpolate(
+    const std::vector<slice<double>> &grid,
+    const slice<double> &values,
+    const slice<double> &interpolation_points,
+    slice<double> &out
+);
+
+#endif

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -234,10 +234,10 @@ public:
 };
 
 void interpolate_1d_along_axis(
-    const py::array_t<double> points,
-    const py::array_t<double> values,
-    const py::array_t<double> interp_points,
-    py::array_t<double> out,
+    const py::buffer_info grid,
+    const py::buffer_info values,
+    const py::buffer_info interp_points,
+    py::buffer_info out,
     size_t axis,
     bool assume_sorted
 );

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -61,4 +61,22 @@ void interpolate(
     bool assume_sorted
 );
 
+template <typename T>
+inline size_t offset(const ssize_t *strides, const std::vector<size_t> &index) {
+    size_t offset = 0;
+    for (size_t dim = 0; dim < index.size(); dim++) {
+        offset += index[dim] * strides[dim];
+    }
+    return offset / sizeof(T);
+}
+
+void interpolate_1d_along_axis(
+    const py::array_t<double> points,
+    const py::array_t<double> values,
+    const py::array_t<double> interp_points,
+    py::array_t<double> out,
+    size_t axis,
+    bool assume_sorted
+);
+
 #endif

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -1,9 +1,16 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Author: Rohan Weeden
+// Copyright 2020, by the California Institute of Technology. ALL RIGHTS
+// RESERVED. United States Government Sponsorship acknowledged.
+//
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
 #include <iterator>
 #include <optional>
-#include <iostream>
 
 #include "sys/types.h"
 #include "assert.h"

--- a/tools/bindings/interpolate/src/interpolate.h
+++ b/tools/bindings/interpolate/src/interpolate.h
@@ -1,12 +1,49 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+#include <iterator>
+
 #include "sys/types.h"
 
 #ifndef PY_FAST_INTERP_H
 #define PY_FAST_INTERP_H
 
 namespace py = pybind11;
+
+template<typename RAIter>
+inline size_t bisect_left(RAIter begin, RAIter end, double x) {
+    size_t left = 0;
+    size_t right = std::distance(begin, end) - 1;
+
+    while (right - left > 1) {
+        size_t mid = left + (right - left) / 2;
+        if (x < begin[mid]) {
+            right = mid;
+        } else {
+            left = mid;
+        }
+    }
+
+    return right;
+}
+
+// Like bisect_left but optimized for when we expect the target to appear near
+// the start of the array.
+//
+// Tries a small scan first and then switches to bisection
+template<typename RAIter>
+inline size_t find_left(RAIter begin, RAIter end, double x) {
+    size_t left = 0;
+    size_t data_N = std::distance(begin, end);
+
+    for (; left < 5; left++) {
+        if (left == data_N || x < begin[left]) {
+            return left;
+        }
+    }
+
+    return bisect_left(begin + left, end, x) + left;
+}
 
 // TODO: Don't store grid points as an array, just derive them from a formula?
 // TODO: Same for interpolation points?
@@ -69,6 +106,78 @@ inline size_t offset(const ssize_t *strides, const std::vector<size_t> &index) {
     }
     return offset / sizeof(T);
 }
+
+// Helper for handling the striding required to iterate along a given axis
+template<typename T>
+class axis_iterator {
+    const unsigned char *data;
+    size_t ndim;
+    size_t axis;
+    const size_t * index;
+    const ssize_t * strides;
+    size_t position = 0;
+public:
+    axis_iterator(
+        const T *data,
+        size_t ndim,
+        size_t axis,
+        const size_t * index,
+        const ssize_t * strides
+    ) : data((unsigned char*) data), ndim(ndim), axis(axis), index(index), strides(strides) {}
+
+    axis_iterator& operator++() {
+        position += 1;
+        return *this;
+    }
+    axis_iterator operator++(int) {
+        axis_iterator retval = *this;
+        ++(*this);
+        return retval;
+    }
+    axis_iterator& operator+=(size_t n) {
+        this->position += n;
+        return *this;
+    }
+    axis_iterator operator+(size_t n) const {
+        axis_iterator next(*this);
+        next += n;
+        return next;
+    }
+    long operator-(axis_iterator &other) const {
+        return ((ssize_t) position) - other.position;
+    }
+    bool operator==(axis_iterator &other) const {
+        return data == other.data
+            && ndim == other.ndim
+            && axis == other.axis
+            && index == other.index
+            && strides == other.strides
+            && position == other.position;
+    }
+    bool operator!=(axis_iterator &other) const {
+        return !(*this == other);
+    }
+    T operator*() {
+        return (*this)[position];
+    }
+    T & operator[](const ssize_t &n) const {
+        size_t offset = 0;
+        for (size_t dim = 0; dim < ndim; dim++) {
+            if (dim == axis) {
+                offset += (position + n) * strides[dim];
+            } else {
+                offset += index[dim] * strides[dim];
+            }
+        }
+        return *((T*) (data + offset));
+    }
+    // iterator traits
+    using difference_type = long;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+};
 
 void interpolate_1d_along_axis(
     const py::array_t<double> points,

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -1,9 +1,16 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Author: Rohan Weeden
+// Copyright 2020, by the California Institute of Technology. ALL RIGHTS
+// RESERVED. United States Government Sponsorship acknowledged.
+//
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
 #include <algorithm>
-#include <iostream>
 #include <future>
 #include <sstream>
 #include <optional>

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -1,0 +1,249 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <algorithm>
+#include <iostream>
+#include <future>
+#include <sstream>
+
+#include "interpolate.h"
+
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(interpolate, m) {
+    m.doc() = "Fast linear interpolator";
+
+    m.def("interpolate", [](
+        std::vector<py::array_t<double, py::array::c_style>> points,
+        py::array_t<double, py::array::c_style> values,
+        py::array_t<double, py::array::c_style> interp_points,
+        size_t max_threads
+    ) {
+        size_t num_dims = points.size();
+
+        if (values.ndim() == 0 || interp_points.ndim() == 0) {
+            throw py::type_error("Only arrays are supported, not scalar values!");
+        }
+
+        for (auto arr : points) {
+            if (arr.ndim() != 1) {
+                throw py::type_error("'points' must be a list of 1D arrays!");
+            }
+        }
+
+        if (num_dims != values.ndim()) {
+            std::stringstream ss;
+            ss << "Dimension mismatch! Grid is " << num_dims
+               << "D but values are " << values.ndim() << "D!";
+            throw py::type_error(ss.str());
+        }
+
+        if (interp_points.ndim() != 2) {
+            throw py::type_error("'interp_points' should have shape (N, ndim).");
+        }
+
+        size_t interp_dims = interp_points.shape()[1];
+        if (num_dims != interp_dims) {
+            std::stringstream ss;
+            ss << "Dimension mismatch! Grid is " << num_dims
+               << "D but interpolation points are " << interp_dims << "D!";
+            throw py::type_error(ss.str());
+        }
+        size_t num_elements = interp_points.shape()[0];
+        double * out = new double[num_elements];
+
+        auto values_info = values.request();
+        auto interp_points_info = interp_points.request();
+
+
+        // Reasonable thread defaults based on profiling. It seems that spawning
+        // threads in powers of 2 yields optimal performance.
+        size_t desired_threads;
+        if (num_elements < 10000) {
+            desired_threads = 1;
+        } else if (num_elements < 4000000) {
+            desired_threads = 2;
+        } else if (num_elements < 160000000){
+            desired_threads = 4;
+        } else {
+            desired_threads = 8;
+        }
+        size_t num_threads = std::min(desired_threads, max_threads);
+        if (num_threads == 0) {
+            num_threads = 1;
+        }
+        size_t stride = num_elements / num_threads;
+
+        double * values_ptr = (double *) values_info.ptr,
+               * interp_points_ptr = (double *) interp_points_info.ptr;
+
+        if (num_dims == 1) {
+            auto xs_info = points[0].request();
+
+            double * xs_ptr = (double *) xs_info.ptr;
+
+            if (num_threads == 1) {
+                // For small arrays just compute in one thread
+                interpolate_1d(
+                    xs_ptr,
+                    points[0].size(),
+                    values_ptr,
+                    interp_points_ptr,
+                    out,
+                    num_elements
+                );
+            } else {
+                std::vector<std::future<void>> tasks;
+
+                for (size_t i = 0; i < num_threads; i++) {
+                    size_t index = i * stride;
+                    tasks.push_back(
+                        std::async(
+                            &interpolate_1d,
+                            xs_ptr,
+                            xs_info.shape[0],
+                            values_ptr,
+                            &interp_points_ptr[index],
+                            &out[index],
+                            index + stride < num_elements ? stride : num_elements - index
+                        )
+                    );
+                }
+                for (auto &future : tasks) {
+                    std::move(future);
+                }
+            }
+        } else if (num_dims == 2) {
+            auto xs_info = points[0].request();
+            auto ys_info = points[1].request();
+
+            double * xs_ptr = (double *) xs_info.ptr,
+                   * ys_ptr = (double *) ys_info.ptr;
+
+            if (num_threads == 1) {
+                interpolate_2d(
+                    xs_ptr,
+                    points[0].size(),
+                    ys_ptr,
+                    points[1].size(),
+                    values_ptr,
+                    interp_points_ptr,
+                    out,
+                    num_elements
+                );
+            } else {
+                std::vector<std::future<void>> tasks;
+
+                for (size_t i = 0; i < num_threads; i++) {
+                    size_t index = i * stride;
+                    tasks.push_back(
+                        std::async(
+                            &interpolate_2d,
+                            xs_ptr,
+                            points[0].size(),
+                            ys_ptr,
+                            points[1].size(),
+                            values_ptr,
+                            &interp_points_ptr[index * num_dims],
+                            &out[index],
+                            index + stride < num_elements ? stride : num_elements - index
+                        )
+                    );
+                }
+                for (auto &future : tasks) {
+                    std::move(future);
+                }
+            }
+        } else if (num_dims == 3) {
+            auto xs_info = points[0].request();
+            auto ys_info = points[1].request();
+            auto zs_info = points[2].request();
+
+            double * xs_ptr = (double *) xs_info.ptr,
+                   * ys_ptr = (double *) ys_info.ptr,
+                   * zs_ptr = (double *) zs_info.ptr;
+
+            if (num_threads == 1) {
+                interpolate_3d(
+                    xs_ptr,
+                    points[0].size(),
+                    ys_ptr,
+                    points[1].size(),
+                    zs_ptr,
+                    points[2].size(),
+                    values_ptr,
+                    interp_points_ptr,
+                    out,
+                    num_elements
+                );
+            } else {
+                std::vector<std::future<void>> tasks;
+
+                for (size_t i = 0; i < num_threads; i++) {
+                    size_t index = i * stride;
+                    tasks.push_back(
+                        std::async(
+                            &interpolate_3d,
+                            xs_ptr,
+                            points[0].size(),
+                            ys_ptr,
+                            points[1].size(),
+                            zs_ptr,
+                            points[2].size(),
+                            values_ptr,
+                            &interp_points_ptr[index * num_dims],
+                            &out[index],
+                            index + stride < num_elements ? stride : num_elements - index
+                        )
+                    );
+                }
+                for (auto &future : tasks) {
+                    std::move(future);
+                }
+            }
+        } else {
+            std::vector<slice<double>> grid;
+            for (auto axis : points) {
+                auto info = axis.request();
+                grid.push_back(slice<double> {info.shape[0], (double *) info.ptr});
+            }
+            slice<double> values_slice = {
+                values_info.size / sizeof(double),
+                values_ptr
+            };
+            slice<double> interpolation_points_slice = {
+                values_info.size / sizeof(double),
+                interp_points_ptr
+            };
+            slice<double> out_slice = {num_elements, out};
+
+            interpolate(
+                grid,
+                values_slice,
+                interpolation_points_slice,
+                out_slice
+            );
+        }
+
+
+        py::capsule free_when_done(out, [](void *f) {
+            double *out = reinterpret_cast<double *>(f);
+            delete[] out;
+        });
+
+        return py::array_t<double>(
+            {num_elements}, // Shape
+            {sizeof(double)}, // Strides
+            out, // the data pointer
+            free_when_done
+        ); // numpy array references this parent
+    },
+    R"pbdoc(
+        Linear interpolator in any dimension. Arguments are similar to
+        scipy.interpolate.RegularGridInterpolator
+    )pbdoc",
+    py::arg("points"), py::arg("values"), py::arg("interp_points"), py::arg("max_threads") = 8
+  );
+}

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -87,7 +87,7 @@ PYBIND11_MODULE(interpolate, m) {
 
                 if (num_threads == 1) {
                     // For small arrays just compute in one thread
-                    interpolate_1d(
+                    interpolate_1d<double>(
                         xs_ptr,
                         points[0].size(),
                         values_ptr,
@@ -103,7 +103,7 @@ PYBIND11_MODULE(interpolate, m) {
                         size_t index = i * stride;
                         tasks.push_back(
                             std::async(
-                                &interpolate_1d,
+                                &interpolate_1d<double, double *>,
                                 xs_ptr,
                                 xs_info.shape[0],
                                 values_ptr,

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -97,7 +97,6 @@ PYBIND11_MODULE(interpolate, m) {
                 double * xs_ptr = (double *) xs_info.ptr;
 
                 if (num_threads == 1) {
-                    // For small arrays just compute in one thread
                     interpolate_1d<double>(
                         xs_ptr,
                         points[0].size(),

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -207,7 +207,10 @@ PYBIND11_MODULE(interpolate, m) {
             std::vector<slice<double>> grid;
             for (auto axis : points) {
                 auto info = axis.request();
-                grid.push_back(slice<double> {info.shape[0], (double *) info.ptr});
+                grid.push_back(slice<double> {
+                    (size_t) info.shape[0],
+                    (double *) info.ptr
+                });
             }
             slice<double> values_slice = {
                 values_info.size / sizeof(double),

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -16,259 +16,259 @@ PYBIND11_MODULE(interpolate, m) {
     m.doc() = "Fast linear interpolator";
 
     m.def("interpolate", [](
-        std::vector<py::array_t<double, py::array::c_style>> points,
-        py::array_t<double, py::array::c_style> values,
-        py::array_t<double, py::array::c_style> interp_points,
-        bool assume_sorted,
-        size_t max_threads
-    ) {
-        size_t num_dims = points.size();
+            std::vector<py::array_t<double, py::array::c_style>> points,
+            py::array_t<double, py::array::c_style> values,
+            py::array_t<double, py::array::c_style> interp_points,
+            bool assume_sorted,
+            size_t max_threads
+        ) {
+            size_t num_dims = points.size();
 
-        if (values.ndim() == 0 || interp_points.ndim() == 0) {
-            throw py::type_error("Only arrays are supported, not scalar values!");
-        }
-
-        for (auto arr : points) {
-            if (arr.ndim() != 1) {
-                throw py::type_error("'points' must be a list of 1D arrays!");
+            if (values.ndim() == 0 || interp_points.ndim() == 0) {
+                throw py::type_error("Only arrays are supported, not scalar values!");
             }
-        }
 
-        if (num_dims != values.ndim()) {
-            std::stringstream ss;
-            ss << "Dimension mismatch! Grid is " << num_dims
-               << "D but values are " << values.ndim() << "D!";
-            throw py::type_error(ss.str());
-        }
+            for (auto arr : points) {
+                if (arr.ndim() != 1) {
+                    throw py::type_error("'points' must be a list of 1D arrays!");
+                }
+            }
 
-        if (interp_points.ndim() != 2) {
-            throw py::type_error("'interp_points' should have shape (N, ndim).");
-        }
+            if (num_dims != values.ndim()) {
+                std::stringstream ss;
+                ss << "Dimension mismatch! Grid is " << num_dims
+                   << "D but values are " << values.ndim() << "D!";
+                throw py::type_error(ss.str());
+            }
 
-        size_t interp_dims = interp_points.shape()[1];
-        if (num_dims != interp_dims) {
-            std::stringstream ss;
-            ss << "Dimension mismatch! Grid is " << num_dims
-               << "D but interpolation points are " << interp_dims << "D!";
-            throw py::type_error(ss.str());
-        }
-        size_t num_elements = interp_points.shape()[0];
-        double * out = new double[num_elements];
+            if (interp_points.ndim() != 2) {
+                throw py::type_error("'interp_points' should have shape (N, ndim).");
+            }
 
-        auto values_info = values.request();
-        auto interp_points_info = interp_points.request();
+            size_t interp_dims = interp_points.shape()[1];
+            if (num_dims != interp_dims) {
+                std::stringstream ss;
+                ss << "Dimension mismatch! Grid is " << num_dims
+                   << "D but interpolation points are " << interp_dims << "D!";
+                throw py::type_error(ss.str());
+            }
+            size_t num_elements = interp_points.shape()[0];
+            double * out = new double[num_elements];
+
+            auto values_info = values.request();
+            auto interp_points_info = interp_points.request();
 
 
-        // Reasonable thread defaults based on profiling. It seems that spawning
-        // threads in powers of 2 yields optimal performance.
-        size_t desired_threads;
-        if (num_elements < 10000) {
-            desired_threads = 1;
-        } else if (num_elements < 4000000) {
-            desired_threads = 2;
-        } else if (num_elements < 160000000){
-            desired_threads = 4;
-        } else {
-            desired_threads = 8;
-        }
-        size_t num_threads = std::min(desired_threads, max_threads);
-        if (num_threads == 0) {
-            num_threads = 1;
-        }
-        size_t stride = num_elements / num_threads;
+            // Reasonable thread defaults based on profiling. It seems that spawning
+            // threads in powers of 2 yields optimal performance.
+            size_t desired_threads;
+            if (num_elements < 10000) {
+                desired_threads = 1;
+            } else if (num_elements < 4000000) {
+                desired_threads = 2;
+            } else if (num_elements < 160000000){
+                desired_threads = 4;
+            } else {
+                desired_threads = 8;
+            }
+            size_t num_threads = std::min(desired_threads, max_threads);
+            if (num_threads == 0) {
+                num_threads = 1;
+            }
+            size_t stride = num_elements / num_threads;
 
-        double * values_ptr = (double *) values_info.ptr,
-               * interp_points_ptr = (double *) interp_points_info.ptr;
+            double * values_ptr = (double *) values_info.ptr,
+                   * interp_points_ptr = (double *) interp_points_info.ptr;
 
-        if (num_dims == 1) {
-            auto xs_info = points[0].request();
+            if (num_dims == 1) {
+                auto xs_info = points[0].request();
 
-            double * xs_ptr = (double *) xs_info.ptr;
+                double * xs_ptr = (double *) xs_info.ptr;
 
-            if (num_threads == 1) {
-                // For small arrays just compute in one thread
-                interpolate_1d(
-                    xs_ptr,
-                    points[0].size(),
-                    values_ptr,
-                    interp_points_ptr,
-                    out,
-                    num_elements,
+                if (num_threads == 1) {
+                    // For small arrays just compute in one thread
+                    interpolate_1d(
+                        xs_ptr,
+                        points[0].size(),
+                        values_ptr,
+                        interp_points_ptr,
+                        out,
+                        num_elements,
+                        assume_sorted
+                    );
+                } else {
+                    std::vector<std::future<void>> tasks;
+
+                    for (size_t i = 0; i < num_threads; i++) {
+                        size_t index = i * stride;
+                        tasks.push_back(
+                            std::async(
+                                &interpolate_1d,
+                                xs_ptr,
+                                xs_info.shape[0],
+                                values_ptr,
+                                &interp_points_ptr[index],
+                                &out[index],
+                                index + stride < num_elements ? stride : num_elements - index,
+                                assume_sorted
+                            )
+                        );
+                    }
+                    for (auto &future : tasks) {
+                        std::move(future);
+                    }
+                }
+            } else if (num_dims == 2) {
+                auto xs_info = points[0].request();
+                auto ys_info = points[1].request();
+
+                double * xs_ptr = (double *) xs_info.ptr,
+                       * ys_ptr = (double *) ys_info.ptr;
+
+                if (num_threads == 1) {
+                    interpolate_2d(
+                        xs_ptr,
+                        points[0].size(),
+                        ys_ptr,
+                        points[1].size(),
+                        values_ptr,
+                        interp_points_ptr,
+                        out,
+                        num_elements,
+                        assume_sorted
+                    );
+                } else {
+                    std::vector<std::future<void>> tasks;
+
+                    for (size_t i = 0; i < num_threads; i++) {
+                        size_t index = i * stride;
+                        tasks.push_back(
+                            std::async(
+                                &interpolate_2d,
+                                xs_ptr,
+                                points[0].size(),
+                                ys_ptr,
+                                points[1].size(),
+                                values_ptr,
+                                &interp_points_ptr[index * num_dims],
+                                &out[index],
+                                index + stride < num_elements ? stride : num_elements - index,
+                                assume_sorted
+                            )
+                        );
+                    }
+                    for (auto &future : tasks) {
+                        std::move(future);
+                    }
+                }
+            } else if (num_dims == 3) {
+                auto xs_info = points[0].request();
+                auto ys_info = points[1].request();
+                auto zs_info = points[2].request();
+
+                double * xs_ptr = (double *) xs_info.ptr,
+                       * ys_ptr = (double *) ys_info.ptr,
+                       * zs_ptr = (double *) zs_info.ptr;
+
+                if (num_threads == 1) {
+                    interpolate_3d(
+                        xs_ptr,
+                        points[0].size(),
+                        ys_ptr,
+                        points[1].size(),
+                        zs_ptr,
+                        points[2].size(),
+                        values_ptr,
+                        interp_points_ptr,
+                        out,
+                        num_elements,
+                        assume_sorted
+                    );
+                } else {
+                    std::vector<std::future<void>> tasks;
+
+                    for (size_t i = 0; i < num_threads; i++) {
+                        size_t index = i * stride;
+                        tasks.push_back(
+                            std::async(
+                                &interpolate_3d,
+                                xs_ptr,
+                                points[0].size(),
+                                ys_ptr,
+                                points[1].size(),
+                                zs_ptr,
+                                points[2].size(),
+                                values_ptr,
+                                &interp_points_ptr[index * num_dims],
+                                &out[index],
+                                index + stride < num_elements ? stride : num_elements - index,
+                                assume_sorted
+                            )
+                        );
+                    }
+                    for (auto &future : tasks) {
+                        std::move(future);
+                    }
+                }
+            } else {
+                std::vector<slice<double>> grid;
+                for (auto axis : points) {
+                    auto info = axis.request();
+                    grid.push_back(slice<double> {
+                        (size_t) info.shape[0],
+                        (double *) info.ptr
+                    });
+                }
+                slice<double> values_slice = {
+                    values_info.size / sizeof(double),
+                    values_ptr
+                };
+                slice<double> interpolation_points_slice = {
+                    values_info.size / sizeof(double),
+                    interp_points_ptr
+                };
+                slice<double> out_slice = {num_elements, out};
+
+                interpolate(
+                    grid,
+                    values_slice,
+                    interpolation_points_slice,
+                    out_slice,
                     assume_sorted
                 );
-            } else {
-                std::vector<std::future<void>> tasks;
-
-                for (size_t i = 0; i < num_threads; i++) {
-                    size_t index = i * stride;
-                    tasks.push_back(
-                        std::async(
-                            &interpolate_1d,
-                            xs_ptr,
-                            xs_info.shape[0],
-                            values_ptr,
-                            &interp_points_ptr[index],
-                            &out[index],
-                            index + stride < num_elements ? stride : num_elements - index,
-                            assume_sorted
-                        )
-                    );
-                }
-                for (auto &future : tasks) {
-                    std::move(future);
-                }
             }
-        } else if (num_dims == 2) {
-            auto xs_info = points[0].request();
-            auto ys_info = points[1].request();
-
-            double * xs_ptr = (double *) xs_info.ptr,
-                   * ys_ptr = (double *) ys_info.ptr;
-
-            if (num_threads == 1) {
-                interpolate_2d(
-                    xs_ptr,
-                    points[0].size(),
-                    ys_ptr,
-                    points[1].size(),
-                    values_ptr,
-                    interp_points_ptr,
-                    out,
-                    num_elements,
-                    assume_sorted
-                );
-            } else {
-                std::vector<std::future<void>> tasks;
-
-                for (size_t i = 0; i < num_threads; i++) {
-                    size_t index = i * stride;
-                    tasks.push_back(
-                        std::async(
-                            &interpolate_2d,
-                            xs_ptr,
-                            points[0].size(),
-                            ys_ptr,
-                            points[1].size(),
-                            values_ptr,
-                            &interp_points_ptr[index * num_dims],
-                            &out[index],
-                            index + stride < num_elements ? stride : num_elements - index,
-                            assume_sorted
-                        )
-                    );
-                }
-                for (auto &future : tasks) {
-                    std::move(future);
-                }
-            }
-        } else if (num_dims == 3) {
-            auto xs_info = points[0].request();
-            auto ys_info = points[1].request();
-            auto zs_info = points[2].request();
-
-            double * xs_ptr = (double *) xs_info.ptr,
-                   * ys_ptr = (double *) ys_info.ptr,
-                   * zs_ptr = (double *) zs_info.ptr;
-
-            if (num_threads == 1) {
-                interpolate_3d(
-                    xs_ptr,
-                    points[0].size(),
-                    ys_ptr,
-                    points[1].size(),
-                    zs_ptr,
-                    points[2].size(),
-                    values_ptr,
-                    interp_points_ptr,
-                    out,
-                    num_elements,
-                    assume_sorted
-                );
-            } else {
-                std::vector<std::future<void>> tasks;
-
-                for (size_t i = 0; i < num_threads; i++) {
-                    size_t index = i * stride;
-                    tasks.push_back(
-                        std::async(
-                            &interpolate_3d,
-                            xs_ptr,
-                            points[0].size(),
-                            ys_ptr,
-                            points[1].size(),
-                            zs_ptr,
-                            points[2].size(),
-                            values_ptr,
-                            &interp_points_ptr[index * num_dims],
-                            &out[index],
-                            index + stride < num_elements ? stride : num_elements - index,
-                            assume_sorted
-                        )
-                    );
-                }
-                for (auto &future : tasks) {
-                    std::move(future);
-                }
-            }
-        } else {
-            std::vector<slice<double>> grid;
-            for (auto axis : points) {
-                auto info = axis.request();
-                grid.push_back(slice<double> {
-                    (size_t) info.shape[0],
-                    (double *) info.ptr
-                });
-            }
-            slice<double> values_slice = {
-                values_info.size / sizeof(double),
-                values_ptr
-            };
-            slice<double> interpolation_points_slice = {
-                values_info.size / sizeof(double),
-                interp_points_ptr
-            };
-            slice<double> out_slice = {num_elements, out};
-
-            interpolate(
-                grid,
-                values_slice,
-                interpolation_points_slice,
-                out_slice,
-                assume_sorted
-            );
-        }
 
 
-        py::capsule free_when_done(out, [](void *f) {
-            double *out = reinterpret_cast<double *>(f);
-            delete[] out;
-        });
+            py::capsule free_when_done(out, [](void *f) {
+                double *out = reinterpret_cast<double *>(f);
+                delete[] out;
+            });
 
-        return py::array_t<double>(
-            {num_elements}, // Shape
-            {sizeof(double)}, // Strides
-            out, // the data pointer
-            free_when_done
-        ); // numpy array references this parent
-    },
-    R"pbdoc(
-        Linear interpolator in any dimension. Arguments are similar to
-        scipy.interpolate.RegularGridInterpolator
+            return py::array_t<double>(
+                {num_elements}, // Shape
+                {sizeof(double)}, // Strides
+                out, // the data pointer
+                free_when_done
+            ); // numpy array references this parent
+        },
+        R"pbdoc(
+            Linear interpolator in any dimension. Arguments are similar to
+            scipy.interpolate.RegularGridInterpolator
 
-        :param points: Tuple of N axis coordinates specifying the grid.
-        :param values: Nd array containing the grid point values.
-        :param interp_points: List of points to interpolate, should have
-            dimension (x, N). If this list is guaranteed to be sorted make sure
-            to use the `assume_sorted` option.
-        :param assume_sorted: Enable optimization when the list of interpolation
-            points is sorted.
-        :param max_threads: Limit the number of threads to a certain amount.
-            Note: The number of threads will always be one of {1, 2, 4, 8}
-    )pbdoc",
-    py::arg("points"),
-    py::arg("values"),
-    py::arg("interp_points"),
-    py::arg("assume_sorted") = false,
-    py::arg("max_threads") = 8
-  );
+            :param points: Tuple of N axis coordinates specifying the grid.
+            :param values: Nd array containing the grid point values.
+            :param interp_points: List of points to interpolate, should have
+                dimension (x, N). If this list is guaranteed to be sorted make sure
+                to use the `assume_sorted` option.
+            :param assume_sorted: Enable optimization when the list of interpolation
+                points is sorted.
+            :param max_threads: Limit the number of threads to a certain amount.
+                Note: The number of threads will always be one of {1, 2, 4, 8}
+        )pbdoc",
+        py::arg("points"),
+        py::arg("values"),
+        py::arg("interp_points"),
+        py::arg("assume_sorted") = false,
+        py::arg("max_threads") = 8
+    );
 }

--- a/tools/bindings/interpolate/src/module.cpp
+++ b/tools/bindings/interpolate/src/module.cpp
@@ -19,6 +19,7 @@ PYBIND11_MODULE(interpolate, m) {
         std::vector<py::array_t<double, py::array::c_style>> points,
         py::array_t<double, py::array::c_style> values,
         py::array_t<double, py::array::c_style> interp_points,
+        bool assume_sorted,
         size_t max_threads
     ) {
         size_t num_dims = points.size();
@@ -92,7 +93,8 @@ PYBIND11_MODULE(interpolate, m) {
                     values_ptr,
                     interp_points_ptr,
                     out,
-                    num_elements
+                    num_elements,
+                    assume_sorted
                 );
             } else {
                 std::vector<std::future<void>> tasks;
@@ -107,7 +109,8 @@ PYBIND11_MODULE(interpolate, m) {
                             values_ptr,
                             &interp_points_ptr[index],
                             &out[index],
-                            index + stride < num_elements ? stride : num_elements - index
+                            index + stride < num_elements ? stride : num_elements - index,
+                            assume_sorted
                         )
                     );
                 }
@@ -131,7 +134,8 @@ PYBIND11_MODULE(interpolate, m) {
                     values_ptr,
                     interp_points_ptr,
                     out,
-                    num_elements
+                    num_elements,
+                    assume_sorted
                 );
             } else {
                 std::vector<std::future<void>> tasks;
@@ -148,7 +152,8 @@ PYBIND11_MODULE(interpolate, m) {
                             values_ptr,
                             &interp_points_ptr[index * num_dims],
                             &out[index],
-                            index + stride < num_elements ? stride : num_elements - index
+                            index + stride < num_elements ? stride : num_elements - index,
+                            assume_sorted
                         )
                     );
                 }
@@ -176,7 +181,8 @@ PYBIND11_MODULE(interpolate, m) {
                     values_ptr,
                     interp_points_ptr,
                     out,
-                    num_elements
+                    num_elements,
+                    assume_sorted
                 );
             } else {
                 std::vector<std::future<void>> tasks;
@@ -195,7 +201,8 @@ PYBIND11_MODULE(interpolate, m) {
                             values_ptr,
                             &interp_points_ptr[index * num_dims],
                             &out[index],
-                            index + stride < num_elements ? stride : num_elements - index
+                            index + stride < num_elements ? stride : num_elements - index,
+                            assume_sorted
                         )
                     );
                 }
@@ -226,7 +233,8 @@ PYBIND11_MODULE(interpolate, m) {
                 grid,
                 values_slice,
                 interpolation_points_slice,
-                out_slice
+                out_slice,
+                assume_sorted
             );
         }
 
@@ -246,7 +254,21 @@ PYBIND11_MODULE(interpolate, m) {
     R"pbdoc(
         Linear interpolator in any dimension. Arguments are similar to
         scipy.interpolate.RegularGridInterpolator
+
+        :param points: Tuple of N axis coordinates specifying the grid.
+        :param values: Nd array containing the grid point values.
+        :param interp_points: List of points to interpolate, should have
+            dimension (x, N). If this list is guaranteed to be sorted make sure
+            to use the `assume_sorted` option.
+        :param assume_sorted: Enable optimization when the list of interpolation
+            points is sorted.
+        :param max_threads: Limit the number of threads to a certain amount.
+            Note: The number of threads will always be one of {1, 2, 4, 8}
     )pbdoc",
-    py::arg("points"), py::arg("values"), py::arg("interp_points"), py::arg("max_threads") = 8
+    py::arg("points"),
+    py::arg("values"),
+    py::arg("interp_points"),
+    py::arg("assume_sorted") = false,
+    py::arg("max_threads") = 8
   );
 }

--- a/tools/bindings/interpolate/src/tests.cpp
+++ b/tools/bindings/interpolate/src/tests.cpp
@@ -1,0 +1,23 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include <catch2/catch.hpp>
+
+#include "interpolate.h"
+
+
+TEST_CASE( "test_bisect_left", "[bisect_left]" ) {
+    std::vector<float> list = {1., 2., 3., 4.};
+    REQUIRE( bisect_left(list.begin(), list.end(), 0.5) == 0 );
+    REQUIRE( bisect_left(list.begin(), list.end(), 1.5) == 1 );
+    REQUIRE( bisect_left(list.begin(), list.end(), 2.1) == 2 );
+    REQUIRE( bisect_left(list.begin(), list.end(), 3.99) == 3 );
+    REQUIRE( bisect_left(list.begin(), list.end(), 4.2) == 4 );
+}
+
+TEST_CASE( "test_find_left", "[find_left]" ) {
+    std::vector<float> list = {1., 2., 3., 4.};
+    REQUIRE( find_left(list.begin(), list.end(), 0.5) == 0 );
+    REQUIRE( find_left(list.begin(), list.end(), 1.5) == 1 );
+    REQUIRE( find_left(list.begin(), list.end(), 2.1) == 2 );
+    REQUIRE( find_left(list.begin(), list.end(), 3.99) == 3 );
+    REQUIRE( find_left(list.begin(), list.end(), 4.2) == 4 );
+}


### PR DESCRIPTION
After several weeks of fighting against outdated documentation, poor unit testing frameworks and of course constant segfaults I finally got the C++ interpolation into a pretty stable and usable state. I was also reminded of all the reasons why C++ sucks and everyone should just switch to Rust already :)!

If you recall from my other PR, I was able to load the HRRR model and compute zenith delays at the weather model nodes in about 285 seconds using the command:
```
raiderDelay.py --date 20180101 --time 23:00:00 -b 40 -110 25 -95 --model HRRR --zref 30000 -v
```
The most expensive call was `interp_along_axis` which was multithreaded in Python so it showed up as the "acquire" method of lock objects:
```
         11804562 function calls (10569262 primitive calls) in 285.811 seconds

   Ordered by: internal time
   List reduced from 4431 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       77  182.879    2.375  182.879    2.375 {method 'acquire' of '_thread.lock' objects}
        3   14.221    4.740   24.008    8.003 dataset.py:326(__getitem__)
```

Since I couldn't find a way to achieve this 1D interpolation along an axis in a single call using existing numpy/scipy interpolators, and I had already implemented 1D interpolation in C++ at that point, I decided to rewrite `interp_along_axis` entirely in C++, to get around the overhead of calling python functions. I also went ahead and implemented the multithreading in C++ as well using std::async so we don't need to worry about managing that on the Python side anymore. After replacing the calls to `interp_along_axis` inside of `_uniform_in_z`, I ended up with the following profile:

```
         11801983 function calls (10566645 primitive calls) in 96.529 seconds

   Ordered by: internal time
   List reduced from 4264 to 15 due to restriction <15>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        3   13.949    4.650   24.460    8.153 dataset.py:326(__getitem__)
      324    9.199    0.028    9.199    0.028 bindings.py:158(wrapper)
      148    7.954    0.054   17.377    0.117 bindings.py:277(codes_get_double_array)
        1    5.671    5.671    5.671    5.671 {built-in method _pickle.dump}
        3    4.670    1.557    4.670    1.557 utilFcns.py:31(cosd)
1219699/1219662    4.170    0.000   28.692    0.000 {built-in method numpy.array}
       82    3.771    0.046    4.289    0.052 function_base.py:4006(trapz)
        1    3.620    3.620    3.620    3.620 weatherModel.py:419(_find_svp)
1219381/571    3.613    0.000   24.255    0.042 {built-in method numpy.core._multiarray_umath.implement_array_function}
        2    3.523    1.761    3.523    1.761 {method 'sort' of 'numpy.ndarray' objects}
   609309    2.898    0.000    2.898    0.000 {built-in method numpy.core._multiarray_umath.interp}
       13    2.696    0.207    2.795    0.215 dataset.py:57(make_new_dset)
        3    2.247    0.749    2.247    0.749 {built-in method RAiDER.interpolate.interpolate_along_axis}
        2    1.879    0.939    9.191    4.596 shape_base.py:267(apply_along_axis)
        8    1.680    0.210    1.680    0.210 {method 'flatten' of 'numpy.ndarray' objects}
```

The interpolation which took 182 seconds before, now takes only 2.2 seconds. As far as I can tell, the results are exactly the same, although I want to write some unit tests to verify this (specifically to verify the "output" of _uniform_in_z).

Now the majority of the time is spent loading the data into memory. This might be something that we can't even speed up very easily, and is probably pretty low hanging fruit anyways.