### PR TITLE
Series of fixes for statsplot

### DIFF
--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -57,7 +57,7 @@ raiderStats.py -f <filename> -grid_delay_mean -ti '2016-01-01 2018-01-01' --seas
     userinps.add_argument('-c', '--column_name', dest='col_name', type=str, default='ZTD',
                           help='Name of the input column to plot. Input assumed to be in units of meters')
     userinps.add_argument('-u', '--unit', dest='unit', type=str, default='m',
-                          help='Specified output unit, by default m. Input unit interpreted from input filename following convention in downloadGNSSDelays.py (i.e. mm if UNR, cm if MEASURES).')
+                          help='Specified output unit, by default m. Input unit assumed to be m following convention in downloadGNSSDelays.py.')
     userinps.add_argument('-w', '--workdir', dest='workdir', default='./',
                           help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
     add_cpus(userinps)
@@ -79,6 +79,8 @@ raiderStats.py -f <filename> -grid_delay_mean -ti '2016-01-01 2018-01-01' --seas
     # Plot formatting/options
     pltformat = parser.add_argument_group(
         'Optional controls for plot formatting/options.')
+    pltformat.add_argument('-figdpi', '--figdpi', dest='figdpi', type=int,
+                           default=100, help='DPI to use for saving figures')
     pltformat.add_argument('-fmt', '--plot_format', dest='plot_fmt', type=str,
                            default='png', help='Plot format to use for saving figures')
     pltformat.add_argument('-cb', '--color_bounds', dest='cbounds', type=str,
@@ -134,7 +136,20 @@ def cmd_line_parse(iargs=None):
     return parser.parse_args(args=iargs)
 
 
-def save_gridfile(df, gridfile_type, fname, plotbbox, spacing, unit, colorbarfmt='%.3f', stationsongrids=False, gdal_fmt='float32'):
+def convert_SI(val, unit_in, unit_out):
+    '''
+        Convert input to desired units
+    '''
+
+    SI = {'mm': 0.001, 'cm': 0.01, 'm': 1.0, 'km': 1000.}
+    # check if output unit is supported
+    if unit_out not in SI:
+        raise Exception("User-specified output unit {} not recognized.".format(unit_out))
+
+    return val * SI[unit_in] / SI[unit_out]
+
+
+def save_gridfile(df, gridfile_type, fname, plotbbox, spacing, unit, colorbarfmt='%.2f', stationsongrids=False, gdal_fmt='float32'):
     '''
         Function to save gridded-arrays as GDAL-readable file.
     '''
@@ -176,7 +191,7 @@ def save_gridfile(df, gridfile_type, fname, plotbbox, spacing, unit, colorbarfmt
     return
 
 
-def load_gridfile(fname):
+def load_gridfile(fname, unit):
     '''
         Function to load gridded-arrays saved from previous runs.
     '''
@@ -194,13 +209,16 @@ def load_gridfile(fname):
     plotbbox = [float(i) for i in metadata_dict['plotbbox'].split()]
     spacing = float(metadata_dict['spacing'])
     colorbarfmt = metadata_dict['colorbarfmt']
-    unit = metadata_dict['unit']
+    inputunit = metadata_dict['unit']
+    # convert to specified output unit
+    grid_array = convert_SI(grid_array, inputunit, unit)
+
     if metadata_dict['stationsongrids'] == 'False':
         stationsongrids = False
     else:
         stationsongrids = [float(i) for i in metadata_dict['stationsongrids'.split()]]
 
-    return grid_array, plotbbox, spacing, colorbarfmt, unit, stationsongrids
+    return grid_array, plotbbox, spacing, colorbarfmt, stationsongrids
 
 class VariogramAnalysis():
     '''
@@ -350,6 +368,11 @@ class VariogramAnalysis():
         res_robust = least_squares(resid, x0, bounds=bounds,
                                    loss='soft_l1', f_scale=0.1,
                                    args=(d, v, model))
+
+        # convert range to specified output unit
+        # TODO temp fix first multiply by 1,010,000 m as crude conversion from degrees to km
+        res_robust.x[0] = res_robust.x[0]*1010000
+        res_robust.x[0] = convert_SI(res_robust.x[0], 'm', 'km')
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="All-NaN slice encountered")
@@ -527,8 +550,14 @@ class VariogramAnalysis():
                 timeslice[6:8]), int(timeslice[-4:-2]), int(timeslice[-2:]))
 
         if dists is not None and vario is not None:
+            # TODO temp fix first multiply by 1,010,000 m as crude conversion from degrees to km
+            dists = [i*1010000 for i in dists]
+            dists = [convert_SI(i, 'm', 'km') for i in dists]
             plt.scatter(dists, vario, s=1, facecolor='0.5', label='raw')
         if dists_binned is not None and vario_binned is not None:
+            # TODO temp fix first multiply by 1,010,000 m as crude conversion from degrees to km
+            dists_binned = [i*1010000 for i in dists_binned]
+            dists_binned = [convert_SI(i, 'm', 'km') for i in dists_binned]
             plt.plot(dists_binned, vario_binned, 'bo', label='binned')
         if res_robust is not None:
             plt.axhline(y=res_robust[1], color='g',
@@ -536,8 +565,10 @@ class VariogramAnalysis():
             plt.axvline(x=res_robust[0], color='c',
                         linestyle='--', label='h\u0332(°)')
         if d_test is not None and v_test is not None:
+            # TODO temp fix first multiply by 1,010,000 m as crude conversion from degrees to km
+            d_test = [i*1010000 for i in d_test]
             plt.plot(d_test, v_test, 'r-', label='experimental fit')
-        plt.xlabel('Distance (°)')
+        plt.xlabel('Distance (km)')
         plt.ylabel('Dissimilarity ({}\u00b2)'.format(self.unit))
         plt.legend(bbox_to_anchor=(1.02, 1),
                    loc='upper left', borderaxespad=0., framealpha=1.)
@@ -584,8 +615,8 @@ class RaiderStats(object):
         self.grid_delay_mean = grid_delay_mean
         self.grid_delay_stdev = grid_delay_stdev
         self.grid_to_raster = grid_to_raster
-        self.range_heatmap = False
-        self.sill_heatmap = False
+        self.grid_range = False
+        self.grid_variance = False
 
         # create workdir if it doesn't exist
         if not os.path.exists(self.workdir):
@@ -605,15 +636,15 @@ class RaiderStats(object):
         # load dataframe directly if previously generated TIF grid-file
         if self.fname.endswith('.tif'):
             if 'grid_heatmap' in self.fname:
-                self.grid_heatmap, self.plotbbox, self.spacing, self.colorbarfmt, self.unit, self.stationsongrids = load_gridfile(self.fname)
+                self.grid_heatmap, self.plotbbox, self.spacing, self.colorbarfmt, self.stationsongrids = load_gridfile(self.fname, self.unit)
             if 'grid_delay_mean' in self.fname:
-                self.grid_delay_mean, self.plotbbox, self.spacing, self.colorbarfmt, self.unit, self.stationsongrids = load_gridfile(self.fname)
+                self.grid_delay_mean, self.plotbbox, self.spacing, self.colorbarfmt, self.stationsongrids = load_gridfile(self.fname, self.unit)
             if 'grid_delay_stdev' in self.fname:
-                self.grid_delay_stdev, self.plotbbox, self.spacing, self.colorbarfmt, self.unit, self.stationsongrids = load_gridfile(self.fname)
-            if 'range_heatmap' in self.fname:
-                self.range_heatmap, self.plotbbox, self.spacing, self.colorbarfmt, self.unit, self.stationsongrids = load_gridfile(self.fname)
-            if 'sill_heatmap' in self.fname:
-                self.sill_heatmap, self.plotbbox, self.spacing, self.colorbarfmt, self.unit, self.stationsongrids = load_gridfile(self.fname)
+                self.grid_delay_stdev, self.plotbbox, self.spacing, self.colorbarfmt, self.stationsongrids = load_gridfile(self.fname, self.unit)
+            if 'grid_range' in self.fname:
+                self.grid_range, self.plotbbox, self.spacing, self.colorbarfmt, self.stationsongrids = load_gridfile(self.fname, self.unit)
+            if 'grid_variance' in self.fname:
+                self.grid_variance, self.plotbbox, self.spacing, self.colorbarfmt, self.stationsongrids = load_gridfile(self.fname, self.unit)
         # setup dataframe for statistical analyses (if CSV)
         if self.fname.endswith('.csv'):
             self.create_DF()
@@ -675,17 +706,6 @@ class RaiderStats(object):
 
         return extent, grid_dim, gridpoints
 
-    def _convert_SI(self, val, unit_in, unit_out):
-        '''
-        Convert input to desired units
-        '''
-        SI = {'mm': 0.001, 'cm': 0.01, 'm': 1.0, 'km': 1000.}
-        # check if output unit is supported
-        if unit_out not in SI:
-            raise Exception("User-specified output unit {} not recognized.".format(unit_out))
-
-        return val * SI[unit_in] / SI[unit_out]
-
     def _check_stationgrid_intersection(self, stat_ID):
         '''
         Return index of grid cell which intersects with station
@@ -709,12 +729,11 @@ class RaiderStats(object):
         # check if user-specified key is valid
         if self.col_name not in data.keys():
             raise Exception(
-                'User-specified key {} not found in inpuit file {}. Must specify valid key.' .format(self.col_name, self.fname))
+                'User-specified key {} not found in input file {}. Must specify valid key.' .format(self.col_name, self.fname))
 
         # convert to specified output unit
         inputunit = 'm'
-        data[self.col_name] = self._convert_SI(
-            data[self.col_name], inputunit, self.unit)
+        data[self.col_name] = convert_SI(data[self.col_name], inputunit, self.unit)
 
         return data
 
@@ -817,7 +836,7 @@ class RaiderStats(object):
             if self.grid_to_raster:
                 gridfile_name = os.path.join(self.workdir, self.col_name + '_' + 'grid_delay_mean' + '.tif')
                 save_gridfile(self.grid_delay_mean, 'grid_delay_mean', gridfile_name, self.plotbbox, self.spacing, \
-                              self.unit, colorbarfmt='%.3f', stationsongrids=self.stationsongrids, gdal_fmt='float32')
+                              self.unit, colorbarfmt='%.2f', stationsongrids=self.stationsongrids, gdal_fmt='float32')
 
         if self.grid_delay_stdev:
             unique_points = self.df.groupby(['gridnode'])[self.col_name].std()
@@ -828,9 +847,9 @@ class RaiderStats(object):
             if self.grid_to_raster:
                 gridfile_name = os.path.join(self.workdir, self.col_name + '_' + 'grid_delay_stdev' + '.tif')
                 save_gridfile(self.grid_delay_stdev, 'grid_delay_stdev', gridfile_name, self.plotbbox, self.spacing, \
-                              self.unit, colorbarfmt='%.3f', stationsongrids=self.stationsongrids, gdal_fmt='float32')
+                              self.unit, colorbarfmt='%.2f', stationsongrids=self.stationsongrids, gdal_fmt='float32')
 
-    def __call__(self, gridarr, plottype, workdir='./', drawgridlines=False, colorbarfmt='%.3f', stationsongrids=None, resValue=5, plotFormat='pdf'):
+    def __call__(self, gridarr, plottype, workdir='./', drawgridlines=False, colorbarfmt='%.2f', stationsongrids=None, resValue=5, plotFormat='pdf'):
         '''
             Visualize a suite of statistics w.r.t. stations. Pass either a list of points or a gridded array as the first argument. Alternatively, you may superimpose your gridded array with a supplementary list of points by passing the latter through the stationsongrids argument.
         '''
@@ -862,8 +881,8 @@ class RaiderStats(object):
         # create the new map
         cmap = mpl.colors.LinearSegmentedColormap.from_list(
             'Custom cmap', cmaplist, cmap.N)
-        axes.set_xlabel('longitude', weight='bold', zorder=2)
-        axes.set_ylabel('latitude', weight='bold', zorder=2)
+        axes.set_xlabel('Longitude', weight='bold', zorder=2)
+        axes.set_ylabel('Latitude', weight='bold', zorder=2)
 
         # set ticks
         axes.set_xticks(np.linspace(
@@ -960,20 +979,18 @@ class RaiderStats(object):
 
         # Add labels to colorbar, if necessary
         if 'cbar_ax' in locals():
-            # experimental variogram fit range heatmap
-            if plottype == "range_heatmap":
-                cbar_ax.set_label(" ".join(plottype.split('_')) + ' (°)', rotation=-90, labelpad=10)
             # experimental variogram fit sill heatmap
-            elif plottype == "sill_heatmap":
-                cbar_ax.set_label(" ".join(plottype.split('_')) + ' ({}\u00b2)'.format(self.unit), rotation=-90, labelpad=10)
-            # specify appropriate units for mean/std
-            elif plottype == "grid_delay_mean" or plottype == "grid_delay_stdev" or \
+            if plottype == "grid_variance":
+                cbar_ax.set_label(" ".join(plottype.replace('grid_', '').split('_')).title() + ' ({}\u00b2)'.format(self.unit), 
+                                  rotation=-90, labelpad=10)
+            # specify appropriate units for mean/std/experimental variogram fit range heatmap
+            elif plottype == "grid_delay_mean" or plottype == "grid_delay_stdev" or  plottype == "grid_range" or \
                     plottype == "station_delay_mean" or plottype == "station_delay_stdev":
-                cbar_ax.set_label(" ".join(plottype.split('_')) + ' ({})'.format(self.unit),
+                cbar_ax.set_label(" ".join(plottype.replace('grid_', '').split('_')).title() + ' ({})'.format(self.unit),
                                   rotation=-90, labelpad=10)
             # gridmap of station density has no units
             else:
-                cbar_ax.set_label(" ".join(plottype.split('_')), rotation=-90, labelpad=10)
+                cbar_ax.set_label(" ".join(plottype.replace('grid_', '').split('_')).title(), rotation=-90, labelpad=10)
 
         # save/close figure
         plt.savefig(os.path.join(workdir, self.col_name + '_' + plottype + '.' + plotFormat),
@@ -994,6 +1011,7 @@ def stats_analyses(
     spacing,
     timeinterval,
     seasonalinterval,
+    figdpi,
     plot_fmt,
     cbounds,
     colorpercentile,
@@ -1018,6 +1036,9 @@ def stats_analyses(
     '''
     if verbose:
         logger.setLevel(logging.DEBUG)
+
+    # Control DPI for output figures
+    mpl.rcParams['savefig.dpi'] = figdpi
 
     # If user requests to generate all plots.
     if plotall:
@@ -1079,38 +1100,41 @@ def stats_analyses(
                  drawgridlines=drawgridlines, stationsongrids=stationsongrids, plotFormat=plot_fmt)
 
     # Perform variogram analysis
-    if variogramplot and not isinstance(df_stats.range_heatmap, np.ndarray) and not isinstance(df_stats.sill_heatmap, np.ndarray):
+    if variogramplot and not isinstance(df_stats.grid_range, np.ndarray) and not isinstance(df_stats.grid_variance, np.ndarray):
         logger.info("***Variogram Analysis Function:***")
         make_variograms = VariogramAnalysis(df_stats.df, df_stats.gridpoints, col_name, unit, workdir,
                                             df_stats.seasonalinterval, densitythreshold, binnedvariogram,
                                             numCPUs, variogram_per_timeslice)
         TOT_grids, TOT_res_robust_arr = make_variograms.create_variograms()
         # get range
-        df_stats.range_heatmap = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
+        df_stats.grid_range = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
             i[0])][0]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim).T
+        # convert range to specified output unit
+        # first multiply by 1,010,000 m as crude conversion from degrees to km
+        df_stats.grid_range = convert_SI(df_stats.grid_range, 'km', unit)
         # get sill
-        df_stats.sill_heatmap = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
+        df_stats.grid_variance = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
             i[0])][1]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim).T
         # If specified, save gridded array(s)
         if grid_to_raster:
-            gridfile_name = os.path.join(workdir, col_name + '_' + 'range_heatmap' + '.tif')
+            gridfile_name = os.path.join(workdir, col_name + '_' + 'grid_range' + '.tif')
             # write range
-            save_gridfile(df_stats.range_heatmap, 'grid_heatmap', gridfile_name, df_stats.plotbbox, df_stats.spacing, \
+            save_gridfile(df_stats.grid_range, 'grid_heatmap', gridfile_name, df_stats.plotbbox, df_stats.spacing, \
                           df_stats.unit, colorbarfmt='%1i', stationsongrids=df_stats.stationsongrids, gdal_fmt='float32')
-            gridfile_name = os.path.join(workdir, col_name + '_' + 'sill_heatmap' + '.tif')
+            gridfile_name = os.path.join(workdir, col_name + '_' + 'grid_variance' + '.tif')
             # write sill
-            save_gridfile(df_stats.sill_heatmap, 'grid_heatmap', gridfile_name, df_stats.plotbbox, df_stats.spacing, \
-                          df_stats.unit, colorbarfmt='%1i', stationsongrids=df_stats.stationsongrids, gdal_fmt='float32')
+            save_gridfile(df_stats.grid_variance, 'grid_heatmap', gridfile_name, df_stats.plotbbox, df_stats.spacing, \
+                          df_stats.unit, colorbarfmt='%.3e', stationsongrids=df_stats.stationsongrids, gdal_fmt='float32')
 
-    if isinstance(df_stats.range_heatmap, np.ndarray):
+    if isinstance(df_stats.grid_range, np.ndarray):
         # plot range heatmap
         logger.info("- Plot variogram range per gridcell.")
-        df_stats(df_stats.range_heatmap, 'range_heatmap', workdir=os.path.join(workdir, 'figures'),
-                 drawgridlines=drawgridlines, stationsongrids=stationsongrids, plotFormat=plot_fmt)
-    if isinstance(df_stats.sill_heatmap, np.ndarray):
+        df_stats(df_stats.grid_range, 'grid_range', workdir=os.path.join(workdir, 'figures'),
+                 colorbarfmt='%1i', drawgridlines=drawgridlines, stationsongrids=stationsongrids, plotFormat=plot_fmt)
+    if isinstance(df_stats.grid_variance, np.ndarray):
         # plot sill heatmap
         logger.info("- Plot variogram sill per gridcell.")
-        df_stats(df_stats.sill_heatmap, 'sill_heatmap', workdir=os.path.join(workdir, 'figures'), drawgridlines=drawgridlines,
+        df_stats(df_stats.grid_variance, 'grid_variance', workdir=os.path.join(workdir, 'figures'), drawgridlines=drawgridlines,
                  colorbarfmt='%.3e', stationsongrids=stationsongrids, plotFormat=plot_fmt)
 
 
@@ -1128,6 +1152,7 @@ if __name__ == "__main__":
         inps.spacing,
         inps.timeinterval,
         inps.seasonalinterval,
+        inps.figdpi,
         inps.plot_fmt,
         inps.cbounds,
         inps.colorpercentile,

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -302,7 +302,7 @@ class VariogramAnalysis():
         x, y = self._get_XY(x, y, indpars)
         dists = self._get_distances(
             np.array([[x[:, 0], y[:, 0]], [x[:, 1], y[:, 1]]]).T)
-        # TODO temp fix first multiply by 110,000 m as crude conversion from degrees to km
+        # TODO temp fix first multiply by 110,000 m as crude conversion from degrees to m
         dists = dists*110000
         vario = self._get_variogram(samples[:, 0], samples[:, 1])
 
@@ -550,25 +550,25 @@ class VariogramAnalysis():
                 timeslice[6:8]), int(timeslice[-4:-2]), int(timeslice[-2:]))
 
         if dists is not None and vario is not None:
-            # scale from m to km
-            dists = [convert_SI(i, 'm', 'km') for i in dists]
+            # scale from m to user-defined units
+            dists = [convert_SI(i, 'm', self.unit) for i in dists]
             plt.scatter(dists, vario, s=1, facecolor='0.5', label='raw')
         if dists_binned is not None and vario_binned is not None:
-            # scale from m to km
-            dists_binned = [convert_SI(i, 'm', 'km') for i in dists_binned]
+            # scale from m to user-defined units
+            dists_binned = [convert_SI(i, 'm', self.unit) for i in dists_binned]
             plt.plot(dists_binned, vario_binned, 'bo', label='binned')
         if res_robust is not None:
             plt.axhline(y=res_robust[1], color='g',
                         linestyle='--', label='ɣ\u0332\u00b2({}\u00b2)'.format(self.unit))
-            # scale from m to km
-            res_robust[0] = convert_SI(res_robust[0], 'm', 'km')
+            # scale from m to user-defined units
+            res_robust[0] = convert_SI(res_robust[0], 'm', self.unit)
             plt.axvline(x=res_robust[0], color='c',
-                        linestyle='--', label='h (m)')
+                        linestyle='--', label='h ({})'.format(self.unit))
         if d_test is not None and v_test is not None:
-            # scale from m to km
-            d_test = [convert_SI(i, 'm', 'km') for i in d_test]
+            # scale from m to user-defined units
+            d_test = [convert_SI(i, 'm', self.unit) for i in d_test]
             plt.plot(d_test, v_test, 'r-', label='experimental fit')
-        plt.xlabel('Distance (km)')
+        plt.xlabel('Distance ({})'.format(self.unit))
         plt.ylabel('Dissimilarity ({}\u00b2)'.format(self.unit))
         plt.legend(bbox_to_anchor=(1.02, 1),
                    loc='upper left', borderaxespad=0., framealpha=1.)
@@ -1110,8 +1110,7 @@ def stats_analyses(
         df_stats.grid_range = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
             i[0])][0]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim).T
         # convert range to specified output unit
-        # first multiply by 110,000 m as crude conversion from degrees to km
-        df_stats.grid_range = convert_SI(df_stats.grid_range, 'km', unit)
+        df_stats.grid_range = convert_SI(df_stats.grid_range, 'm', unit)
         # get sill
         df_stats.grid_variance = np.array([np.nan if i[0] not in TOT_grids else float(TOT_res_robust_arr[TOT_grids.index(
             i[0])][1]) for i in enumerate(df_stats.gridpoints)]).reshape(df_stats.grid_dim).T

--- a/tools/bin/raiderStats.py
+++ b/tools/bin/raiderStats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/data2/ssangha/conda_installation/stable_jan10_2020/ariatools_conda/envs/RAiDER/bin/python3
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Simran Sangha, Jeremy Maurer, & David Bekaert
@@ -22,6 +22,7 @@ if __name__ == "__main__":
         inps.spacing,
         inps.timeinterval,
         inps.seasonalinterval,
+        inps.figdpi,
         inps.plot_fmt,
         inps.cbounds,
         inps.colorpercentile,

--- a/tools/bin/raiderStats.py
+++ b/tools/bin/raiderStats.py
@@ -1,4 +1,4 @@
-#!/data2/ssangha/conda_installation/stable_jan10_2020/ariatools_conda/envs/RAiDER/bin/python3
+#!/usr/bin/env python3
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Simran Sangha, Jeremy Maurer, & David Bekaert


### PR DESCRIPTION
Supports series of fixes outlined in #202, namely:
- Rounding of the colorbar ticks to two decimal points for floating values (as opposed to integer heatmaps of station locations).
- Variogram range to be reported in km units. Currently crude factor of 1010km applied, to be updated in PR #203 
- Remove the wording heatmap from the colorbar title
- Change "sill" to "Variance" and "range" to "Range"; "latitude" to "Latitude"; "longitude" to "Longitude"
- Ability to improve the dpm for the Figures, now toggled with ```-figdpi``` option
- Ability to change units of loaded arrays.