### PR TITLE
Issue/#89 Take bounding box as SNWE

### DIFF
--- a/test/cli/test_validators.py
+++ b/test/cli/test_validators.py
@@ -120,7 +120,7 @@ def test_date_list_action(parser):
         date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)
     ]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(SystemExit):
         parser.parse_args(["--datelist", "2020-1-1", "2020-1-2", "2020-1-3"])
 
 
@@ -151,9 +151,9 @@ def test_bbox_action(parser):
     args = parser.parse_args(["--bbox_int", "10", "20", "30", "40"])
     assert args.bbox_int == [10, 20, 30, 40]
 
-    with pytest.raises(ValueError):
-        parser.parse_args(["--bbox_int", "10", "20", "10", "20"])
-    with pytest.raises(ValueError):
-        parser.parse_args(["--bbox_int", "100", "20", "30", "40"])
-    with pytest.raises(ValueError):
-        parser.parse_args(["--bbox_int", "10", "190", "30", "40"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--bbox_int", "10", "10", "20", "20"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--bbox_int", "30", "100", "20", "40"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--bbox_int", "10", "30", "40", "190"])

--- a/tools/RAiDER/cli/parser.py
+++ b/tools/RAiDER/cli/parser.py
@@ -37,5 +37,5 @@ def add_bbox(parser):
         nargs=4,
         type=float,
         action=BBoxAction,
-        metavar=('N', 'W', 'S', 'E')
+        metavar=('S', 'N', 'W', 'E')
     )

--- a/tools/RAiDER/downloadGNSSDelays.py
+++ b/tools/RAiDER/downloadGNSSDelays.py
@@ -35,7 +35,7 @@ Check for and download tropospheric zenith delays for a set of GNSS stations fro
 Example call to virtually access and append zenith delay information to a CSV table in specified output
 directory, across specified range of years and all available times of day, and confined to specified
 geographic bounding box :
-downloadGNSSdelay.py --out products -y '2010,2014' -b '40 -79 39 -78'
+downloadGNSSdelay.py --out products -y '2010,2014' -b '39 40 -79 -78'
 
 Example call to virtually access and append zenith delay information to a CSV table in specified output
 directory, across specified range of years and specified time of day, and distributed globally :
@@ -51,7 +51,7 @@ necessary for most applications.
 Example call to physically download and append zenith delay information to a CSV table in specified output
 directory, across specified range of years and specified time of day, and confined to specified
 geographic bounding box :
-downloadGNSSdelay.py --download --out products -y '2010,2014' --returntime '00:00:00' -b '40 -79 39 -78'
+downloadGNSSdelay.py --download --out products -y '2010,2014' --returntime '00:00:00' -b '39 40 -79 -78'
 """)
 
     # Stations to check/download

--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -20,8 +20,8 @@ def create_parser():
         description=dedent("""\
             Calculate tropospheric delay from a weather model.
             Usage examples:
-            raiderDelay.py --date 20200103 --time 23:00:00 -b 40 -79 39 -78 --model ERA5 --zref 15000 -v
-            raiderDelay.py --date 20200103 --time 23:00:00 -b 40 -79 39 -78 --model ERA5 --zref 15000 --heightlvs 0 100 200 -v
+            raiderDelay.py --date 20200103 --time 23:00:00 -b 39 40 -79 -78 --model ERA5 --zref 15000 -v
+            raiderDelay.py --date 20200103 --time 23:00:00 -b 39 40 -79 -78 --model ERA5 --zref 15000 --heightlvs 0 100 200 -v
             raiderDelay.py --date 20200103 --time 23:00:00 --latlon test/scenario_1/geom/lat.dat test/scenario_1/geom/lon.dat --model ERA5 --zref 20000 -v --out test/scenario_1/
             """)
     )


### PR DESCRIPTION
Require that bounding box arguments are passed strictly in SNWE order to be consistent with printed output and bounding box format of stats class.

Also fixed the custom actions to raises appropriate errors which will trigger the argparse help message instead of printing a stacktrace.

Fixes #89 