### PR TITLE
Add error options

### DIFF
--- a/tools/bin/raiderStats.py
+++ b/tools/bin/raiderStats.py
@@ -22,6 +22,7 @@ if __name__ == "__main__":
         inps.spacing,
         inps.timeinterval,
         inps.seasonalinterval,
+        inps.obs_errlimit,
         inps.figdpi,
         inps.user_title,
         inps.plot_fmt,
@@ -50,5 +51,6 @@ if __name__ == "__main__":
         inps.period_limit,
         inps.variogramplot,
         inps.binnedvariogram,
-        inps.variogram_per_timeslice
+        inps.variogram_per_timeslice,
+        inps.variogram_errlimit
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Users may now control the variogram rmse threshold with the `—variogram_errlimit` option (#282 ), and station-wise error threshold with the `--obs_errlimit` option (#283 )

Also added support to convert between squared units if specified (i.e. m^2 to cm^2), of relevance to the sill value which was originally forced to remain in units m^2 irregardless of user inputs.

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->


<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
