### PR TITLE
Address plotting depreciation warnings + gray background for station …

### DIFF
--- a/tools/RAiDER/downloadGNSSDelays.py
+++ b/tools/RAiDER/downloadGNSSDelays.py
@@ -61,7 +61,7 @@ downloadGNSSdelay.py --download --out products -y '2010,2014' --returntime '00:0
         '--station_file', '-f', default=None, dest='station_file',
         help=('Text file containing a list of 4-char station IDs separated by newlines'))
     area.add_argument(
-        '--BBOX', '-b', dest='bounding_box', type=str, default=None,
+        '-b', '--bounding_box', dest='bounding_box', type=str, default=None,
         help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
 
     misc = p.add_argument_group("Run parameters")

--- a/tools/bin/raiderStats.py
+++ b/tools/bin/raiderStats.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         inps.workdir,
         inps.cpus,
         inps.verbose,
-        inps.bbox,
+        inps.bounding_box,
         inps.spacing,
         inps.timeinterval,
         inps.seasonalinterval,


### PR DESCRIPTION
Introduce grey background for continent, and light-blue in station stats plots (```--station_delay_mean --station_delay_stdev```). Originally stations with large mean/std/density values (denoted by white) would not be distinguished from white background. Now white background is only displayed if a user just wishes to discern station locations (```--station_distribution```)
 
Update matplotlib plotting to eliminate depreciation warnings. I.e. the program no longer passes duplicate colormap and norm variables to matplotlib colorbar after such variables were defined when figures were initialized.

Ensure consistency between stats programs for ```--bounding_box``` argument.