### PR TITLE
Issue 303

### DIFF
--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -402,7 +402,8 @@ class WeatherModel(ABC):
 
     def checkContainment(self: weatherModel,
                          outLats: np.ndarray,
-                         outLons: np.ndarray) -> bool:
+                         outLons: np.ndarray,
+                         buffer_deg: float = 1e-5) -> bool:
         """"
         Checks containment of weather model bbox of outLats and outLons
         provided.
@@ -414,6 +415,10 @@ class WeatherModel(ABC):
             An array of latitude points
         outLons : np.ndarray
             An array of longitude points
+        buffer_deg : float
+            For x-translates for extents that lie outside of world bounding box,
+            this ensures that translates have some overlap. The default is 1e-5
+            or ~11.1 meters.
 
         Returns
         -------
@@ -445,9 +450,13 @@ class WeatherModel(ABC):
         # Look at two x-translates, buffer them, and take their union.
         world_box = box(-180, -90, 180, 90)
         if not world_box.contains(weather_model_box):
-            translates = [weather_model_box.buffer(1e-8),
-                          translate(weather_model_box, xoff=360).buffer(1e-8),
-                          translate(weather_model_box, xoff=-360).buffer(1e-8)
+            logger.info('Considering x-translates of weather model +/-360 '
+                        'as bounding box outside of -180, -90, 180, 90')
+            translates = [weather_model_box.buffer(buffer_deg),
+                          translate(weather_model_box,
+                                    xoff=360).buffer(buffer_deg),
+                          translate(weather_model_box,
+                                    xoff=-360).buffer(buffer_deg)
                           ]
             weather_model_box = unary_union(translates)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the weather model's bounds are outside `-180, -90, 180, 90`, then perform translations in the `x` (or longitudinal) direction by `+/- 360` and then take the union. This is done with shapely.

The basis of this is this code snippet:

```
from shapely.geometry import box
from shapely.affinity import translate
from shapely.ops import unary_union

weather_model_box = box(-180.04, -90.04, 179.96, 90.04)
input_box = box( -180.00, -90.00, 180.00, 90.00)

world_box = box(-180, -90, 180, 90)
if not world_box.contains(weather_model_box):
    translates = [weather_model_box.buffer(1e-8),
                  translate(weather_model_box, xoff=360).buffer(1e-8),
                  translate(weather_model_box, xoff=-360).buffer(1e-8)
                  ]
    weather_model_box_new = unary_union(translates)

weather_model_box_new.contains(input_box), weather_model_box.contains(input_box)
```
Whose output is now `True, False`.

## Motivation and Context

HRES bounds are outside the said bounds.

```
(RAiDER) --- APS_analysis/HRES » raiderDelay.py --time 06:00 --model HRES --date 20140803  --download_only --bbox -90 90 -180 180
WARNING: Weather model already exists, please remove it ("['./weather_files/HRES_2014_08_03_T06_00_00.nc']") if you want to download a new one.
/u/leffe-data2/cmarshak/miniconda3/envs/RAiDER/lib/python3.7/site-packages/rasterio/__init__.py:207: NotGeoreferencedWarning: Dataset has no geotransform, gcps, or rpcs. The identity matrix be returned.
  s = DatasetReader(path, driver=driver, sharing=sharing, **kwargs)
Extent of the weather model lats/lons is:-180.04, -90.04, 179.96, 90.04
Extent of the input lats/lons is: -180.00, -90.00, 180.00, 90.00
ERROR: The weather model passed does not cover all of the input points; you need to download a larger area.
ERROR: Date 2014-08-03 06:00:00 failed
Traceback (most recent call last):
  File "/u/leffe-data2/cmarshak/miniconda3/envs/RAiDER/lib/python3.7/site-packages/RAiDER/runProgram.py", line 208, in _tropo_delay
    (_, _) = tropo_delay(args_copy)
  File "/u/leffe-data2/cmarshak/miniconda3/envs/RAiDER/lib/python3.7/site-packages/RAiDER/delay.py", line 121, in tropo_delay
    makePlots=True
  File "/u/leffe-data2/cmarshak/miniconda3/envs/RAiDER/lib/python3.7/site-packages/RAiDER/processWM.py", line 72, in prepareWeatherModel
    'The weather model passed does not cover all of the input '
RuntimeError: The weather model passed does not cover all of the input points; you need to download a larger area.
```

## How Has This Been Tested?

This is not adequately tested and the above snippet needs to be included into the unit tests. TBD.


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
