### PR TITLE
Multi parallel capability and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+__pycache__
 *.pyc
 *~
 *.swp
 *.DS_Store
-__pycache__
+.ftpignore
+.ftpconfig
 .ipynb_checkpoints
 build
 *.so
@@ -13,6 +15,8 @@ dummy*
 weather_files
 test/data
 *.log
+*.pdf
+*.cpp
 test/*/geom/*.dem
 .eggs/
 dist/

--- a/test/test_scenario_1.py
+++ b/test/test_scenario_1.py
@@ -39,7 +39,7 @@ def test_tropo_delay(tmp_path):
     with pushd(tmp_path):
         # packing the dictionairy
         args={}
-        args['los']=Zenith,
+        args['los']=Zenith
         args['lats']=lats
         args['lons']=lons
         args['ll_bounds']=(15.75, 18.25, -103.24, -99.75)

--- a/test/test_scenario_1.py
+++ b/test/test_scenario_1.py
@@ -37,29 +37,26 @@ def test_tropo_delay(tmp_path):
     )
 
     with pushd(tmp_path):
-        (_, _) = tropo_delay(
-            los=Zenith,
-            lats=lats,
-            lons=lons,
-            ll_bounds=(15.75, 18.25, -103.24, -99.75),
-            heights=("dem", os.path.join(
-                TEST_DIR, "test_geom", "warpedDEM.dem")),
-            flag="files",
-            weather_model={
-                "type": model_obj(),
-                "files": None,
-                "name": "ERA5"
-            },
-            wmLoc=wmLoc,
-            zref=20000.,
-            outformat="envi",
-            time=time,
-            out=tmp_path,
-            download_only=False,
-            wetFilename=wet_file,
-            hydroFilename=hydro_file
-        )
-
+        # packing the dictionairy
+        args={}
+        args['los']=Zenith,
+        args['lats']=lats
+        args['lons']=lons
+        args['ll_bounds']=(15.75, 18.25, -103.24, -99.75)
+        args['heights']=("dem", os.path.join(TEST_DIR, "test_geom", "warpedDEM.dem"))
+        args['flag']="files"
+        args['weather_model']={"type": model_obj(),"files": None,"name": "ERA5"}
+        args['wmLoc']=wmLoc
+        args['zref']=20000.
+        args['outformat']="envi"
+        args['times']=time
+        args['out']=tmp_path
+        args['download_only']=False
+        args['wetFilenames']=wet_file
+        args['hydroFilenames']=hydro_file
+        
+        (_, _) = tropo_delay(args)
+      
         # get the results
         wet = gdal_open(wet_file)
         hydro = gdal_open(hydro_file)

--- a/test/test_scenario_2.py
+++ b/test/test_scenario_2.py
@@ -38,24 +38,26 @@ def test_computeDelay(tmp_path):
     _, model_obj = modelName2Module('ERA5')
 
     with pushd(tmp_path):
-        (_, _) = tropo_delay(
-            los=Zenith,
-            lats=lats,
-            lons=lons,
-            ll_bounds=(33.746, 36.795, -118.312, -114.892),
-            heights=('merge', [wetFile]),
-            flag='station_file',
-            weather_model={'type': model_obj(), 'files': None, 'name': 'ERA5'},
-            wmLoc=None,
-            zref=20000.,
-            outformat='csv',
-            time=datetime(2020, 1, 3, 23, 0, 0),
-            out=tmp_path,
-            download_only=False,
-            wetFilename=wetFile,
-            hydroFilename=hydroFile
-        )
-
+        
+        # packing the dictionairy
+        args={}
+        args['los']=Zenith,
+        args['lats']=lats
+        args['lons']=lons
+        args['ll_bounds']=(33.746, 36.795, -118.312, -114.892)
+        args['heights']=('merge', [wetFile])
+        args['flag']="station_file"
+        args['weather_model']={"type": model_obj(),"files": None,"name": "ERA5"}
+        args['wmLoc']=None
+        args['zref']=20000.
+        args['outformat']="csv"
+        args['times']=datetime(2020, 1, 3, 23, 0, 0)
+        args['out']=tmp_path
+        args['download_only']=False
+        args['wetFilenames']=wetFile
+        args['hydroFilenames']=hydroFile
+        (_, _) = tropo_delay(args)
+        
     # get the results
     est_delay = pd.read_csv(wetFile)
     true_delay = pd.read_csv(true_delay)

--- a/test/test_scenario_2.py
+++ b/test/test_scenario_2.py
@@ -41,7 +41,7 @@ def test_computeDelay(tmp_path):
         
         # packing the dictionairy
         args={}
-        args['los']=Zenith,
+        args['los']=Zenith
         args['lats']=lats
         args['lons']=lons
         args['ll_bounds']=(33.746, 36.795, -118.312, -114.892)

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -64,6 +64,17 @@ def checkArgs(args, p):
     # zref
     zref = args.zref
 
+    # parallel or concurrent runs
+    parallel = args.parallel
+    if not parallel==1:
+        import multiprocessing
+        # asses the number of concurrent jobs to be executed
+        max_threads = multiprocessing.cpu_count()
+        if parallel == 'all':
+            parallel = max_threads
+        parallel = parallel if parallel < max_threads else max_threads
+
+
     # handle the datetimes requested
     datetimeList = [datetime.combine(d, args.time) for d in args.dateList]
 
@@ -129,4 +140,25 @@ def checkArgs(args, p):
     else:
         heights = ('download', os.path.join(out, 'geom', 'warpedDEM.dem'))
 
-    return los, lat, lon, bounds, heights, flag, weathers, wmLoc, zref, outformat, datetimeList, out, download_only, verbose, wetNames, hydroNames
+    # put all the arguments in a dictionary
+    outArgs = {}
+    outArgs['los']=los
+    outArgs['lats']=lat
+    outArgs['lons']=lon
+    outArgs['ll_bounds']=bounds
+    outArgs['heights']=heights
+    outArgs['flag']=flag
+    outArgs['weather_model']=weathers
+    outArgs['wmLoc']=wmLoc
+    outArgs['zref']=zref
+    outArgs['outformat']=outformat
+    outArgs['times']=datetimeList
+    outArgs['download_only']=download_only
+    outArgs['out']=out
+    outArgs['verbose']=verbose
+    outArgs['wetFilenames']=wetNames
+    outArgs['hydroFilenames']=hydroNames
+    outArgs['parallel']=parallel
+
+    return outArgs
+    #return los, lat, lon, bounds, heights, flag, weathers, wmLoc, zref, outformat, datetimeList, out, download_only, verbose, wetNames, hydroNames, parallel

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -102,32 +102,35 @@ def computeDelay(weather_model_file_name, pnts_file_name, useWeatherNodes=False,
         return wet, hydro
 
 
-def tropo_delay(
-    los,
-    lats,
-    lons,
-    ll_bounds,
-    heights,
-    flag,
-    weather_model,
-    wmLoc,
-    zref,
-    outformat,
-    time,
-    out,
-    download_only,
-    wetFilename,
-    hydroFilename
-):
+def tropo_delay(args):
     """
     raiderDelay main function.
     """
+
+    # unpacking the dictionairy
+    los = args['los']
+    lats = args['lats']
+    lons = args['lons']
+    ll_bounds = args['ll_bounds']
+    heights = args['heights']
+    flag = args['flag']
+    weather_model = args['weather_model']
+    wmLoc = args['wmLoc']
+    zref = args['zref']
+    outformat = args['outformat']
+    time = args['times']
+    out = args['out']
+    download_only = args['download_only']
+    wetFilename = args['wetFilenames']
+    hydroFilename = args['hydroFilenames']
+    
+    # logging
     logger.debug('Starting to run the weather model calculation')
     logger.debug('Time type: %s', type(time))
     logger.debug('Time: %s', time.strftime('%Y%m%d'))
     logger.debug('Flag type is %s', flag)
     logger.debug('DEM/height type is "%s"', heights[0])
-
+    
     # Flags
     useWeatherNodes = flag == 'bounding_box'
     delayType = ["Zenith" if los is Zenith else "LOS"]

--- a/tools/RAiDER/models/gmao.py
+++ b/tools/RAiDER/models/gmao.py
@@ -72,41 +72,41 @@ class GMAO(WeatherModel):
         ds = pydap.client.open_url(url, session=session)
 
         q = ds['qv'].array[
-            time_ind, 
-            ml_min:(ml_max + 1), 
-            lat_min_ind:(lat_max_ind + 1), 
+            time_ind,
+            ml_min:(ml_max + 1),
+            lat_min_ind:(lat_max_ind + 1),
             lon_min_ind:(lon_max_ind + 1)
         ][0]
         p = ds['pl'].array[
-            time_ind, 
-            ml_min:(ml_max + 1), 
-            lat_min_ind:(lat_max_ind + 1), 
+            time_ind,
+            ml_min:(ml_max + 1),
+            lat_min_ind:(lat_max_ind + 1),
             lon_min_ind:(lon_max_ind + 1)
         ][0]
         t = ds['t'].array[
-            time_ind, 
-            ml_min:(ml_max + 1), 
-            lat_min_ind:(lat_max_ind + 1), 
+            time_ind,
+            ml_min:(ml_max + 1),
+            lat_min_ind:(lat_max_ind + 1),
             lon_min_ind:(lon_max_ind + 1)
         ][0]
         h = ds['h'].array[
-            time_ind, 
-            ml_min:(ml_max + 1), 
-            lat_min_ind:(lat_max_ind + 1), 
+            time_ind,
+            ml_min:(ml_max + 1),
+            lat_min_ind:(lat_max_ind + 1),
             lon_min_ind:(lon_max_ind + 1)
         ][0]
 
         lats = np.arange(
-            (-90 + lat_min_ind * self._lat_res), 
-            (-90 + (lat_max_ind + 1) * self._lat_res), 
+            (-90 + lat_min_ind * self._lat_res),
+            (-90 + (lat_max_ind + 1) * self._lat_res),
             self._lat_res
         )
         lons = np.arange(
-            (-180 + lon_min_ind * self._lon_res), 
-            (-180 + (lon_max_ind + 1) * self._lon_res), 
+            (-180 + lon_min_ind * self._lon_res),
+            (-180 + (lon_max_ind + 1) * self._lon_res),
             self._lon_res
         )
-        
+
         try:
             # Note that lat/lon gets written twice for GMAO because they are the same as y/x
             writeWeatherVars2HDF5(lats, lons, lons, lats, h, q, p, t, self._proj, out)
@@ -132,14 +132,14 @@ class GMAO(WeatherModel):
         # adding the import here should become absolute when transition to netcdf
         import h5py
         with h5py.File(filename, 'r') as f:
-            lons = f['lons'].value.copy()
-            lats = f['lats'].value.copy()
-            h = f['z'].value.copy()
-            p = f['p'].value.copy()
-            q = f['q'].value.copy()
-            t = f['t'].value.copy()
-        
-        
+            lons = f['lons'][:].copy()
+            lats = f['lats'][:].copy()
+            h = f['z'][:].copy()
+            p = f['p'][:].copy()
+            q = f['q'][:].copy()
+            t = f['t'][:].copy()
+
+
         # restructure the 3-D lat/lon/h in regular grid
         _lons = np.broadcast_to(lons[np.newaxis, np.newaxis, :], t.shape)
         _lats = np.broadcast_to(lats[np.newaxis, :, np.newaxis], t.shape)

--- a/tools/RAiDER/models/gmao.py
+++ b/tools/RAiDER/models/gmao.py
@@ -129,6 +129,8 @@ class GMAO(WeatherModel):
         Get the variables from the GMAO link using OpenDAP
         '''
 
+        # adding the import here should become absolute when transition to netcdf
+        import h5py
         with h5py.File(filename, 'r') as f:
             lons = f['lons'].value.copy()
             lats = f['lats'].value.copy()

--- a/tools/RAiDER/models/merra2.py
+++ b/tools/RAiDER/models/merra2.py
@@ -67,7 +67,7 @@ class MERRA2(WeatherModel):
 
         # check whether the file already exists
         if os.path.exists(out):
-           return 
+           return
 
         # calculate the array indices for slicing the GMAO variable arrays
         lat_min_ind = int((self._bounds[0] - (-90.0)) / self._lat_res)
@@ -76,16 +76,16 @@ class MERRA2(WeatherModel):
         lon_max_ind = int((self._bounds[3] - (-180.0)) / self._lon_res)
 
         lats = np.arange(
-            (-90 + lat_min_ind * self._lat_res), 
+            (-90 + lat_min_ind * self._lat_res),
             (-90 + (lat_max_ind + 1) * self._lat_res),
             self._lat_res
         )
         lons = np.arange(
-            (-180 + lon_min_ind * self._lon_res), 
-            (-180 + (lon_max_ind + 1) * self._lon_res), 
+            (-180 + lon_min_ind * self._lon_res),
+            (-180 + (lon_max_ind + 1) * self._lon_res),
             self._lon_res
             )
-        
+
         if time.year < 1992:
             url_sub = 100
         elif time.year < 2001:
@@ -137,12 +137,12 @@ class MERRA2(WeatherModel):
         import h5py
 
         with h5py.File(filename, 'r') as f:
-            lons = f['lons'].value.copy()
-            lats = f['lats'].value.copy()
-            h = f['z'].value.copy()
-            p = f['p'].value.copy()
-            q = f['q'].value.copy()
-            t = f['t'].value.copy()
+            lons = f['lons'][:].copy()
+            lats = f['lats'][:].copy()
+            h = f['z'][:].copy()
+            p = f['p'][:].copy()
+            q = f['q'][:].copy()
+            t = f['t'][:].copy()
 
         # restructure the 3-D lat/lon/h in regular grid
         _lons = np.broadcast_to(lons[np.newaxis, np.newaxis, :], t.shape)

--- a/tools/RAiDER/models/merra2.py
+++ b/tools/RAiDER/models/merra2.py
@@ -132,6 +132,10 @@ class MERRA2(WeatherModel):
         '''
         Get the variables from the GMAO link using OpenDAP
         '''
+
+        # adding the import here should become absolute when transition to netcdf
+        import h5py
+
         with h5py.File(filename, 'r') as f:
             lons = f['lons'].value.copy()
             lats = f['lats'].value.copy()

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -35,7 +35,7 @@ def getWMFilename(weather_model_name, time, outLoc):
         )
     )
 
-    if weather_model_name is 'GMAO' or weather_model_name is 'MERRA2':
+    if weather_model_name == 'GMAO' or weather_model_name == 'MERRA2':
         f = f[:-2]+'h5'
 
     logger.debug('Storing weather model at: %s', f)

--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -188,7 +188,7 @@ def _tropo_delay(args):
         try:
             (_, _) = tropo_delay(args_copy)
         except RuntimeError:
-            logger.exception("Date %s failed", times[0])
+            logger.exception("Date %s failed", args_copy['times'])
     else:
         for tim, wetFilename, hydroFilename in zip(args['times'], args['wetFilenames'], args['hydroFilenames']):
             try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fixing h5py import error
- Fixing the change of nc and h5 depending if one uses parallel or not. issue is related to comparison of the object versus its explicit comparision
 - enabling parallel as input argument parallel for both delay and download change the args parse to be a dictionary update delay to handle a dictionary


fixes #188 and #190 

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->
Tested in parallel mode and without
Tested for MERRA2, GMAO, ERA5, ECMWF
Latter has an issue reported in #191 

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
