### PR TITLE
Add all models scenario 1 update

### DIFF
--- a/tools/RAiDER/models/gmao.py
+++ b/tools/RAiDER/models/gmao.py
@@ -140,9 +140,13 @@ class GMAO(WeatherModel):
 
         try:
             # Note that lat/lon gets written twice for GMAO because they are the same as y/x
+            writeWeatherVars2NETCDF4(self, lats, lons, h.data, q.data, p.data, t.data, outName=out)
+        except AttributeError:
             writeWeatherVars2NETCDF4(self, lats, lons, h, q, p, t, outName=out)
-        except Exception:
+        except Exception as e:
+            logger.debug(e)
             logger.exception("Unable to save weathermodel to file")
+            raise RuntimeError('GMAO failed with the following error: {}'.format(e))
 
     def load_weather(self, f=None):
         '''

--- a/tools/RAiDER/models/hres.py
+++ b/tools/RAiDER/models/hres.py
@@ -244,7 +244,6 @@ class HRES(WeatherModel):
             lnsp = np.squeeze(block['lnsp'].values)[0, ...]
             lats = np.squeeze(block.latitude.values)
             lons = np.squeeze(block.longitude.values)
-            
             xs = lons.copy()
             ys = lats.copy()
 
@@ -289,3 +288,4 @@ class HRES(WeatherModel):
             'area': "{}/{}/{}/{}".format(lat_max, lon_min, lat_min, lon_max),
             'format': "netcdf", },
             out)
+

--- a/tools/RAiDER/models/merra2.py
+++ b/tools/RAiDER/models/merra2.py
@@ -128,7 +128,6 @@ class MERRA2(WeatherModel):
             logger.exception("MERRA-2: Unable to read weathermodel data")
         ########################################################################################################################
     
-
         try:
             writeWeatherVars2NETCDF4(self, lats, lons, h, q, p, t, outName=out)
         except Exception as e:

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -143,17 +143,14 @@ def prepareWeatherModel(
 def checkBounds(weather_model, outLats, outLons):
     '''Check the bounds of a weather model'''
     ds = xr.load_dataset(weather_model.files[0])
-    
     try:
         xc = convertLons(ds.longitude.values)
     except AttributeError:
         xc = convertLons(ds.x.values)
-    
     try:
         yc = ds.latitude.values
     except AttributeError:
         yc = ds.y.values
-    
     lat_bounds = [yc.min(), yc.max()]
     lon_bounds = [xc.min(), xc.max()]
     self_extent = lat_bounds + lon_bounds

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -807,14 +807,12 @@ def write2NETCDF4core(nc_outfile, dimension_dict, dataset_dict, tran, mapping_na
         var.setncattr('description', dataset_dict[data]['description'])
         if 'units' in dataset_dict[data]:
             var.setncattr('units', dataset_dict[data]['units'])
-
         ndmask = np.isnan(dataset_dict[data]['dataset'])
         dataset_dict[data]['dataset'][ndmask] = FillValue
 
         var[:] = dataset_dict[data]['dataset'].astype(datatype)
 
     return nc_outfile
-
 
 def convertLons(inLons):
     '''Convert lons from 0-360 to -180-180'''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fixes some bugs in the original PR #285 

## Description
<!--- Describe your changes in detail -->
This PR adds all other weather models besides ERA5 for test scenario 1. For each model, there is a sub-folder named by that model, i.e. RAiDER/test/scenario_1/GMAO/, containing all the wet and hydrostatic results in both envi and header format. The test_scenario_1.py file has been updated with a number of sub-tests for all of the models: 6 for now and NCMR is to be included soon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->


<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.