### PR TITLE
Update delay.py

### DIFF
--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -122,7 +122,10 @@ def tropo_delay(los, lats, lons, ll_bounds, heights, flag, weather_model, wmLoc,
     logger.debug('Download-only is %s', download_only)
     if wmLoc is None:
         wmLoc = os.path.join(out, 'weather_files')
-
+    
+    if download_only:
+        return None, None
+    
     # weather model calculation
     wm_filename = make_weather_model_filename(weather_model['name'], time, ll_bounds)
     weather_model_file = os.path.join(wmLoc, wm_filename)
@@ -143,8 +146,6 @@ def tropo_delay(los, lats, lons, ll_bounds, heights, flag, weather_model, wmLoc,
             'to create a new one.', weather_model_file
         )
 
-    if download_only:
-        return None, None
 
     # Pull the DEM.
     logger.debug('Beginning DEM calculation')


### PR DESCRIPTION
If download-only was specified it tried to create hdf5 file, errors out, which is not expected behavior

<!--- Provide a general summary of your changes in the Title above -->

## Description
When downloadOnly option delay tried to make the h5 file, and errors out.

```
2020-10-29 07:09:43,881 WARNING download_only flag selected. No further processing will happen.
ERROR: Unable to save weathermodel to file
Traceback (most recent call last):
  File "/Users/dbekaert/Software/python/miniconda37/envs/RAIDER/lib/python3.7/site-packages/RAiDER-0.0.1-py3.7-macosx-10.9-x86_64.egg/RAiDER/delay.py", line 135, in tropo_delay
    weather_model.write2HDF5(weather_model_file)
AttributeError: 'NoneType' object has no attribute 'write2HDF5'
2020-10-29 07:09:43,882 ERROR Unable to save weathermodel to file
Traceback (most recent call last):
  File "/Users/dbekaert/Software/python/miniconda37/envs/RAIDER/lib/python3.7/site-packages/RAiDER-0.0.1-py3.7-macosx-10.9-x86_64.egg/RAiDER/delay.py", line 135, in tropo_delay
    weather_model.write2HDF5(weather_model_file)
AttributeError: 'NoneType' object has no attribute 'write2HDF5'
```


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


