### PR TITLE
Fix multiparallel processing bug

### DIFF
--- a/tools/RAiDER/runProgram.py
+++ b/tools/RAiDER/runProgram.py
@@ -154,30 +154,46 @@ def parseCMD():
 
     if args['verbose']: logger.setLevel(logging.DEBUG)
 
-    # if pararallel processing is requested then call multi-processing approach
+    # Package arguments for processing
+    allTimesFiles = zip(
+            args['times'], 
+            args['wetFilenames'],
+            args['hydroFilenames']
+        )
+
+    allTimesFiles_chunk = np.array_split(
+            list(allTimesFiles), 
+            args['parallel']
+        )
+
+    lst_new_args  = []
+    for chunk in allTimesFiles_chunk:
+        if chunk.size == 0: continue
+        times, wetFilenames, hydroFilenames = chunk.transpose()
+        args_copy = copy.deepcopy(args)
+        args_copy['times']=times.tolist()
+        args_copy['wetFilenames']=wetFilenames.tolist()
+        args_copy['hydroFilenames']=hydroFilenames.tolist()
+        lst_new_args.append(args_copy)
+
+    # multi-processing approach
     if not args['parallel']==1:
+        if not args['download_only']:
+            raise RuntimeError('Cannot process multiple delay calculations in parallel,' \
+                    ' either specify --download_only or set parallel = 1')
 
-        # split the args evenly across the number of concurrent jobs
-        allTimesFiles = zip(args['times'], args['wetFilenames'],args['hydroFilenames'])
-        allTimesFiles_chunk = np.array_split(list(allTimesFiles), args['parallel'])
-        lst_new_args  = []
-
-        for chunk in allTimesFiles_chunk:
-            if chunk.size == 0: continue
-            times, wetFilenames, hydroFilenames = chunk.transpose()
-            args_copy = copy.deepcopy(args)
-            args_copy['times']=times.tolist()
-            args_copy['wetFilenames']=wetFilenames.tolist()
-            args_copy['hydroFilenames']=hydroFilenames.tolist()
-            lst_new_args.append(args_copy)
-
-        with multiprocessing.Pool(len(lst_new_args)) as pool:
+        # split the args across the number of concurrent jobs
+        Nprocs = len(lst_new_args)
+        with multiprocessing.Pool(Nprocs) as pool:
             pool.map(_tropo_delay, lst_new_args)
 
+    # Otherwise a regular for-loop
     else:
-        _tropo_delay(args)
+        for new_args in lst_new_args:
+            _tropo_delay(new_args)
 
     return
+
 
 def _tropo_delay(args):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds in a simple for-loop option for processing delays for multiple dates.

## Description
<!--- Describe your changes in detail -->
- multiprocessing works when download_only option is called, but the delays are already individually parallelized so the current implementation breaks if the delay calculation is attempted
- This PR implements a simple way to run delay calculations for multiple dates without requiring parallelization
- Is still based on user input, but now raises a RuntimeError if parallel > 1 and download_only is False.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #206 for now; later enhancements to improve the overall parallelization strategy
Replaces #230 

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
- Passes unit tests locally

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
