### PR TITLE
Update pyproj requirement

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,7 @@ dependencies:
  - pandas
  - progressbar
  - pygrib
- - pyproj>=2.1.0
+ - pyproj>=2.2.0
  - scipy
  - xarray
  - shapely

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
  - progressbar
  - pydap>3.2.2|<3.2.2
  - pygrib
- - pyproj>=2.1.0
+ - pyproj>=2.2.0
  - pytest
  - pytest-timeout
  - rasterio


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See #308 for rationale. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our current version of pyproj required is >=2.1.0, however this is inconsistent with the "always_xy" argument and with geopandas, which is now a requirement. 

