### PR TITLE
Ray Tracing - Computing Ray End points

### DIFF
--- a/test/test_llreader.py
+++ b/test/test_llreader.py
@@ -132,8 +132,8 @@ def test_readLL_files(parser, llfiles):
     assert proj == ''
 
     lats, lons, llproj, bounds, flag, pnts_file_name = readLL(args.query_area)
-    assert np.allclose(lats, lat_true)
-    assert np.allclose(lons, lon_true)
+    assert lats == latfile
+    assert lons == lonfile
     assert llproj == ''
 
     # Hard code the lat/lon bounds to test against changing the files

--- a/test/test_raytracing.py
+++ b/test/test_raytracing.py
@@ -44,6 +44,6 @@ def test_toa():
                        [0.0, 6388137.0, 0.0],
                        [0.0, -6388137.0, 0.0]])
 
-    z.getTopOfAtmosphere(toaheight=10000.)
+    topxyz = z.getIntersectionWithHeight(10000.)
 
-    assert np.allclose(z._topxyz, toppts)
+    assert np.allclose(topxyz, toppts)

--- a/test/test_raytracing.py
+++ b/test/test_raytracing.py
@@ -1,0 +1,49 @@
+import datetime
+import pytest
+import numpy as np
+
+from RAiDER.losreader import Raytracing
+
+
+def test_Raytracing():
+    lats = np.array([-90, 0, 0, 90])
+    lons = np.array([-90, 0, 90, 180])
+    hgts = np.array([-10, 0, 10, 1000])
+
+    unit_vecs = np.array([[0,0,-1], [1,0,0], [0,1,0], [0,0,1]])
+
+    z = Raytracing()
+    with pytest.raises(RuntimeError):
+        z.setPoints(lats=None)
+
+    z.setPoints(lats=lats, lons=lons, heights = hgts)
+    assert z._lats.shape == (4,)
+    assert z._lats.shape == z._lons.shape
+    assert np.allclose(z._heights, hgts)
+
+
+def test_toa():
+    lats = np.array([0, 0, 0, 0])
+    lons = np.array([0, 180, 90, -90])
+    hgts = np.array([0, 0, 0, 0])
+
+    z = Raytracing()
+    z.setPoints(lats=lats, lons=lons, heights=hgts)
+
+    # Mock xyz
+    z._xyz = np.array([[6378137.0, 0.0, 0.0],
+                       [-6378137.0, 0.0, 0.0],
+                       [0.0, 6378137.0, 0.0],
+                       [0.0, -6378137.0, 0.0]])
+    z._lookvecs = np.array([[1, 0, 0],
+                            [-1, 0, 0],
+                            [0, 1, 0],
+                            [0, -1, 0]])
+    toppts = np.array([[6388137.0, 0.0, 0.0],
+                       [-6388137.0, 0.0, 0.0],
+                       [0.0, 6388137.0, 0.0],
+                       [0.0, -6388137.0, 0.0]])
+
+    z.getTopOfAtmosphere(toaheight=10000.)
+
+    assert np.allclose(z._topxyz, toppts)

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -40,7 +40,7 @@ def checkArgs(args, p):
     # Query Area
     lat, lon, llproj, bounds, flag, pnts_file = readLL(args.query_area)
 
-    if (np.min(lat) < -90) | (np.max(lat) > 90):
+    if (np.min(bounds[:2]) < -90) | (np.max(bounds[:2]) > 90):
         raise ValueError('Lats are out of N/S bounds; are your lat/lon coordinates switched?')
 
     # Line of sight calc

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -53,7 +53,7 @@ def checkArgs(args, p):
         # or 3 mins with start time tag
         los = Conventional(args.statevectors,
                            datetime.combine(args.dateList[0], args.time),
-                           10*60)
+                           10 * 60)
     else:
         los = Zenith()
 

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -41,8 +41,8 @@ def tropo_delay(args):
                 containing the following key-value pairs:
 
         los     - tuple, Zenith class object, ('los', 2-band los file), or ('sv', orbit_file)
-        lats    - ndarray
-        lons    - ndarray
+        lats    - ndarray or str
+        lons    - ndarray or str
         heights - see checkArgs for format
         flag    -
         weather_model   - type of weather model to use
@@ -61,6 +61,7 @@ def tropo_delay(args):
     los = args['los']
     lats = args['lats']
     lons = args['lons']
+    ll_bounds = args['ll_bounds']
     heights = args['heights']
     flag = args['flag']
     weather_model = args['weather_model']
@@ -94,8 +95,8 @@ def tropo_delay(args):
         weather_model,
         time,
         wmLoc=wmLoc,
-        lats=lats,
-        lons=lons,
+        lats=ll_bounds[:2] if isinstance(lats, str) else lats,
+        lons=ll_bounds[2:] if isinstance(lons, str) else lons,
         zref=zref,
         download_only=download_only,
         makePlots=verbose,
@@ -119,39 +120,42 @@ def tropo_delay(args):
         return None, None
 
     ###########################################################
-    # If query points are specified, pull the height info
-    logger.debug('Beginning DEM calculation')
-    lats, lons, hgts = getHeights(lats, lons, heights, useWeatherNodes)
-    logger.debug(
-        'DEM height range for the queried region is %.2f-%.2f m',
-        np.nanmin(hgts), np.nanmax(hgts)
-    )
-
-    # Transform the query points 
-    pnt_proj = CRS.from_epsg(4326)
+    # Load the downloaded model file
     ds = xarray.load_dataset(weather_model_file)
     try:
         wm_proj = ds['CRS']
     except:
         print("WARNING: I can't find a CRS in the weather model file, so I will assume you are using WGS84")
         wm_proj = 4326
-    if wm_proj != pnt_proj:
-        pnts = transformPoints(
-            lats,
-            lons,
-            hgts,
-            pnt_proj,
-            wm_proj
-        )
-    else:
-        # interpolators require y, x, z
-        pnts = np.stack([lats, lons, hgts], axis=-1)
     ####################################################################
 
     ####################################################################
     # Calculate delays
-    los.setPoints(lats, lons, hgts)
     if isinstance(los, (Zenith, Conventional)):
+        # Start actual processing here
+        logger.debug("Beginning DEM calculation")
+        # Lats, Lons will be translated from file to array here if needed
+        lats, lons, hgts = getHeights(lats, lons, heights, useWeatherNodes)
+        logger.debug(
+            'DEM height range for the queried region is %.2f-%.2f m',
+            np.nanmin(hgts), np.nanmax(hgts)
+        )
+        los.setPoints(lats, lons, hgts)
+
+        # Transform query points if needed
+        pnt_proj = CRS.from_epsg(4326)
+        if wm_proj != pnt_proj:
+            pnts = transformPoints(
+                lats,
+                lons,
+                hgts,
+                pnt_proj,
+                wm_proj
+            )
+        else:
+            # interpolators require y, x, z
+            pnts = np.stack([lats, lons, hgts], axis=-1)
+
         # either way I'll need the ZTD
         ifWet, ifHydro = getInterpolators(weather_model_file, 'total')
         wetDelay = ifWet(pnts)
@@ -161,8 +165,10 @@ def tropo_delay(args):
         wetDelay = los(wetDelay)
         hydroDelay = los(hydroDelay)
 
-    else:
+    elif isinstance(los, Raytracing):
         raise NotImplementedError
+    else:
+        raise ValueError("Unknown operation type")
 
     del ds  # cleanup
 

--- a/tools/RAiDER/dem.py
+++ b/tools/RAiDER/dem.py
@@ -22,7 +22,7 @@ import RAiDER.utilFcns
 
 from RAiDER.interpolator import interpolateDEM
 from RAiDER.logger import logger
-from RAiDER.utilFcns import gdal_open, gdal_extents
+from RAiDER.utilFcns import gdal_open, gdal_extents, get_file_and_band
 
 
 def getHeights(lats, lons, heights, useWeatherNodes=False):
@@ -30,7 +30,15 @@ def getHeights(lats, lons, heights, useWeatherNodes=False):
     Fcn to return heights from a DEM, either one that already exists
     or will download one if needed.
     '''
+    # TODO - All files are assumed to be one band files here. Generalize.
+
     height_type, height_data = heights
+    if isinstance(lats, str):
+        lats = gdal_open(lats)
+
+    if isinstance(lons, str):
+        lons = gdal_open(lons)
+
     in_shape = lats.shape
 
     if height_type == 'dem':

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -11,7 +11,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from RAiDER.utilFcns import gdal_open
+from RAiDER.utilFcns import gdal_open, gdal_stats, get_file_and_band
 
 
 def readLL(*args):
@@ -20,9 +20,17 @@ def readLL(*args):
     the appropriate outputs
     '''
     if len(args[0]) == 2:
-        # If they are files, open them
+        # If they are files, open them for stats
         flag = 'files'
-        lats, lons, llproj = readLLFromLLFiles(*args[0])
+
+        latinfo= get_file_and_band(args[0][0])
+        loninfo = get_file_and_band(args[0][1])
+        lat_stats = gdal_stats(latinfo[0], band=latinfo[1])
+        lon_stats = gdal_stats(loninfo[0], band=loninfo[1])
+        snwe = (lat_stats[0][0], lat_stats[0][1],
+                lon_stats[0][0], lon_stats[0][1])
+
+        lats, lons, llproj = readLLFromBBox(snwe)
         fname = os.path.basename(args[0][0]).split('.')[0]
 
     elif len(args[0]) == 4:
@@ -38,8 +46,12 @@ def readLL(*args):
     else:
         raise RuntimeError('llreader: Cannot parse query region: {}'.format(args))
 
-    lats, lons = forceNDArray(lats), forceNDArray(lons)
     bounds = (np.nanmin(lats), np.nanmax(lats), np.nanmin(lons), np.nanmax(lons))
+    # If files, pass file names instead of arrays 
+    if flag == "files":
+        lats = args[0][0]
+        lons = args[0][1]
+
 
     pnts_file_name = 'query_points_' + fname + '.h5'
 

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -31,6 +31,7 @@ def readLL(*args):
                 lon_stats[0][0], lon_stats[0][1])
 
         lats, lons, llproj = readLLFromBBox(snwe)
+        llproj = lat_stats[1]
         fname = os.path.basename(args[0][0]).split('.')[0]
 
     elif len(args[0]) == 4:

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -146,6 +146,7 @@ class Raytracing(LOS):
 
     def __init__(self, filename=None, time=None, pad=None):
         '''read in and parse a statevector file'''
+        super().__init__()
         self._file = filename
         self._time = time
         self._pad = pad
@@ -199,15 +200,15 @@ class Raytracing(LOS):
 
         for niter in range(5):
             pos_llh = ecef2lla(pos[..., 0], pos[..., 1], pos[..., 2])
-            pos = pos + (pos_llh[..., 2] - toaheight) * self._lookvecs
+            pos = pos + self._lookvecs * (pos_llh[2] - toaheight)[:, None]
 
         # The converged solution represents top of the rays
         self._topxyz = pos
 
         # This is for debugging the approach
         print("Stats for TOA computation: ")
-        print("Height min: ", np.nanmin(pos_llh[..., 2]))
-        print("Height max: ", np.nanmax(pos_llh[..., 2]))
+        print("Height min: ", np.nanmin(pos_llh[2]))
+        print("Height max: ", np.nanmax(pos_llh[2]))
 
     def calculateDelays(self, delays):
         '''

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -71,6 +71,7 @@ class Conventional(LOS):
     Special value indicating that the zenith delay will
     be projected using the standard cos(inc) scaling.
     """
+
     def __init__(self, filename=None, time=None, pad=None):
         super().__init__()
         self._file = filename
@@ -93,7 +94,8 @@ class Conventional(LOS):
                 get_sv(self._file, self._time, self._pad), axis=-1
             )
             LOS_enu = state_to_los(svs,
-                                  [self._lats, self._lons, self._heights])
+                                   [self._lats, self._lons, self._heights],
+                                   out="lookangle")
 
         if delays.shape == LOS_enu.shape:
             return delays / LOS_enu
@@ -141,25 +143,51 @@ class Raytracing(LOS):
 >>> #TODO
     >>> # 
     """
-    def __init__(self, filename=None):
+
+    def __init__(self, filename=None, time=None, pad=None):
         '''read in and parse a statevector file'''
         self._file = filename
+        self._time = time
+        self._pad = pad
 
-    def getLookVectors(self, time, pad=3*60):
+    def getLookVectors(self, time, pad=3 * 60):
         '''
         Calculate look vectors for raytracing
         '''
-        svs = np.stack(get_sv(self._file, time, pad), axis=-1)
-        LOS_enu = state_to_los(svs,
-                              [self._lats, self._lons, self._heights])
-        self._look_vecs = enu2ecef(
-            LOS_enu[..., 0],
-            LOS_enu[..., 1],
-            LOS_enu[..., 2],
-            self._lats,
-            self._lons,
-            self._heights
-        )
+        if self._lats is None:
+            raise ValueError('Target points not set')
+        if self._file is None:
+            raise ValueError('LOS file not set')
+
+        try:
+            # if an ISCE-style los file is provided, use GDAL
+            LOS_enu = inc_hd_to_enu(*gdal_open(self._file))
+            self._lookvecs = enu2ecef(
+                LOS_enu[..., 0],
+                LOS_enu[..., 1],
+                LOS_enu[..., 2],
+                self._lats,
+                self._lons,
+                self._heights
+            )
+            self._xyz = np.stack(
+                lla2ecef([
+                    self._lats,
+                    self._lons,
+                    self._heights
+                ]), axis=-1
+            )
+
+        except OSError:
+            # Otherwise treat it as a state vector file
+            svs = np.stack(
+                get_sv(self._file, self._time, self._pad), axis=-1
+            )
+            self._lookvecs, self._xyz = state_to_los(
+                svs, [self._lats, self._lons, self._heights],
+                out="ecef"
+            )
+
 
     def calculateDelays(self, delays):
         '''
@@ -169,7 +197,7 @@ class Raytracing(LOS):
         # Create rays
         # Interpolate delays to rays
         # Integrate along rays
-        # Return STD 
+        # Return STD
         raise NotImplementedError
 
 
@@ -192,7 +220,7 @@ def getZenithLookVecs(lats, lons, heights):
     return np.stack([x, y, z], axis=-1)
 
 
-def get_sv(los_file, ref_time, pad=3*60):
+def get_sv(los_file, ref_time, pad=3 * 60):
     """
     Read an LOS file and return orbital state vectors
 
@@ -366,7 +394,7 @@ def read_ESA_Orbit_file(filename):
     vz = np.ones(numOSV)
 
     for i, st in enumerate(data_block[0]):
-        t.append (
+        t.append(
             datetime.datetime.strptime(
                 st[1].text,
                 'UTC=%Y-%m-%dT%H:%M:%S.%f'
@@ -384,7 +412,7 @@ def read_ESA_Orbit_file(filename):
 
 
 ############################
-def state_to_los(svs, llh_targets):
+def state_to_los(svs, llh_targets, out="lookangle"):
     '''
     Converts information from a state vector for a satellite orbit, given in terms of
     position and velocity, to line-of-sight information at each (lon,lat, height)
@@ -409,6 +437,10 @@ def state_to_los(svs, llh_targets):
     >>> svs = losr.read_ESA_Orbit_file(esa_orbit_file)
     >>> LOS = losr.state_to_los(*svs, [lats, lons, heights], xyz)
     '''
+    if out not in ["lookangle", "ecef"]:
+        raise ValueError(
+            f"Output type can be lookangle or ecef - not {out}"
+        )
 
     # check the inputs
     if np.min(svs.shape) < 4:
@@ -431,10 +463,15 @@ def state_to_los(svs, llh_targets):
     Npts = len(target_llh)
 
     # Iterate through targets and compute LOS
-    los_ang, slant_range = get_radar_pos(target_llh, orb, out="lookangle")
-
-    los_factor = np.cos(np.deg2rad(los_ang)).reshape(in_shape)
-    return los_factor
+    if out == "lookangle":
+        los_ang, slant_range = get_radar_pos(target_llh, orb, out="lookangle")
+        los_factor = np.cos(np.deg2rad(los_ang)).reshape(in_shape)
+        return los_factor
+    elif out == "ecef":
+        los_xyz, targ_xyz = get_radar_pos(target_llh, orb, out="ecef")
+        return los_xyz, targ_xyz
+    else:
+        raise NotImplementedError("Unexpected logic in state_to_los")
 
 
 def cut_times(times, ref_time, pad=3600 * 3):
@@ -452,7 +489,7 @@ def cut_times(times, ref_time, pad=3600 * 3):
     idx: Nt x 1 logical ndarray - a mask of times within the padded request time.
     """
     diff = np.array(
-        [(x-ref_time).total_seconds() for x in times]
+        [(x - ref_time).total_seconds() for x in times]
     )
     return np.abs(diff) < pad
 
@@ -469,12 +506,16 @@ def get_radar_pos(llh, orb, out="lookangle"):
 
     Returns
     -------
-    los: ndarray  - Satellite position vector in ECEF or look angle
-    sr:  ndarray  - Slant range in meters
+    if out == "lookangle"
+        los: ndarray  - Satellite incidence angle
+        sr:  ndarray  - Slant range in meters
+    if out == "ecef"
+        los_xyz: ndarray - Satellite LOS in ECEF from target to satellite
+        targ_xyz: ndarray - Target XYZ positions in ECEF
     '''
     if out not in ["lookangle", "ecef"]:
         raise ValueError(
-            f"vector kwargs must be angle or ecef - not {vector}"
+            f"out kwarg must be lookangle or ecef - not {out}"
         )
 
     num_iteration = 30
@@ -502,8 +543,8 @@ def get_radar_pos(llh, orb, out="lookangle"):
         if not any(np.isnan(pt)):
             # ISCE3 always uses xy convention
             inp = np.array([np.deg2rad(pt[1]),
-                   np.deg2rad(pt[0]),
-                   pt[2]])
+                            np.deg2rad(pt[0]),
+                            pt[2]])
             # Local normal vector
             nv = elp.n_vector(inp[0], inp[1])
 
@@ -523,9 +564,7 @@ def get_radar_pos(llh, orb, out="lookangle"):
                     # skip the arccos here and cos above
                     delta = delta / np.linalg.norm(delta)
                     output[ind] = np.rad2deg(
-                        np.arccos(
-                            np.dot(delta, nv)
-                        )
+                        np.arccos(np.dot(delta, nv))
                     )
                 else:
                     output[ind, :] = (sat_xyz - targ_xyz) / slant_range
@@ -539,8 +578,10 @@ def get_radar_pos(llh, orb, out="lookangle"):
             sr[ind] = np.nan
             output[ind, ...] = np.nan
 
-    # For debugging
-    # print(np.nanmin(sr), np.nanmax(sr), np.sum(np.isnan(sr)))
-    # print(np.nanmin(output), np.nanmax(output), np.sum(np.isnan(output)))
-
-    return output, sr
+    # If lookangle is requested
+    if out == "lookangle":
+        return output, sr
+    elif out == "ecef":
+        return output, targ_xyz
+    else:
+        raise NotImplementedError("Unexpected logic in get_radar_pos")

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -50,6 +50,12 @@ def lla2ecef(lat, lon, height):
     return T.transform(lon, lat, height)
 
 
+def ecef2lla(x, y, z):
+    T = Transformer.from_crs(4978, 4326, always_xy=True)
+
+    return T.transform(x, y, z)
+
+
 def enu2ecef(
     east: ndarray,
     north: ndarray,

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -944,7 +944,7 @@ def calcgeoh(lnsp, t, q, z, a, b, R_d, num_levels):
         Ph_lev = a[lev - 1] + (b[lev - 1] * sp)
         Ph_levplusone = a[lev] + (b[lev] * sp)
 
-        pressurelvs[ilevel] = Ph_lev# + Ph_levplusone) / 2  # average pressure at half-levels above and below
+        pressurelvs[ilevel] = Ph_lev  # + Ph_levplusone) / 2  # average pressure at half-levels above and below
 
         if lev == 1:
             dlogP = np.log(Ph_levplusone / 0.1)

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -167,8 +167,9 @@ def gdal_stats(fname, band=1, userNDV=None):
     try:
         ds = gdal.Open(fname, gdal.GA_ReadOnly)
     except BaseException:  # TODO: Which error(s)?
-        gdal.SetConfigOption("GDAL_PAM_ENABLED", old_config_val)
         raise OSError('File {} could not be opened'.format(fname))
+    finally:
+        gdal.SetConfigOption("GDAL_PAM_ENABLED", old_config_val)
     proj = ds.GetProjection()
     gt = ds.GetGeoTransform()
 


### PR DESCRIPTION
## Description
Determine the end points of the line-of-sight ray for RayTracing option
- `Raytracing._xyz` will represent ECEF positions of targets on the ground
- `Raytracing._topxyz` will represent ECEF positions of ray starting point at the top of the atmosphere
- Both LOS angles as well as state vectors are supported. They are both internally transformed to unit vectors in LOS direction before ray tracing starts.

This PR is more to start discussion of the implementation approach @jlmaurer 

## Motivation and Context
- Slant range for satellite-based SAR images can be on order of 500-1000km
- Troposphere is only significant in the lower 15-30km
- Determining the start / end points through the troposphere only will significantly reduce computation burden for ray tracing

## How Has This Been Tested?
- No unit tests exist yet as we are starting from scratch and this approach is up for discussion
- All previous unit tests work as expected

