### PR TITLE
Filter out NaNs properly

### DIFF
--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -907,7 +907,7 @@ class RaiderStats(object):
 
         # map gridnode dictionary to dataframe
         self.df['gridnode'] = self.df['ID'].map(idtogrid_dict)
-        self.df.dropna(how='any', inplace=True)
+        self.df = self.df[self.df['gridnode'].astype(str) != 'NaN']
         del self.unique_points, self.polygon_dict, self.polygon_tree, idtogrid_dict, append_poly
         # sort by grid and date
         self.df.sort_values(['gridnode', 'Date'])


### PR DESCRIPTION
To prevent integer fields from being converted to float, NaN values must be passed as strings (i.e. as 'NaN'). However, the 'pandas.dropna" function doesn't recognize such strings in integer fields. Thus, NaNs must be filtered out as specified in this edit.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->


<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
