### PR TITLE
Add option to download GNSS in steps

### DIFF
--- a/tools/RAiDER/downloadGNSSDelays.py
+++ b/tools/RAiDER/downloadGNSSDelays.py
@@ -10,11 +10,12 @@ import argparse
 import itertools
 import multiprocessing
 import os
-
 import pandas as pd
 import requests
+from textwrap import dedent
 
 from RAiDER.cli.parser import add_cpus, add_out, add_verbose
+from RAiDER.cli.validators import DateListAction, date_type
 from RAiDER.logger import *
 from RAiDER.getStationDelays import get_station_data
 from RAiDER.utilFcns import requests_retry_session
@@ -31,25 +32,30 @@ def create_parser():
 Check for and download tropospheric zenith delays for a set of GNSS stations from UNR
 
 Example call to virtually access and append zenith delay information to a CSV table in specified output
-directory, across specified range of years and all available times of day, and confined to specified
+directory, across specified range of time (in YYMMDD YYMMDD) and all available times of day, and confined to specified
 geographic bounding box :
-downloadGNSSdelay.py --out products -y '2010,2014' -b '39 40 -79 -78'
+downloadGNSSdelay.py --out products -y 20100101 20141231 -b '39 40 -79 -78'
 
 Example call to virtually access and append zenith delay information to a CSV table in specified output
-directory, across specified range of years and specified time of day, and distributed globally :
-downloadGNSSdelay.py --out products -y '2010,2014' --returntime '00:00:00' -f station_list.txt
+directory, across specified range of time (in YYMMDD YYMMDD) and specified time of day, and distributed globally :
+downloadGNSSdelay.py --out products -y 20100101 20141231 --returntime '00:00:00'
+
 
 Example call to virtually access and append zenith delay information to a CSV table in specified output
-directory, across specified range of years and specified time of day, and distributed globally but restricted
+directory, across specified range of time in 12 day steps (in YYMMDD YYMMDD days) and specified time of day, and distributed globally :
+downloadGNSSdelay.py --out products -y 20100101 20141231 12 --returntime '00:00:00'
+
+Example call to virtually access and append zenith delay information to a CSV table in specified output
+directory, across specified range of time (in YYMMDD YYMMDD) and specified time of day, and distributed globally but restricted
 to list of stations specified in input textfile :
-downloadGNSSdelay.py --out products -y '2010,2014' --returntime '00:00:00' -f station_list.txt
+downloadGNSSdelay.py --out products -y 20100101 20141231 --returntime '00:00:00' -f station_list.txt
 
 NOTE, following example call to physically download zenith delay information not recommended as it is not
 necessary for most applications.
 Example call to physically download and append zenith delay information to a CSV table in specified output
-directory, across specified range of years and specified time of day, and confined to specified
+directory, across specified range of time (in YYMMDD YYMMDD) and specified time of day, and confined to specified
 geographic bounding box :
-downloadGNSSdelay.py --download --out products -y '2010,2014' --returntime '00:00:00' -b '39 40 -79 -78'
+downloadGNSSdelay.py --download --out products -y 20100101 20141231 --returntime '00:00:00' -b '39 40 -79 -78'
 """)
 
     # Stations to check/download
@@ -69,10 +75,20 @@ downloadGNSSdelay.py --download --out products -y '2010,2014' --returntime '00:0
     add_out(misc)
 
     misc.add_argument(
-        '--years', '-y', dest='years',
-        help="""Year to check or download delays (format YYYY).
-Can be a single value or a comma-separated list. If two years non-consecutive years are given, download each year in between as well.
-""", type=parse_years, required=True)
+        '--date', dest='dateList',
+        help=dedent("""\
+            Date to calculate delay.
+            Can be a single date, a list of two dates (earlier, later) with 1-day interval, or a list of two dates and interval in days (earlier, later, interval).
+            Example accepted formats:
+               YYYYMMDD or
+               YYYYMMDD YYYYMMDD
+               YYYYMMDD YYYYMMDD N
+            """),
+        nargs="+",
+        action=DateListAction,
+        type=date_type,
+        required=True
+    )
 
     misc.add_argument(
         '--returntime', dest='returnTime',
@@ -272,23 +288,12 @@ def get_ID(line):
     return stat_id, float(lat), float(lon), float(height)
 
 
-def parse_years(timestr):
-    '''
-    Takes string input and returns a list of years as integers
-    '''
-    years = list(map(int, timestr.split(',')))
-    # If two years non-consecutive years are given, query for each year in between
-    if len(years) == 2:
-        years = list(range(years[0], years[1] + 1))
-    return years
-
-
 def query_repos(
     station_file,
     bounding_box,
     gps_repo,
     out,
-    years,
+    dateList,
     returnTime,
     download,
     cpus,
@@ -347,6 +352,7 @@ def query_repos(
             bbox=bbox, writeLoc=out, userstatList=station_file)
 
     # iterate over years
+    years = list(set([i.year for i in dateList]))
     download_tropo_delays(
         stats, years, gps_repo=gps_repo, writeDir=out, download=download
     )
@@ -362,8 +368,10 @@ def query_repos(
     del origstatsFile, statsFile
 
     # Extract delays for each station
+    dateList = [k.strftime('%Y-%m-%d') for k in dateList]
     get_station_data(
         os.path.join(out, '{}gnssStationList_overbbox_withpaths.csv'.format(gps_repo)),
+        dateList,
         gps_repo=gps_repo,
         numCPUs=cpus,
         outDir=out,
@@ -381,7 +389,7 @@ if __name__ == "__main__":
         inps.bounding_box,
         inps.gps_repo,
         inps.out,
-        inps.years,
+        inps.dateList,
         inps.returnTime,
         inps.download,
         inps.cpus,

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -223,7 +223,9 @@ def load_gridfile(fname, unit):
 
     df = gdal.Open(fname)
     grid_array = df.ReadAsArray()
-    grid_array = np.ma.masked_where(grid_array == 0, grid_array)
+    # set masked values as nans
+    grid_array = np.ma.masked_where(grid_array == np.nan, grid_array)
+    grid_array = np.ma.filled(grid_array, np.nan)
 
     # Read metadata variables needed for plotting
     metadata_dict = df.GetMetadata_Dict()
@@ -1346,7 +1348,10 @@ class RaiderStats(object):
                     'physical', 'land', '50m', facecolor='#A9A9A9'), zorder=0)
                 axes.add_feature(cfeature.NaturalEarthFeature(
                     'physical', 'ocean', '50m', facecolor='#ADD8E6'), zorder=0)
+                # set masked values as nans
                 zvalues = gridarr[2]
+                zvalues = np.ma.masked_where(zvalues == np.nan, zvalues)
+                zvalues = np.ma.filled(zvalues, np.nan)
                 # define the bins and normalize
                 if cbounds is None:
                     cbounds = [np.nanpercentile(zvalues, self.colorpercentile[0]), np.nanpercentile(
@@ -1358,7 +1363,6 @@ class RaiderStats(object):
                 colorbounds = np.linspace(cbounds[0], cbounds[1], 10)
 
                 norm = mpl.colors.BoundaryNorm(colorbounds, cmap.N)
-                zvalues = np.ma.masked_where(zvalues == 0, zvalues)
 
                 # plot data and initiate colorbar
                 im = axes.scatter(gridarr[0], gridarr[1], c=zvalues, cmap=cmap, norm=norm,
@@ -1371,6 +1375,9 @@ class RaiderStats(object):
 
         # If gridded area passed
         else:
+            # set masked values as nans
+            gridarr = np.ma.masked_where(gridarr == np.nan, gridarr)
+            gridarr = np.ma.filled(gridarr, np.nan)
             # set land/water background to light gray/blue respectively so grid cells can be seen
             axes.add_feature(cfeature.NaturalEarthFeature(
                 'physical', 'land', '50m', facecolor='#A9A9A9'), zorder=0)
@@ -1387,7 +1394,6 @@ class RaiderStats(object):
 
             colorbounds = np.linspace(cbounds[0], cbounds[1], 10)
             norm = mpl.colors.BoundaryNorm(colorbounds, cmap.N)
-            gridarr = np.ma.masked_where(gridarr == np.nan, gridarr)
 
             # plot data
             im = axes.imshow(gridarr, cmap=cmap, norm=norm, extent=self.plotbbox,

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -225,6 +225,7 @@ def load_gridfile(fname, unit):
     grid_array = df.ReadAsArray()
     # set masked values as nans
     grid_array = np.ma.masked_where(grid_array == np.nan, grid_array)
+    grid_array = np.ma.masked_where(grid_array == np.inf, grid_array)
     grid_array = np.ma.filled(grid_array, np.nan)
 
     # Read metadata variables needed for plotting
@@ -1351,6 +1352,7 @@ class RaiderStats(object):
                 # set masked values as nans
                 zvalues = gridarr[2]
                 zvalues = np.ma.masked_where(zvalues == np.nan, zvalues)
+                zvalues = np.ma.masked_where(zvalues == np.inf, zvalues)
                 zvalues = np.ma.filled(zvalues, np.nan)
                 # define the bins and normalize
                 if cbounds is None:
@@ -1377,6 +1379,7 @@ class RaiderStats(object):
         else:
             # set masked values as nans
             gridarr = np.ma.masked_where(gridarr == np.nan, gridarr)
+            gridarr = np.ma.masked_where(gridarr == np.inf, gridarr)
             gridarr = np.ma.filled(gridarr, np.nan)
             # set land/water background to light gray/blue respectively so grid cells can be seen
             axes.add_feature(cfeature.NaturalEarthFeature(

--- a/tools/bin/raiderDownloadGNSS.py
+++ b/tools/bin/raiderDownloadGNSS.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
         inps.bounding_box,
         inps.gps_repo,
         inps.out,
-        inps.years,
+        inps.dateList,
         inps.returnTime,
         inps.download,
         inps.cpus,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated ```raiderDownloadGNSS.py``` to support specification of time-step in days, in a way that mirrors the ```--date``` option through ```raiderDelay.py```

## Motivation and Context
Before, GNSS data for each day across a specified interval (if available) was downloaded. This can be very time-consuming and inefficient, especially if this level of temporal sampled was not needed.

## How Has This Been Tested?
As an example run, download in 12-day increments across the year 2019 as so:
```raiderDownloadGNSS.py --out GNSS --date 20190101 20191231 12 --returntime '00:00:00' --bounding_box '36 40 -124 -119' --cpus 12```


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Note that the user now specified input time with the ```--date``` flag (before it was ```-year```) to mirror input time to the ```radarDelay.py``` function.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [X ] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
