### PR TITLE
Initial fix for converting weather model heights to ellipsoidal

### DIFF
--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -59,7 +59,6 @@ class HRRR(WeatherModel):
         earth_radius = 6371229
         p1 = CRS('+proj=lcc +lat_1={lat1} +lat_2={lat2} +lat_0={lat0} +lon_0={lon0} +x_0={x0} +y_0={y0} +a={a} +b={a} +units=m +no_defs'.format(lat1=lat1, lat2=lat2, lat0=lat0, lon0=lon0, x0=x0, y0=y0, a=earth_radius))
         self._proj = p1
-        self._vproj = CRS.from_epsg(5171) # Assume EGM96 by default
 
 
     def _fetch(self, lats, lons, time, out, Nextra=2):

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -18,7 +18,7 @@ class HRRR(WeatherModel):
         WeatherModel.__init__(self)
 
         self._humidityType = 'q'
-        self._model_level_type = 'pl'  # Default, pressure levels are 'pl'
+        self._model_level_type = 'pl'
         self._expver = '0001'
         self._classname = 'hrrr'
         self._dataset = 'hrrr'
@@ -59,6 +59,7 @@ class HRRR(WeatherModel):
         earth_radius = 6371229
         p1 = CRS('+proj=lcc +lat_1={lat1} +lat_2={lat2} +lat_0={lat0} +lon_0={lon0} +x_0={x0} +y_0={y0} +a={a} +b={a} +units=m +no_defs'.format(lat1=lat1, lat2=lat2, lat0=lat0, lon0=lon0, x0=x0, y0=y0, a=earth_radius))
         self._proj = p1
+        self._vproj = CRS.from_epsg(5171) # Assume EGM96 by default
 
 
     def _fetch(self, lats, lons, time, out, Nextra=2):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Problem: the DEM is ellipsoidal heights, while the weather model heights are geoidal
Potential fix: Convert the weather model heights to ellipsoidal before saving the NETCDF file

## Description
<!--- Describe your changes in detail -->
- This solution is based on  @cmarshak 's [dem_stitcher](https://github.com/aria-jpl/dem_stitcher) program, but implements a separate version of the correction that works with NDarrays instead of rasters. 
- The idea is simple: download a geoid correction from AGISOFT, interpolate to the weather model grid nodes, and then add the correction to the z-values of the weather model grid
- Uses the efficient [RegularGridInterpolator](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html) in scipy, which is also used elsewhere in the code. 
- No new dependencies introduced
- Main functionality is in the `_convert_z_to_ellipsoid` method of the base weather model class. 
- This PR also contains a bug fix for the _get_ll_bounds method

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #293 

## Caveats / Remaining Issues
- It's not currently clear to me what geoid correction to use. In the linked issue (#293) I reference the ECMWF page that states geoidal heights are in EGM96. However, I don't see how EGM08 would be incorrect to use (everything gets calculated from the geopotential), and as it's a better geoid maybe we ought to use that one instead of EGM96. 
- The same issue holds for the other weather models that are not ECMWF - is it correct to use a generic geoid for them? May need to reach out to ECMWF folks to get an idea of what is correct on this front. 
- Along with these issues we should probably document the code a little bit better about the issues with vertical projections

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
- Methodology has been tested for consistency
- Need to add unit tests (can be done before merging)
- Need to format to match autopep8 (can be done before merging)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
