### PR TITLE
Raise better error for missing subdatasets

### DIFF
--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -395,6 +395,9 @@ class WeatherModel(ABC):
             with rasterio.open(f'netcdf:{weather_model_path}') as ds:
                 datasets = ds.subdatasets
 
+            if len(datasets) == 0:
+                raise ValueError('No subdatasets found in the weather model. The file may be corrupt.\nWeather model path: {}'.format(weather_model_path))
+
             with rasterio.open(datasets[0]) as ds:
                 bounds = ds.bounds
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the WeatherModel bbox accessor to raise a specific error when the weather model given does not contain any subdatasets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The code has been crashing here sometimes with a `list index out of bounds` error while trying to open the first subdataset in the given file. For better debugging, this change makes this case raise a different error that better explains what has happened.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- X ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
