### PR TITLE
Refactor some arguments to a cli module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,12 @@
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 import glob
 import os
 import re
 
 import numpy as np
-from setuptools import Extension, setup
+from setuptools import Extension, find_packages, setup
 
 # Cythonize should be imported after setuptools. See:
 # https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#configuring-the-c-build
@@ -95,10 +94,9 @@ setup(
     description='This is the RAiDER package',
     package_dir={
         'tools': 'tools',
-        'RAiDER': 'tools/RAiDER',
-        'RAiDER.models': 'tools/RAiDER/models',
+        '': 'tools'
     },
-    packages=['tools', 'RAiDER', 'RAiDER.models'],
+    packages=['tools'] + find_packages('tools'),
     ext_modules=cythonize(
         cython_extensions,
         quiet=True,

--- a/test/cli/test_argument_parsers.py
+++ b/test/cli/test_argument_parsers.py
@@ -100,3 +100,21 @@ def test_delay_aoi_mutually_exclusive(delay_parser):
             '--date', '20200103',
             '--time', '23:00:00',
         ])
+
+
+def test_delay_model(delay_parser):
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+            '--station_file', 'station_file',
+            '--model', 'FOOBAR'
+        ])
+
+    args = delay_parser.parse_args([
+        '--date', '20200103',
+        '--time', '23:00:00',
+        '--station_file', 'station_file',
+        '--model', 'era-5'
+    ])
+    assert args.model == "ERA5"

--- a/test/cli/test_argument_parsers.py
+++ b/test/cli/test_argument_parsers.py
@@ -1,0 +1,102 @@
+from datetime import date, time
+
+import pytest
+
+import RAiDER.runProgram
+
+
+@pytest.fixture
+def delay_parser():
+    return RAiDER.runProgram.create_parser()
+
+
+@pytest.fixture
+def stats_parser():
+    pass
+
+
+@pytest.fixture
+def gnss_parser():
+    pass
+
+
+def test_delay_args(delay_parser):
+    args = delay_parser.parse_args([
+        '--date', '20200103',
+        '--time', '23:00:00',
+        '--latlon', 'latfile.dat', 'lonfile.dat',
+        '--model', 'ERA5',
+        '--zref', '20000',
+        '-v',
+        '--out', 'test/scenario_1/'
+    ])
+
+    assert args.dateList == [date(2020, 1, 3)]
+    assert args.time == time(23, 0, 0)
+    assert args.latlon == ['latfile.dat', 'lonfile.dat']
+    assert args.bbox is None
+    assert args.station_file is None
+    assert args.lineofsight is None
+    assert args.statevectors is None
+    assert args.dem is None
+    assert args.heightlvs is None
+    assert args.model == "ERA5"
+    assert args.files is None
+    assert args.wmLoc is None
+    assert args.zref == 20000.0
+    assert args.outformat is None
+    assert args.out == 'test/scenario_1/'
+    assert args.download_only is False
+    assert args.verbose == 1
+
+
+def test_delay_los_mutually_exclusive(delay_parser):
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+            '--lineofsight', 'losfile',
+            '--statevectors', 'statevectorfile'
+        ])
+
+
+def test_delay_aoi_mutually_exclusive(delay_parser):
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+            '--bbox', '10', '20', '30', '40',
+            '--latlon', 'lat', 'lon',
+            '--station_file', 'station_file'
+        ])
+
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+            '--bbox', '10', '20', '30', '40',
+            '--latlon', 'lat', 'lon',
+        ])
+
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+            '--bbox', '10', '20', '30', '40',
+            '--station_file', 'station_file'
+        ])
+
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+            '--latlon', 'lat', 'lon',
+            '--station_file', 'station_file'
+        ])
+
+    # AOI is required
+    with pytest.raises(SystemExit):
+        delay_parser.parse_args([
+            '--date', '20200103',
+            '--time', '23:00:00',
+        ])

--- a/test/cli/test_validators.py
+++ b/test/cli/test_validators.py
@@ -1,0 +1,159 @@
+from argparse import ArgumentParser, ArgumentTypeError
+from datetime import date, time
+
+import pytest
+
+from RAiDER.cli.validators import (
+    BBoxAction, DateListAction, IntegerMappingType, IntegerType, MappingType,
+    date_type, time_type
+)
+
+
+@pytest.fixture
+def parser():
+    return ArgumentParser()
+
+
+def test_mapping_type_default():
+    mapping = MappingType(foo=42, bar="baz").default(None)
+
+    assert mapping("foo") == 42
+    assert mapping("bar") == "baz"
+    assert mapping("hello") is None
+
+
+def test_mapping_type_no_default():
+    mapping = MappingType(foo=42, bar="baz")
+
+    assert mapping("foo") == 42
+    assert mapping("bar") == "baz"
+    with pytest.raises(KeyError):
+        assert mapping("hello")
+
+
+def test_integer_type():
+    integer = IntegerType(0, 100)
+
+    assert integer("0") == 0
+    assert integer("100") == 100
+    with pytest.raises(ArgumentTypeError):
+        integer("-10")
+    with pytest.raises(ArgumentTypeError):
+        integer("101")
+
+
+def test_integer_mapping_type_default():
+    integer = IntegerMappingType(0, 100, random=42).default(-1)
+
+    assert integer("0") == 0
+    assert integer("100") == 100
+    assert integer("random") == 42
+    assert integer("foo") == -1
+    with pytest.raises(ArgumentTypeError):
+        integer("-1")
+
+
+def test_integer_mapping_type_no_default():
+    integer = IntegerMappingType(0, 100, random=42)
+
+    assert integer("0") == 0
+    assert integer("100") == 100
+    assert integer("random") == 42
+    with pytest.raises(KeyError):
+        integer("foo")
+    with pytest.raises(ArgumentTypeError):
+        integer("-1")
+
+
+def test_date_type():
+    assert date_type("2020-10-1") == date(2020, 10, 1)
+    assert date_type("2020101") == date(2020, 10, 1)
+
+    with pytest.raises(ArgumentTypeError):
+        date_type("foobar")
+
+
+@pytest.mark.parametrize("input,expected", (
+    ("T23:00:01.000000", time(23, 0, 1)),
+    ("T23:00:01.000000", time(23, 0, 1)),
+    ("T230001.000000", time(23, 0, 1)),
+    ("230001.000000", time(23, 0, 1)),
+    ("T23:00:01", time(23, 0, 1)),
+    ("23:00:01", time(23, 0, 1)),
+    ("T230001", time(23, 0, 1)),
+    ("230001", time(23, 0, 1)),
+    ("T23:00", time(23, 0, 0)),
+    ("T2300", time(23, 0, 0)),
+    ("23:00", time(23, 0, 0)),
+    ("2300", time(23, 0, 0))
+))
+@pytest.mark.parametrize("timezone", ("", "z", "+0000"))
+def test_time_type(input, timezone, expected):
+    assert time_type(input + timezone) == expected
+
+
+def test_time_type_error():
+    with pytest.raises(ArgumentTypeError):
+        time_type("foobar")
+
+
+def test_date_list_action(parser):
+    # DateListAction must be used with type=date_type
+    with pytest.raises(ValueError):
+        parser.add_argument(
+            "--datelist",
+            action=DateListAction,
+        )
+
+    parser.add_argument(
+        "--datelist",
+        action=DateListAction,
+        nargs="+",
+        type=date_type,
+    )
+
+    args = parser.parse_args(["--datelist", "2020-1-1"])
+    assert args.datelist == [date(2020, 1, 1)]
+
+    args = parser.parse_args(["--datelist", "2020-1-1", "2020-1-3"])
+    assert args.datelist == [
+        date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)
+    ]
+
+    with pytest.raises(TypeError):
+        parser.parse_args(["--datelist", "2020-1-1", "2020-1-2", "2020-1-3"])
+
+
+def test_bbox_action(parser):
+    # BBoxAction must be used with nargs=4
+    with pytest.raises(ValueError):
+        parser.add_argument(
+            "--bbox",
+            action=BBoxAction,
+        )
+
+    parser.add_argument(
+        "--bbox_float",
+        action=BBoxAction,
+        nargs=4,
+        type=float,
+    )
+
+    parser.add_argument(
+        "--bbox_int",
+        action=BBoxAction,
+        nargs=4,
+        type=int,
+    )
+
+    args = parser.parse_args(["--bbox_float", "10", "20", "30", "40"])
+    assert args.bbox_float == [10., 20., 30., 40.]
+    args = parser.parse_args(["--bbox_int", "10", "20", "30", "40"])
+    assert args.bbox_int == [10, 20, 30, 40]
+
+    with pytest.raises(ValueError):
+        parser.parse_args(["--bbox_int", "10", "20", "10", "20"])
+    with pytest.raises(ValueError):
+        parser.parse_args(["--bbox_int", "100", "20", "30", "40"])
+    with pytest.raises(ValueError):
+        parser.parse_args(["--bbox_int", "10", "190", "30", "40"])

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -7,6 +7,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import os
+from datetime import datetime
 
 import numpy as np
 
@@ -32,7 +33,7 @@ def checkArgs(args, p):
     # flag depending on the type of input
     if args.latlon is not None:
         flag = 'files'
-    elif args.bounding_box is not None:
+    elif args.bbox is not None:
         flag = 'bounding_box'
     elif args.station_file is not None:
         flag = 'station_file'
@@ -40,13 +41,9 @@ def checkArgs(args, p):
         flag = None
 
     if args.latlon is not None:
-        if args.bounding_box is not None or args.station_file is not None:
-            raise RuntimeError("Please specify only one AOI: either files, a bounding box, or a file of stations")
         lat, lon, latproj, lonproj, bounds = readLL(*args.latlon)
-    elif args.bounding_box is not None:
-        if args.station_file is not None:
-            raise RuntimeError("Please specify only one AOI: either files, a bounding box, or a file of stations")
-        lat, lon, latproj, lonproj, bounds = readLL(*args.bounding_box)
+    elif args.bbox is not None:
+        lat, lon, latproj, lonproj, bounds = readLL(*args.bbox)
     elif args.station_file is not None:
         lat, lon, latproj, lonproj, bounds = readLL(args.station_file)
     elif args.files is None:
@@ -58,8 +55,6 @@ def checkArgs(args, p):
         raise RuntimeError('Lats are out of N/S bounds; are your lat/lon coordinates switched?')
 
     # Line of sight calc
-    if args.lineofsight is not None and args.statevectors is not None:
-        raise RuntimeError('Please supply only one of a line-of-sight file or a statevector file')
     if args.lineofsight is not None:
         los = ('los', args.lineofsight)
     elif args.statevectors is not None:
@@ -85,13 +80,13 @@ def checkArgs(args, p):
             weathers = {'type': model_obj(), 'files': args.files,
                         'name': args.model}
         except:
-            raise NotImplemented('{} is not implemented'.format(weather_model_name))
+            raise NotImplementedError('{} is not implemented'.format(weather_model_name))
 
     # zref
-    zref = float(args.zref)
+    zref = args.zref
 
     # handle the datetimes requested
-    datetimeList = [d + args.time for d in args.dateList]
+    datetimeList = [datetime.combine(d, args.time) for d in args.dateList]
 
     # Misc
     download_only = args.download_only

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -14,7 +14,6 @@ import numpy as np
 import RAiDER.utilFcns
 from RAiDER.constants import Zenith
 from RAiDER.llreader import readLL
-from RAiDER.models.allowed import AllowedModels
 
 
 def checkArgs(args, p):
@@ -63,9 +62,7 @@ def checkArgs(args, p):
         los = Zenith
 
     # Weather
-    weather_model_name = args.model.upper().replace('-', '')
-    if weather_model_name not in AllowedModels():
-        raise NotImplementedError('Model {} has not been implemented'.format(args.model))
+    weather_model_name = args.model
     if weather_model_name == 'WRF' and args.files is None:
         raise RuntimeError('Argument --files is required with --model WRF')
     _, model_obj = RAiDER.utilFcns.modelName2Module(args.model)

--- a/tools/RAiDER/cli/parser.py
+++ b/tools/RAiDER/cli/parser.py
@@ -1,0 +1,41 @@
+import os
+
+from RAiDER.cli.validators import BBoxAction, IntegerMappingType
+
+
+def add_cpus(parser):
+    parser.add_argument(
+        '--cpus',
+        help='The number of cpus to be used for multiprocessing or "all" for '
+             'all available cpus.',
+        type=IntegerMappingType(0, all=os.cpu_count()),
+        default=8,
+    )
+
+
+def add_verbose(parser):
+    parser.add_argument(
+        '--verbose', '-v',
+        help='Run in verbose mode',
+        action='count',
+        default=0
+    )
+
+
+def add_out(parser):
+    parser.add_argument(
+        '--out',
+        help='Output directory',
+        default='.'
+    )
+
+
+def add_bbox(parser):
+    parser.add_argument(
+        '--bbox', '-b',
+        help="Bounding box",
+        nargs=4,
+        type=float,
+        action=BBoxAction,
+        metavar=('N', 'W', 'S', 'E')
+    )

--- a/tools/RAiDER/cli/validators.py
+++ b/tools/RAiDER/cli/validators.py
@@ -1,0 +1,247 @@
+import itertools
+from argparse import Action, ArgumentTypeError
+from datetime import date, time, timedelta
+from time import strptime
+
+
+class MappingType(object):
+    """
+    A type that maps arguments to constants.
+
+    # Example
+    ```
+    mapping = MappingType(foo=42, bar="baz").default(None)
+    assert mapping("foo") == 42
+    assert mapping("bar") == "baz"
+    assert mapping("hello") is None
+    ```
+    """
+    UNSET = object()
+
+    def __init__(self, **kwargs):
+        self.mapping = kwargs
+        self._default = self.UNSET
+
+    def default(self, default):
+        """Set a default value if no mapping is found"""
+        self._default = default
+        return self
+
+    def __call__(self, arg):
+        if arg in self.mapping:
+            return self.mapping[arg]
+
+        if self._default is self.UNSET:
+            raise KeyError(
+                "Invalid choice '{}', must be one of {}".format(
+                    arg, list(self.mapping.keys())
+                )
+            )
+
+        return self._default
+
+
+class IntegerType(object):
+    """
+    A type that converts arguments to integers.
+
+    # Example
+    ```
+    integer = IntegerType(0, 100)
+    assert integer("0") == 0
+    assert integer("100") == 100
+    integer("-10")  # Raises exception
+    ```
+    """
+
+    def __init__(self, lo=None, hi=None):
+        self.lo = lo
+        self.hi = hi
+
+    def __call__(self, arg):
+        integer = int(arg)
+
+        if self.lo is not None and integer < self.lo:
+            raise ArgumentTypeError("Must be greater than {}".format(self.lo))
+        if self.hi is not None and integer > self.hi:
+            raise ArgumentTypeError("Must be less than {}".format(self.hi))
+
+        return integer
+
+
+class IntegerMappingType(MappingType, IntegerType):
+    """
+    An integer type that converts non-integer types through a mapping.
+
+    # Example
+    ```
+    integer = IntegerMappingType(0, 100, random=42)
+    assert integer("0") == 0
+    assert integer("100") == 100
+    assert integer("random") == 42
+    ```
+    """
+
+    def __init__(self, lo=None, hi=None, mapping={}, **kwargs):
+        IntegerType.__init__(self, lo, hi)
+        kwargs.update(mapping)
+        MappingType.__init__(self, **kwargs)
+
+    def __call__(self, arg):
+        try:
+            return IntegerType.__call__(self, arg)
+        except ValueError:
+            return MappingType.__call__(self, arg)
+
+
+class DateListAction(Action):
+    """An Action that parses and stores a list of dates"""
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None
+    ):
+        if type is not date_type:
+            raise ValueError("type must be `date_type`!")
+
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if len(values) > 2 or not values:
+            raise TypeError("Only 1 or 2 dates may be supplied")
+
+        if len(values) == 2:
+            start, end = values
+            values = [start + timedelta(days=k)
+                      for k in range((end - start).days+1)]
+
+        setattr(namespace, self.dest, values)
+
+
+class BBoxAction(Action):
+    """An Action that parses and stores a valid bounding box"""
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None
+    ):
+        if nargs != 4:
+            raise ValueError("nargs must be 4!")
+
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        N, W, S, E = values
+
+        lat = [N, S]
+        lon = [W, E]
+
+        if N == S or E == W:
+            raise ValueError('Bounding box must have a size!')
+
+        if min(lat) < -90 or max(lat) > 90:
+            raise ValueError('Lats are out of N/S bounds')
+
+        if min(lon) < -180 or max(lon) > 180:
+            raise ValueError('Lons are out of W/E bounds')
+
+        setattr(namespace, self.dest, values)
+
+
+def date_type(arg):
+    """
+    Parse a date from a string in pseudo-ISO 8601 format.
+    """
+    year_formats = (
+        '%Y-%m-%d',
+        '%Y%m%d'
+    )
+
+    for yf in year_formats:
+        try:
+            return date(*strptime(arg, yf)[0:3])
+        except ValueError:
+            pass
+
+    raise ArgumentTypeError(
+        'Unable to coerce {} to a date. Try %Y-%m-%d'.format(arg)
+    )
+
+
+def time_type(arg):
+    '''
+    Parse an input time (required to be ISO 8601)
+    '''
+    time_formats = (
+        '',
+        'T%H:%M:%S.%f',
+        'T%H%M%S.%f',
+        '%H%M%S.%f',
+        'T%H:%M:%S',
+        '%H:%M:%S',
+        'T%H%M%S',
+        '%H%M%S',
+        'T%H:%M',
+        'T%H%M',
+        '%H:%M',
+        'T%H',
+    )
+    timezone_formats = (
+        '',
+        'Z',
+        '%z',
+    )
+    all_formats = map(
+        ''.join,
+        itertools.product(time_formats, timezone_formats)
+    )
+
+    for tf in all_formats:
+        try:
+            return time(*strptime(arg, tf)[3:6])
+        except ValueError:
+            pass
+
+    raise ArgumentTypeError(
+        'Unable to coerce {} to a time. Try T%H:%M:%S'.format(arg)
+    )

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -116,7 +116,7 @@ def tropo_delay(los, lats, lons, ll_bounds, heights, flag, weather_model, wmLoc,
     log.debug('DEM/height type is "%s"', heights[0])
 
     # Flags
-    useWeatherNodes = [True if flag == 'bounding_box' else False][0]
+    useWeatherNodes = flag == 'bounding_box'
     delayType = ["Zenith" if los is Zenith else "LOS"]
 
     # location of the weather model files

--- a/tools/RAiDER/models/allowed.py
+++ b/tools/RAiDER/models/allowed.py
@@ -1,26 +1,11 @@
 
-def AllowedModels():
-    '''
-    return a list of the implemented model types
-    '''
-    allowedModels = [
-        'ERA5',
-        'ERA5T',
-        'ERAI',
-        'MERRA2',
-        'WRF',
-        'HRRR',
-        'GMAO',
-        'HDF5'
-    ]
-
-    return allowedModels
-
-
-def checkIfImplemented(modelName):
-    '''
-    Check whether the input model name has been implemented
-    '''
-    allowedWMTypes = AllowedModels()
-    if modelName not in allowedWMTypes:
-        raise RuntimeError('Weather model {} not allowed/implemented'.format(modelName))
+ALLOWED_MODELS = [
+    'ERA5',
+    'ERA5T',
+    'ERAI',
+    'MERRA2',
+    'WRF',
+    'HRRR',
+    'GMAO',
+    'HDF5'
+]

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -14,7 +14,6 @@ from datetime import datetime
 
 import numpy as np
 
-from RAiDER.models.allowed import checkIfImplemented
 from RAiDER.utilFcns import getTimeFromFile
 
 log = logging.getLogger(__name__)
@@ -55,8 +54,7 @@ def prepareWeatherModel(weatherDict, wmFileLoc, out, lats=None, lons=None,
 
     # Make weather
     weather_model, weather_files, weather_model_name = \
-        weatherDict['type'], weatherDict['files'], weatherDict['name']
-    checkIfImplemented(weather_model_name.upper().replace('-', ''))
+    weatherDict['type'], weatherDict['files'], weatherDict['name']
 
     # check whether weather model files are supplied
     if weather_files is None:

--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+from textwrap import dedent
 
 from RAiDER.checkArgs import checkArgs
 from RAiDER.cli.parser import add_bbox, add_out, add_verbose
@@ -16,23 +17,25 @@ def create_parser():
     """Parse command line arguments using argparse."""
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="""
-Calculate tropospheric delay from a weather model.
-Usage examples:
-raiderDelay.py --date 20200103 --time 23:00:00 -b 40 -79 39 -78 --model ERA5 --zref 15000 -v
-raiderDelay.py --date 20200103 --time 23:00:00 -b 40 -79 39 -78 --model ERA5 --zref 15000 --heightlvs 0 100 200 -v
-raiderDelay.py --date 20200103 --time 23:00:00 --latlon test/scenario_1/geom/lat.dat test/scenario_1/geom/lon.dat --model ERA5 --zref 20000 -v --out test/scenario_1/
-""")
+        description=dedent("""\
+            Calculate tropospheric delay from a weather model.
+            Usage examples:
+            raiderDelay.py --date 20200103 --time 23:00:00 -b 40 -79 39 -78 --model ERA5 --zref 15000 -v
+            raiderDelay.py --date 20200103 --time 23:00:00 -b 40 -79 39 -78 --model ERA5 --zref 15000 --heightlvs 0 100 200 -v
+            raiderDelay.py --date 20200103 --time 23:00:00 --latlon test/scenario_1/geom/lat.dat test/scenario_1/geom/lon.dat --model ERA5 --zref 20000 -v --out test/scenario_1/
+            """)
+    )
 
     datetime = p.add_argument_group('Datetime')
     datetime.add_argument(
         '--date', dest='dateList',
-        help="""Date to calculate delay.
-Can be a single date or a list of two dates (earlier, later).
-Example accepted formats:
-   YYYYMMDD or
-   YYYYMMDD YYYYMMDD
-""",
+        help=dedent("""\
+            Date to calculate delay.
+            Can be a single date or a list of two dates (earlier, later).
+            Example accepted formats:
+               YYYYMMDD or
+               YYYYMMDD YYYYMMDD
+            """),
         nargs="+",
         action=DateListAction,
         type=date_type,
@@ -41,18 +44,19 @@ Example accepted formats:
 
     datetime.add_argument(
         '--time', dest='time',
-        help='''Calculate delay at this time.
-Example formats:
-   THHMMSS,
-   HHMMSS, or
-   HH:MM:SS''',
+        help=dedent('''\
+        Calculate delay at this time.
+        Example formats:
+           THHMMSS,
+           HHMMSS, or
+           HH:MM:SS'''),
         type=time_type, required=True)
 
     # Area
     area = p.add_argument_group('Area of Interest (Supply one)').add_mutually_exclusive_group(required=True)
     area.add_argument(
         '--latlon', '-ll', nargs=2, default=None,
-        help=('GDAL-readable latitude and longitude raster files (2 single-band files)'),
+        help='GDAL-readable latitude and longitude raster files (2 single-band files)',
         metavar=('LAT', 'LONG'))
     add_bbox(area)
     area.add_argument(
@@ -70,8 +74,8 @@ Example formats:
              metavar='LOS', default=None)
     los.add_argument(
         '--statevectors', '-s', default=None, metavar='SV',
-        help=('An ESA orbit file or text file containing state vectors specifying ' \
-              'the orbit of the sensor.'))
+        help='An ESA orbit file or text file containing state vectors specifying '
+             'the orbit of the sensor.')
 
     # heights
     heights = p.add_argument_group('Height data. Default is ground surface for specified lat/lons, height levels otherwise')
@@ -103,7 +107,7 @@ Example formats:
     misc = p.add_argument_group("Run parameters")
     misc.add_argument(
         '--zref', '-z',
-        help=('Height limit when integrating (meters) (default: {} km)'.format(_ZREF)),
+        help='Height limit when integrating (meters) (default: {} km)'.format(_ZREF),
         type=float,
         default=_ZREF)
     misc.add_argument(

--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -7,6 +7,7 @@ from RAiDER.cli.validators import DateListAction, date_type, time_type
 from RAiDER.constants import _ZREF
 from RAiDER.delay import tropo_delay
 from RAiDER.logger import logger
+from RAiDER.models.allowed import ALLOWED_MODELS
 
 log = logging.getLogger(__name__)
 
@@ -86,8 +87,10 @@ Example formats:
     weather = p.add_argument_group("Weather model. See documentation for details")
     weather.add_argument(
         '--model',
-        help="""Weather model option to use: ERA5/HRRR/MERRA2/NARR/WRF/HDF5. """,
-        default='ERA-5T')
+        help="Weather model option to use.",
+        type=lambda s: s.upper().replace("-", ""),
+        choices=ALLOWED_MODELS,
+        default='ERA5T')
     weather.add_argument(
         '--files',
         help="""OUT/PLEV or HDF5 file(s) """,

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -15,14 +15,14 @@ import os
 import warnings
 
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib import pyplot as plt
 from pandas.plotting import register_matplotlib_converters
 from shapely.geometry import Point, Polygon
 from shapely.strtree import STRtree
 
-from RAiDER.downloadGNSSDelays import parse_cpus
+from RAiDER.cli.parser import add_cpus
 from RAiDER.logger import logger
 
 log = logging.getLogger(__name__)
@@ -59,8 +59,7 @@ raiderStats.py -f <filename> -grid_delay_mean -ti '2016-01-01 2018-01-01' --seas
                           help='Specified input unit. Input will be converted into m if not already in m.')
     userinps.add_argument('-w', '--workdir', dest='workdir', default='./',
                           help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
-    userinps.add_argument('--cpus', dest='numCPUs', type=parse_cpus, default=8,
-                          help='Specify number of cpus to be used for multiprocessing. May specify "all" at your own discretion.')
+    add_cpus(userinps)
     userinps.add_argument('-verbose', '--verbose', action='store_true', dest='verbose',
                           help="Run in verbose (debug) mode. Default False")
 
@@ -698,11 +697,11 @@ class RaiderStats(object):
         '''
             Visualize a suite of statistics w.r.t. stations. Pass either a list of points or a gridded array as the first argument. Alternatively, you may superimpose your gridded array with a supplementary list of points by passing the latter through the stationsongrids argument.
         '''
-        import cartopy.crs as ccrs
-        import cartopy.feature as cfeature
-        import cartopy.io.img_tiles as cimgt
-        import matplotlib.ticker as mticker
+        from cartopy import crs as ccrs
+        from cartopy import feature as cfeature
+        from cartopy.io import img_tiles as cimgt
         from cartopy.mpl.ticker import LatitudeFormatter, LongitudeFormatter
+        from matplotlib import ticker as mticker
         from mpl_toolkits.axes_grid1 import make_axes_locatable
 
         # If specified workdir doesn't exist, create it
@@ -974,7 +973,7 @@ if __name__ == "__main__":
         inps.col_name,
         inps.unit,
         inps.workdir,
-        inps.numCPUs,
+        inps.cpus,
         inps.verbose,
         inps.bbox,
         inps.spacing,

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -1,16 +1,15 @@
 """Geodesy-related utility functions."""
-import h5py
 import importlib
-import itertools
 import logging
+import multiprocessing as mp
 import os
 import re
-import pyproj
-
 from datetime import datetime
-import multiprocessing as mp
+
+import h5py
 import numpy as np
 import pandas as pd
+import pyproj
 from osgeo import gdal, osr
 
 from RAiDER import Geo2rdr
@@ -335,69 +334,6 @@ def read_hgt_file(filename):
     data = pd.read_csv(filename)
     hgts = data['Hgt_m'].values
     return hgts
-
-
-def parse_date(s):
-    """
-    Parse a date from a string in pseudo-ISO 8601 format.
-    """
-    year_formats = (
-        '%Y-%m-%d',
-        '%Y%m%d'
-    )
-    date = None
-    for yf in year_formats:
-        try:
-            date = datetime.strptime(s, yf)
-        except ValueError:
-            continue
-
-    if date is None:
-        raise ValueError(
-            'Unable to coerce {} to a date. Try %Y-%m-%d'.format(s))
-
-    return date
-
-
-def parse_time(t):
-    '''
-    Parse an input time (required to be ISO 8601)
-    '''
-    time_formats = (
-        '',
-        'T%H:%M:%S.%f',
-        'T%H%M%S.%f',
-        '%H%M%S.%f',
-        'T%H:%M:%S',
-        '%H:%M:%S',
-        'T%H%M%S',
-        '%H%M%S',
-        'T%H:%M',
-        'T%H%M',
-        '%H:%M',
-        'T%H',
-    )
-    timezone_formats = (
-        '',
-        'Z',
-        '%z',
-    )
-    all_formats = map(
-        ''.join,
-        itertools.product(time_formats, timezone_formats))
-
-    time = None
-    for tf in all_formats:
-        try:
-            time = datetime.strptime(t, tf) - datetime(1900, 1, 1)
-        except ValueError:
-            continue
-
-    if time is None:
-        raise ValueError(
-            'Unable to coerce {} to a time. Try T%H:%M:%S'.format(t))
-
-    return time
 
 
 def writeDelays(flag, wetDelay, hydroDelay, lats, lons,

--- a/tools/bin/raiderDownloadGNSS.py
+++ b/tools/bin/raiderDownloadGNSS.py
@@ -18,6 +18,6 @@ if __name__ == "__main__":
         inps.years,
         inps.returnTime,
         inps.download,
-        inps.numCPUs,
+        inps.cpus,
         inps.verbose
     )

--- a/tools/bin/raiderStats.py
+++ b/tools/bin/raiderStats.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
         inps.col_name,
         inps.unit,
         inps.workdir,
-        inps.numCPUs,
+        inps.cpus,
         inps.verbose,
         inps.bbox,
         inps.spacing,


### PR DESCRIPTION
There really is a ton more that could be done, but it's going to take a lot of work so I'm not sure it's worth it at this point. Everything in `checkArgs` needs to be moved into the argument parser. The `argparse` module supports doing everything that `checkArgs` currently does, but in a clean and reusable way.

I hope that this will at least provide some examples for how to add argument parsing correctly in the future, and how to add unit tests for the argument parser.

Related: #78