### PR TITLE
All files downloaded in units of m. Dry and wet delays now passed.

### DIFF
--- a/tools/RAiDER/getStationDelays.py
+++ b/tools/RAiDER/getStationDelays.py
@@ -34,11 +34,19 @@ def get_delays_UNR(stationFile, filename, returnTime=None):
          (delay in mm, delay uncertainty, delay gradients)
     *NOTE: Due to a formatting error in the tropo SINEX files, the two tropospheric gradient columns
     (TGNTOT and TGETOT) are interchanged, as are the formal error columns (_SIG).
-    (source=http://geodesy.unr.edu/gps_timeseries/README_trop2.txt)
+    Source  —> http://geodesy.unr.edu/gps_timeseries/README_trop2.txt)
     '''
     # Refer to the following sites to interpret stationFile variable names:
     # ftp://igs.org/pub/data/format/sinex_tropo.txt
     # http://geodesy.unr.edu/gps_timeseries/README_trop2.txt
+    # Wet and hydrostratic delays were derived as so:
+    # Constants —> k1 = 0.704, k2 = 0.776, k3 = 3739.0, m = 18.0152/28.9644, 
+    # k2' = k2-(k1*m) = 0.33812796398337275, Rv = 461.5 J/(kg·K), ρl = 997 kg/m^3
+    # Note wet delays passed here may be computed as so
+    # where PMV = precipitable water vapor, P = total atm pressure, Tm = mean temp of the column —>
+    # Wet zenith delay = 10^-6 ρlRv(k2' + k3/Tm) PMV
+    # Hydrostatic zenith delay = Total zenith delay - wet zenith delay = k1*(P/Tm)
+    # Source —> Hanssen, R. F. (2001) eqns. 6.2.7-10
 
     # sort through station zip files
     allstationTarfiles = []
@@ -57,7 +65,7 @@ def get_delays_UNR(stationFile, filename, returnTime=None):
         # get the date of the file
         time, yearFromFile, doyFromFile = get_date(os.path.basename(j).split('.'))
         # initialize variables
-        d, Sig, dwet, ddry, timesList = [], [], [], [], []
+        d, Sig, dwet, dhydro, timesList = [], [], [], [], []
         flag = False
         for line in f.readlines():
             try:
@@ -91,7 +99,7 @@ def get_delays_UNR(stationFile, filename, returnTime=None):
                 d.append(trotot*0.001)
                 Sig.append(trototSD*0.001)
                 dwet.append(trwet*0.001)
-                ddry.append((trotot-trwet)*0.001)
+                dhydro.append((trotot-trwet)*0.001)
                 timesList.append(seconds)
             if 'TROP/SOLUTION' in line:
                 flag = True
@@ -110,29 +118,29 @@ def get_delays_UNR(stationFile, filename, returnTime=None):
             missing = [
                 True if t not in timesList else False for t in true_times]
             mask = np.array(missing)
-            delay, sig, wet_delay, dry_delay = [np.full((288,), np.nan)] * 4
+            delay, sig, wet_delay, hydro_delay = [np.full((288,), np.nan)] * 4
             delay[~mask] = d
             sig[~mask] = Sig
             wet_delay[~mask] = dwet
-            dry_delay[~mask] = ddry
+            hydro_delay[~mask] = dhydro
             times = true_times.copy()
         else:
             delay = np.array(d)
             times = np.array(timesList)
             sig = np.array(Sig)
             wet_delay = np.array(dwet)
-            dry_delay = np.array(ddry)
+            hydro_delay = np.array(dhydro)
 
         # if time not specified, pass all times
         if returnTime == None:
             filtoutput = {'ID': [site] * len(wet_delay), 'Date': [time] * len(wet_delay), 'ZTD': delay, 'wet_delay': wet_delay,
-                          'dry_delay': dry_delay, 'times': times, 'sigZTD': sig}
+                          'hydrostatic_delay': hydro_delay, 'times': times, 'sigZTD': sig}
             filtoutput = [{key: value[k] for key, value in filtoutput.items()}
                           for k in range(len(filtoutput['ID']))]
         else:
             index = np.argmin(np.abs(np.array(timesList) - returnTime))
             filtoutput = [{'ID': site, 'Date': time, 'ZTD': delay[index], 'wet_delay': wet_delay[index],
-                           'dry_delay': dry_delay[index], 'times': times[index], 'sigZTD': sig[index]}]
+                           'hydrostatic_delay': hydro_delay[index], 'times': times[index], 'sigZTD': sig[index]}]
         # setup pandas array and write output to CSV, making sure to update existing CSV.
         filtoutput = pd.DataFrame(filtoutput)
         if not os.path.exists(filename):

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -499,8 +499,6 @@ class RaiderStats(object):
 
     def __init__(self, filearg, col_name, unit='m', workdir='./', bbox=None, spacing=1, timeinterval=None, seasonalinterval=None, stationsongrids=False, cbounds=None, colorpercentile='25 95'):
         self.fname = filearg
-        # get source GPS repository from input filename
-        self.gps_repo = os.path.basename(filearg).split('combinedGPS_ztd.csv')[0]
         self.col_name = col_name
         self.unit = unit
         self.workdir = workdir
@@ -615,10 +613,9 @@ class RaiderStats(object):
                 'User-specified key {} not found in inpuit file {}. Must specify valid key.' .format(self.col_name, self.fname))
 
         # convert to specified output unit
-        if self.gps_repo == 'UNR':
-            inputunit = 'mm'
-            data[self.col_name] = self._convert_SI(
-                data[self.col_name], inputunit, self.unit)
+        inputunit = 'm'
+        data[self.col_name] = self._convert_SI(
+            data[self.col_name], inputunit, self.unit)
 
         return data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
All downloaded files now record delays in consistent units (i.e. m) and are no longer reflecting native units of source. These changes are now explicitly reflected through updates to the ```statsPlot.py``` parser and ```get_delays_UNR``` function in ```getStationDelays.py``` 
 
Wet and hydrostatic components of the total delay now passed to final CSV file, where wet delays are already provided by UNR and hydrostatic delay  = Total delay – wet component. Ngrad and Egrad values no longer passed along.

## Motivation and Context
Addresses recording of wet/dry components as proposed in #92 

## How Has This Been Tested?
Before the native unit of delays for a given source repo (e.g. mm for UNR) was recorded, with```statsPlot.py``` tracking these native units based off of the prefix assigned to a given input file (e.g. ```UNRcombinedGPS_ztd.csv```).  Now downloaded files directly record delays in units of m, with ```statsPlot.py``` expecting all input delays to be in units of meters, but with user-specified unit conversions (e.g. m to mm) handled internally.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [X] I have successfully ran tests with your changes locally.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
