### PR TITLE
Fix several bugs related to CDS API and some general clean-up

### DIFF
--- a/tools/RAiDER/models/era5.py
+++ b/tools/RAiDER/models/era5.py
@@ -4,6 +4,7 @@ import numpy as np
 from pyproj import CRS
 
 from RAiDER.models.ecmwf import ECMWF
+from RAiDER.logger import *
 
 
 class ERA5(ECMWF):
@@ -87,9 +88,13 @@ class ERA5(ECMWF):
         lat_min, lat_max, lon_min, lon_max = self._get_ll_bounds(lats, lons, Nextra)
 
         # execute the search at ECMWF
-        self._get_from_cds(
-            lat_min, lat_max, self._lat_res, lon_min, lon_max, self._lon_res, time,
-            out)
+        try:
+            self._get_from_cds(
+                lat_min, lat_max, self._lat_res, lon_min, lon_max, self._lon_res, time,
+                out)
+        except Exception as e:
+            logger.warning(e)
+            raise RuntimeError('Could not access or download from the CDS API')
 
     def load_weather(self, f):
         self._load_pressure_level(f)

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -26,10 +26,6 @@ class WeatherModel(ABC):
     '''
 
     def __init__(self):
-        # Without these two lines, logging.debug won't work. It is a bit weird but it works out so far.
-        import cdsapi
-        c = cdsapi.Client(verify=0)
-        
         # Initialize model-specific constants/parameters
         self._k1 = None
         self._k2 = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- There were two lines in weatherModel.py that queried the CDS API, with a note that the logger wouldn't work without them. However, I tested removing them and the logger worked just fine. We definitely don't want those lines there because not all models use the CDS API. 
- Refactored to better handle errors when the config file for CDS API is missing or the server can't be reached
- Added a note that WRF or HDF5 are not fully implemented if a user calls those
- Fixed a few misc bugs related to passing height levels for only the weather model nodes that I found while testing above
- Cleaned up some formatting

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Improves error messaging and gets rid of problematic call to CDS API in base weatherModel class

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
- Unit tests pass locally

<!--- For new functionality, describe added unit tests. -->


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what the changes do and why I'd like us to include them.
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully ran tests with my changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
