### PR TITLE
Add coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,8 @@ jobs:
       - run:
           name: Setup Miniconda
           command: |
-            apt update
-            apt install -y wget
-            apt-get update --yes && apt-get upgrade --yes
-            apt-get install g++ --yes
+            apt update --yes && apt-get upgrade --yes
+            apt install -y --no-install-recommends wget ca-certificates g++
             cd $HOME
             wget "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh" -O miniconda.sh
             printf '%s' "8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121  miniconda.sh" | sha256sum -c
@@ -25,8 +23,9 @@ jobs:
             conda update -y conda
             conda create -n myenv python=$PYTHON_VERSION -c conda-forge
             source activate myenv
-            conda env create -f environment.yml
+            conda env create -f environment-dev.yml
             conda activate RAiDER
+            pip install coveralls
             echo $'url: https://cds.climate.copernicus.eu/api/v2\nkey: 43214:de6dbdf6-ccf2-4a95-b26e-e1ceb24969e1' > $HOME/.cdsapirc
             python --version
             python -c "import numpy; print(numpy.__version__)"
@@ -41,7 +40,7 @@ jobs:
             python setup.py install
             python -c "import RAiDER; from RAiDER.delay import computeDelay, interpolateDelay; print(computeDelay)"
             python -c "import RAiDER; from RAiDER.interpolator import interp_along_axis; print(interp_along_axis)"
-            raiderDelay.py -h 
+            raiderDelay.py -h
             raiderStats.py -h
             raiderDownloadGNSS.py -h
       - run:
@@ -50,4 +49,14 @@ jobs:
             export PATH="$HOME/miniconda/bin:$PATH"
             source activate myenv
             conda activate RAiDER
-            py.test test/
+            COV_OPTIONS=`python -c "import importlib;print(*(' --cov='+p for p in importlib.util.find_spec('RAiDER').submodule_search_locations))"`
+            py.test test/ $COV_OPTIONS --cov-report=
+      - run:
+          name: Report coverage
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate myenv
+            conda activate RAiDER
+            python .circleci/fix_coverage_paths.py .coverage $(pwd)/tools/RAiDER/
+            coverage report -mi
+            coveralls

--- a/.circleci/fix_coverage_paths.py
+++ b/.circleci/fix_coverage_paths.py
@@ -1,0 +1,23 @@
+import re
+import sqlite3
+import sys
+
+
+def main(file, replacement):
+    conn = sqlite3.connect(file)
+    cur = conn.cursor()
+    cur.execute("select path, id from file")
+
+    patched = [
+        (re.sub(r"/.*/RAiDER/", replacement, r[0]), r[1])
+        for r in cur
+    ]
+
+    cur.executemany("update file set path=? where id=?", patched)
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,5 +1,5 @@
-# create environment : conda env create -f environment.yml
-# update dependencies: conda env update -f environment.yml
+# create environment : conda env create -f environment-dev.yml
+# update dependencies: conda env update -f environment-dev.yml
 # remove environment : conda env remove -n RAiDER
 # enter  environment : conda activate RAiDER
 # exit   environment : conda deactivate
@@ -9,6 +9,7 @@ channels:
  - anaconda
  - defaults
 dependencies:
+# Regular dependencies. Keep these in sync with environment.yml
  - python>=3
  - cartopy
  - cdsapi
@@ -30,3 +31,6 @@ dependencies:
  - xarray
  - shapely
  - pydap>3.2.2|<3.2.2
+ # Dev dependencies. Only needed for contributing
+ - pytest
+ - pytest-cov


### PR DESCRIPTION
Add unit test coverage reporting to the CI build. Because there are some compiled modules, the coverage is recorded on the installed package resulting in coverage paths looking like `/path/to/conda/environment/RAiDER/__init__.py`. To get a proper coverage report we need to strip off the conda environment part, and replace it with the path to the source code from the repo.

All that's left is to set up coveralls and set the `COVERALLS_REPO_TOKEN` environment variable in the circleci build.

Closes #80