### PR TITLE
Fix ray indexing in weather model LOS computation

### DIFF
--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -38,7 +38,7 @@ def readLL(*args):
         lats, latproj, _ = gdal_open(lat, returnProj=True)
         lons, lonproj, _ = gdal_open(lon, returnProj=True)
     elif flag == 'bounding_box':
-        N, W, S, E = args
+        S, N, W, E = args
         lats = np.array([float(N), float(S)])
         lons = np.array([float(E), float(W)])
         latproj = lonproj = 'EPSG:4326'

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -171,7 +171,7 @@ class WeatherModel(ABC):
         if los_flag:
             # ECEF to Lat/Lon reference frame
             p1 = CRS.from_epsg(4978)
-            t = Transformer.from_proj(p1, self._proj)
+            t = Transformer.from_proj(p1, self._proj, always_xy=True)
 
             # Get the look vectors
             # TODO: lengths and LOS return from GEO2RDR are not correct
@@ -190,7 +190,11 @@ class WeatherModel(ABC):
             ray = makePoints3D(max_len, rays_ecef, los_slv, _STEP)
 
             # Transform from ECEF to weather model native projection
-            ray_x, ray_y, ray_z = t.transform(ray[..., 0], ray[..., 1], ray[..., 2], always_xy=True)
+            ray_x, ray_y, ray_z = t.transform(
+                ray[..., 0, :],
+                ray[..., 1, :],
+                ray[..., 2, :]
+            )
 
             delay_wet = interpolate2(ifWet, ray_x, ray_y, ray_z)
             delay_hydro = interpolate2(ifHydro, ray_x, ray_y, ray_z)

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -198,7 +198,7 @@ class WeatherModel(ABC):
 
             delay_wet = interpolate2(ifWet, ray_x, ray_y, ray_z)
             delay_hydro = interpolate2(ifHydro, ray_x, ray_y, ray_z)
-            delays = _integrateLOS(_STEP, delay_wet, delay_hydro, Npts)
+            delays = _integrateLOS(_STEP, delay_wet, delay_hydro)
 
             self._wet_total = delays[..., 0]
             self._hydrostatic_total = delays[..., 1]


### PR DESCRIPTION
The computation is still broken because of the incorrect look vectors returned from `getLookVectors`, but I think these ray indices are correct.