### PR TITLE
Fix bug in llreader

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -27,3 +27,4 @@ def pushd(dir):
 
 TEST_DIR = get_test_dir()
 DATA_DIR = os.path.join(TEST_DIR, "data")
+GEOM_DIR = os.path.join(TEST_DIR, 'test_geom')

--- a/test/cli/test_argument_parsers.py
+++ b/test/cli/test_argument_parsers.py
@@ -33,9 +33,7 @@ def test_delay_args(delay_parser):
 
     assert args.dateList == [date(2020, 1, 3)]
     assert args.time == time(23, 0, 0)
-    assert args.latlon == ['latfile.dat', 'lonfile.dat']
-    assert args.bbox is None
-    assert args.station_file is None
+    assert args.query_area == ['latfile.dat', 'lonfile.dat']
     assert args.lineofsight is None
     assert args.statevectors is None
     assert args.dem is None

--- a/test/test_llreader.py
+++ b/test/test_llreader.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+
+import numpy as np
+
+from test import GEOM_DIR, TEST_DIR
+
+from RAiDER.llreader import (
+    readLLFromLLFiles,readLLFromBBox,readLLFromStationFile,forceNDArray
+)
+
+SCENARIO_DIR = os.path.join(TEST_DIR, "scenario_2")
+
+def test_latlon_reader():
+    lats, lons, llproj = readLLFromLLFiles(os.path.join(GEOM_DIR, 'lat.rdr'), os.path.join(GEOM_DIR, 'lon.rdr'))
+    assert lats.shape == (45, 226)
+    assert lons.shape == (45, 226)
+    
+
+def test_bbox_reade1():
+    lat, lon, llproj = readLLFromBBox(['10', '12', '-72', '-70'])
+    print(lat)
+    print(lon)
+    assert np.allclose(lat, np.array([10, 12]))
+    assert np.allclose(lon, np.array([-72, -70]))
+
+def test_stationfile_reader():
+    lats, lons, llproj = readLLFromStationFile(os.path.join(SCENARIO_DIR, 'stations.csv'))
+    assert len(lats)==8
+
+def test_forceNDArray():
+    assert np.all(np.array([1, 2, 3]) == forceNDArray([1, 2, 3]))
+    assert np.all(np.array([1, 2, 3]) == forceNDArray((1, 2, 3)))
+    assert forceNDArray(None) is None
+

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -28,27 +28,8 @@ def checkArgs(args, p):
             if args.outformat.lower() != 'hdf5':
                 raise RuntimeError('HDF5 must be used with height levels')
 
-    # Area
-    # flag depending on the type of input
-    if args.latlon is not None:
-        flag = 'files'
-    elif args.bbox is not None:
-        flag = 'bounding_box'
-    elif args.station_file is not None:
-        flag = 'station_file'
-    else:
-        flag = None
-
-    if args.latlon is not None:
-        lat, lon, latproj, lonproj, bounds = readLL(*args.latlon)
-    elif args.bbox is not None:
-        lat, lon, latproj, lonproj, bounds = readLL(*args.bbox)
-    elif args.station_file is not None:
-        lat, lon, latproj, lonproj, bounds = readLL(args.station_file)
-    elif args.files is None:
-        raise NotImplementedError("Reading lat/lon data from files is not implemented")
-    else:
-        raise RuntimeError('You must specify an area of interest')
+    # Query Area
+    lat, lon, llproj, bounds, flag = readLL(args.query_area)
 
     if (np.min(lat) < -90) | (np.max(lat) > 90):
         raise RuntimeError('Lats are out of N/S bounds; are your lat/lon coordinates switched?')
@@ -97,7 +78,7 @@ def checkArgs(args, p):
     if args.outformat is None:
         if args.heightlvs is not None:
             outformat = 'hdf5'
-        elif args.station_file is not None:
+        elif flag=='station_file':
             outformat = 'csv'
         elif useWeatherNodes:
             outformat = 'hdf5'

--- a/tools/RAiDER/cli/parser.py
+++ b/tools/RAiDER/cli/parser.py
@@ -36,6 +36,7 @@ def add_bbox(parser):
         help="Bounding box",
         nargs=4,
         type=float,
+        dest='query_area',
         action=BBoxAction,
         metavar=('S', 'N', 'W', 'E')
     )

--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -55,14 +55,22 @@ def create_parser():
     # Area
     area = p.add_argument_group('Area of Interest (Supply one)').add_mutually_exclusive_group(required=True)
     area.add_argument(
-        '--latlon', '-ll', nargs=2, default=None,
+        '--latlon', 
+        '-ll', 
+        nargs=2, 
+        dest='query_area',
         help='GDAL-readable latitude and longitude raster files (2 single-band files)',
-        metavar=('LAT', 'LONG'))
+        metavar=('LAT', 'LONG')
+    )
     add_bbox(area)
     area.add_argument(
-        '--station_file', default=None, type=str, dest='station_file',
+        '--station_file', 
+        default=None, 
+        type=str, 
+        dest='query_area',
         help=('CSV file with a list of stations, containing at least '
-              'the columns "Lat" and "Lon"'))
+              'the columns "Lat" and "Lon"')
+     )
 
     # Line of sight
     los = p.add_argument_group(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #139. 

## Description
<!--- Describe your changes in detail -->
The llreader module was not being adequately tested in the unit test suite, so some bugs got through. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This PR simplifies the llreader module and the query points input and fixes the bug noted in #139. 
- I changed the command-line parser so that the mutually-exclusive area arguments (lat/lon files, bounding box, or station list) all get written to the same variable (query_area) so that only a single function call is needed to parse the inputs, making the code much simpler. 

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->
Added unit tests for the llreader module and they all pass now. 

<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->
No tests break with this PR on my machine (Mac OS 10.15.6, running iterm2 terminal emulator).

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what the changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
