### PR TITLE
fix some comments in LOS and ZREF

### DIFF
--- a/tools/RAiDER/constants.py
+++ b/tools/RAiDER/constants.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 _ZMIN = np.float64(-100)   # minimum required height
-_ZREF = np.float64(15000)  # maximum requierd height
+_ZREF = np.float64(80000)  # default maximum height
 _STEP = np.float64(15.0)     # integration step size in meters
 
 _g0 = np.float64(9.80665)

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -235,7 +235,7 @@ def inc_hd_to_enu(incidence, heading):
     Parameters
     ----------
     incidence: ndarray	       - incidence angle in deg from vertical
-    heading: ndarray 	       - heading angle in deg clockwise from north
+    heading: ndarray 	       - heading angle in deg counter-clockwise from east
     lats/lons/heights: ndarray - WGS84 ellipsoidal target (ground pixel) locations
 
     Returns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- There is a typo in the losreader.py that states heading angle is degrees CW from north, when ISCE in reality uses CCW from east. The comment has been changed to reflect this convention. 
- Also fixed the default value of zref to reflect what is actually used. This should be addressed later as zref is not currently being used in ZTD calculation
