### PR TITLE
Remove NaNs from CSV

### DIFF
--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -787,6 +787,7 @@ class RaiderStats(object):
 
         # map gridnode dictionary to dataframe
         self.df['gridnode'] = self.df['ID'].map(idtogrid_dict)
+        self.df = self.df[self.df['gridnode'] != 'NaN']
         del self.unique_points, self.polygon_dict, self.polygon_tree, idtogrid_dict, append_poly
         # sort by grid and date
         self.df.sort_values(['gridnode', 'Date'])


### PR DESCRIPTION
The program search for intersections between stations and gridcells based off of the user input bounding box. If stations fall outside of the bounding box, no intersection will be found and a NaN is passed to the dataframe. These NaN values were not purged and later crash at the variogram stage. This has been addressed here.

Addresses #157 and #198 