### PR TITLE
Fix variogram sill bug in statsPlot, updated handling of units

### DIFF
--- a/tools/RAiDER/getStationDelays.py
+++ b/tools/RAiDER/getStationDelays.py
@@ -148,7 +148,7 @@ def get_delays(stationFile, filename, returnTime=None):
     return
 
 
-def get_station_data(inFile, numCPUs=8, outDir=None, returnTime=None):
+def get_station_data(inFile, gps_repo=None, numCPUs=8, outDir=None, returnTime=None):
     '''
     Pull tropospheric delay data for a given station name
     '''
@@ -190,7 +190,7 @@ def get_station_data(inFile, numCPUs=8, outDir=None, returnTime=None):
             multipool.starmap(get_delays, args)
 
     # Consolidate all CSV files into one object
-    name = os.path.join(outDir, 'CombinedGPS_ztd.csv')
+    name = os.path.join(outDir, '{}combinedGPS_ztd.csv'.format(gps_repo))
     statsFile = pd.concat([pd.read_csv(i) for i in outputfiles])
     # drop all duplicate lines
     statsFile.drop_duplicates(inplace=True)

--- a/tools/bin/raiderDownloadGNSS.py
+++ b/tools/bin/raiderDownloadGNSS.py
@@ -14,6 +14,7 @@ if __name__ == "__main__":
     query_repos(
         inps.station_file,
         inps.bounding_box,
+        inps.gps_repo,
         inps.out,
         inps.years,
         inps.returnTime,


### PR DESCRIPTION
## Description
Fixed bug in sill value. Specifically, a vestige in the code applied a factor of 1e-4 to the output sill value irregardless of the true units of the input file. Furthermore, input units were assumed to be in units of meters, even though they are downloaded from UNR in units of mm. 
 
Thus, a new filenaming convention has been implemented. Specifically, ```downloadGNSSdelays.py``` and ```getStationDelays.py``` have been updated such that the final output filename reflects the source repository (e.g. ```UNRcombinedGPS_ztd.csv```). The source repository is toggled with the ```—gpsrepo``` option, where currently only UNR is supported. Accordingly, ```statsPlot.py``` has been updated to recognize the source repository based off of the filename and thus handle the native units properly. Given this, the user no longer has to manually specify the native dataset units with the ```—unit```. The ```—unit``` option has thus been modified to now serve as a means to specify the output unit for plotting purposes (by default ‘m’).

Also fixed bug in ```statsPlot.py``` such that grids with more than 1000 samples are subsampled by 1000 randomly selected samples. This wasn’t successfully implemented before as the number of samples (integer) was compared with a threshold value which was defined as a float, such that this condition was ignored and large arrays were passed along without being subsampled. This threshold of 1000 samples is hardcoded, but can easily make into an option that a user can have more direct control over.

Will update the notebooks accordingly to reflect these updates.

## Motivation and Context
Addresses #11 

## How Has This Been Tested?
To replicate small test, run the following download/plotting commands:
```
raiderDownloadGNSS.py --out products --years '2018' --returntime '00:00:00' --bounding_box '36 40 -124 -119'

raiderStats.py --file products/UNRcombinedGPS_ztd.csv -w maps_sill -b '36 40 -124 -119' --seasonalinterval '03-21 06-21' --plotall --cpus all
```

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [X] I have successfully ran tests with your changes locally.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
