### PR TITLE
Address warning + adjust colorbars

### DIFF
--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -174,7 +174,7 @@ def convert_SI(val, unit_in, unit_out):
     return val * SI[unit_in] / SI[unit_out]
 
 
-def save_gridfile(df, gridfile_type, fname, plotbbox, spacing, unit, colorbarfmt='%.2f', stationsongrids=False, gdal_fmt='float32'):
+def save_gridfile(df, gridfile_type, fname, plotbbox, spacing, unit, colorbarfmt='%.2f', stationsongrids=False, gdal_fmt='float32', noData=np.nan):
     '''
         Function to save gridded-arrays as GDAL-readable file.
     '''
@@ -209,7 +209,7 @@ def save_gridfile(df, gridfile_type, fname, plotbbox, spacing, unit, colorbarfmt
     # update with nodata val
     gdalfile.GetRasterBand(1).SetNoDataValue(np.nan)
     # Finalize VRT
-    gdal.Translate(fname + '.vrt', gdalfile, options=gdal.TranslateOptions(format="VRT", noData=np.nan))
+    gdal.Translate(fname + '.vrt', gdalfile, options=gdal.TranslateOptions(format="VRT", noData=noData))
 
     gdalfile = None
 
@@ -923,13 +923,14 @@ class RaiderStats(object):
 
         # If specified, setup gridded array(s)
         if self.grid_heatmap:
-            self.grid_heatmap = np.array([np.nan if i[0] not in self.df['gridnode'].values[:] else float(len(np.unique(
+            self.grid_heatmap = np.array([np.nan if i[0] not in self.df['gridnode'].values[:] else int(len(np.unique(
                 self.df['ID'][self.df['gridnode'] == i[0]]))) for i in enumerate(self.gridpoints)]).reshape(self.grid_dim).T
             # If specified, save gridded array(s)
             if self.grid_to_raster:
                 gridfile_name = os.path.join(self.workdir, self.col_name + '_' + 'grid_heatmap' + '.tif')
                 save_gridfile(self.grid_heatmap, 'grid_heatmap', gridfile_name, self.plotbbox, self.spacing, \
-                              self.unit, colorbarfmt='%1i', stationsongrids=self.stationsongrids, gdal_fmt='int16')
+                              self.unit, colorbarfmt='%1i', stationsongrids=self.stationsongrids, gdal_fmt='int16', \
+                              noData=0)
 
         if self.grid_delay_mean:
             # Take mean of station-wise means per gridcell

--- a/tools/RAiDER/statsPlot.py
+++ b/tools/RAiDER/statsPlot.py
@@ -1366,7 +1366,10 @@ class RaiderStats(object):
                 colorbounds = np.linspace(cbounds[0], cbounds[1], 10)
 
                 norm = mpl.colors.BoundaryNorm(colorbounds, cmap.N)
-
+                
+                # if range small, adjust precision for colorbar
+                if abs(np.nanmax(zvalues)-np.nanmin(zvalues)) < 1:
+                    colorbarfmt = '%.3f'
                 # plot data and initiate colorbar
                 im = axes.scatter(gridarr[0], gridarr[1], c=zvalues, cmap=cmap, norm=norm,
                                   zorder=1, s=0.5, marker='.', transform=ccrs.PlateCarree())
@@ -1399,6 +1402,9 @@ class RaiderStats(object):
             colorbounds = np.linspace(cbounds[0], cbounds[1], 10)
             norm = mpl.colors.BoundaryNorm(colorbounds, cmap.N)
 
+            # if range small, adjust precision for colorbar
+            if abs(np.nanmax(gridarr)-np.nanmin(gridarr)) < 1:
+                colorbarfmt = '%.3f'
             # plot data
             im = axes.imshow(gridarr, cmap=cmap, norm=norm, extent=self.plotbbox,
                              zorder=1, origin='upper', transform=ccrs.PlateCarree())


### PR DESCRIPTION
## Description
Minor warning when saving INT format files (e.g. heatmaps) was being raised because the nodata value was set to nan. For such INT format files, the nodata value is toggled to 0 to avoid this warning.

Also, if the range of plotted values is too small (e.g. as is usually the case for residual/stdev plots), then the colorbar range must be adjusted to avoid useless colorbars.

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
