### PR TITLE
Speed up interpolation during delay calculation

### DIFF
--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -3,6 +3,7 @@ import pytest
 from scipy.interpolate import RegularGridInterpolator
 
 from RAiDER.interpolate import interpolate, interpolate_along_axis
+from RAiDER.interpolator import RegularGridInterpolator as Interpolator
 from RAiDER.interpolator import fillna3D, interp_along_axis, interpVector
 
 
@@ -850,3 +851,31 @@ def test_4d_cube_small():
     ans_scipy = rgi(points)
 
     assert np.allclose(ans, ans_scipy, 1e-15)
+
+
+def test_interpolate_wrapper():
+    def f(x, y, z):
+        return x ** 2 + 3 * y - z
+
+    xs = np.linspace(0, 1000, 100)
+    ys = np.linspace(0, 1000, 100)
+    zs = np.linspace(0, 1000, 100)
+
+    values = f(*np.meshgrid(xs, ys, zs, indexing="ij", sparse=True))
+    points_x = np.linspace(10, 990, 5)
+    points_y = np.linspace(10, 890, 5)
+    points_z = np.linspace(10, 890, 5)
+    points = np.stack((
+        points_x,
+        points_y,
+        points_z
+    ), axis=-1)
+
+    interp = Interpolator((xs, ys, zs), values)
+    ans = interp(points)
+    ans2 = interp((points_x, points_y, points_z))
+    rgi = RegularGridInterpolator((xs, ys, zs), values)
+    ans_scipy = rgi(points)
+
+    assert np.allclose(ans, ans_scipy, 1e-15)
+    assert np.allclose(ans2, ans_scipy, 1e-15)

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -6,13 +6,57 @@
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 import numpy as np
 from scipy.interpolate import interp1d
+
+from RAiDER.interpolate import interpolate
+
+
+class RegularGridInterpolator(object):
+    """
+    Provides a wrapper around RAiDER.interpolate.interpolate with a similar
+    interface to scipy.interpolate.RegularGridInterpolator.
+    """
+
+    def __init__(
+        self,
+        grid,
+        values,
+        fill_value=None,
+        assume_sorted=False,
+        max_threads=8
+    ):
+        self.grid = grid
+        self.values = values
+        self.fill_value = fill_value
+        self.assume_sorted = assume_sorted
+        self.max_threads = max_threads
+
+    def __call__(self, points):
+        if isinstance(points, tuple):
+            shape = points[0].shape
+            for arr in points:
+                assert arr.shape == shape, "All dimensions must contain the same number of points!"
+            interp_points = np.stack(points, axis=-1)
+        else:
+            interp_points = points
+
+        return interpolate(
+            self.grid,
+            self.values,
+            interp_points,
+            fill_value=self.fill_value,
+            assume_sorted=self.assume_sorted,
+            max_threads=self.max_threads
+        )
 
 
 def interp_along_axis(oldCoord, newCoord, data, axis=2, pad=False):
     '''
+    DEPRECATED: Use RAiDER.interpolate.interpolate_along_axis instead (it is
+    much faster). This function now primarily exists to verify the behavior of
+    the new one.
+
     Interpolate an array of 3-D data along one axis. This function
     assumes that the x-coordinate increases monotonically.
     '''


### PR DESCRIPTION
I profiled the zenith delay calculation at query points using the following command:
```
raiderDelay.py --date 20200103 --time 23:00:00 --latlon lat.dat lon.dat --model HRRR --zref 20000 -v --out test_output/
```
Where my lat/lon file consisted of 100x100 points spaced equally over the bounding box (SNWE) `37 40 -120 -116`.

I found that the time was pretty evenly split between interpolation and reprojection:
```
         963425 function calls (913599 primitive calls) in 20.541 seconds

   Ordered by: internal time
   List reduced from 2679 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    8.496    4.248    8.496    4.248 {method '_transform' of 'pyproj._transformer._Transformer' objects}
        2    5.090    2.545    6.403    3.202 interpolate.py:2499(_evaluate_linear)
        2    1.971    0.985    2.926    1.463 interpolate.py:2519(_find_indices)
60259/20139    1.278    0.000    2.736    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
        6    0.954    0.159    0.954    0.159 {method 'searchsorted' of 'numpy.ndarray' objects}
        2    0.432    0.216    0.432    0.216 {built-in method scipy.interpolate.interpnd._ndim_coords_from_arrays}
       40    0.164    0.004    0.164    0.004 {method 'astype' of 'numpy.ndarray' objects}
        2    0.148    0.074    0.148    0.074 interpolate.py:2505(<listcomp>)
        1    0.145    0.145    0.145    0.145 {RAiDER.makePoints.makePoints1D}
        2    0.140    0.070    0.140    0.070 {pyproj._transformer.from_crs}
```
Where the cumulative time spent in interpolation made up about 50% of the total computation time:
```
  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2    0.049    0.025    9.811    4.906 interpolate.py:2450(__call__)
```

After replacing this with the C++ interpolator, the interpolation which took 10 seconds before, took less than 1 second:
```
         963731 function calls (913898 primitive calls) in 11.178 seconds

   Random listing order was used
   List reduced from 2655 to 13 due to restriction <'interpolate'>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001   10.652   10.652 delay.py:28(interpolateDelay)
        2    0.052    0.026    0.769    0.385 delayFcns.py:303(interpolate2)
        2    0.246    0.123    0.246    0.123 {built-in method RAiDER.interpolate.interpolate}
```

I also verified that the results are the same:
```python
>>> old = gdal_open("test_output/old/HRRR_hydro_23_00_00_std.envi")
>>> new = gdal_open("test_output/HRRR_hydro_23_00_00_std.envi")
>>> np.nanmean((old-new)**2)
0.0
```