### PR TITLE
Fixes for cubes in non lat/lon systems

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
  - dem_stitcher>=2.3.0
  - ecmwf-api-client
  - h5py
+ - h5netcdf
  - isce3>=0.8.0
  - lxml
  - matplotlib

--- a/tools/RAiDER/cli/raiderDelay.py
+++ b/tools/RAiDER/cli/raiderDelay.py
@@ -239,6 +239,10 @@ def read_template_file(fname):
             template['aoi'] = get_query_region(AttributeDict(value))
         if key == 'los_group':
             template['los'] = get_los(AttributeDict(value))
+        if key == 'look_dir':
+            if value.lower() not in ['right', 'left']:
+                raise ValueError(f"Unknown look direction {value}")
+            template['look_dir'] = value.lower()
 
     # Have to guarantee that certain variables exist prior to looking at heights
     for key, value in params.items():

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -627,7 +627,17 @@ def get_radar_pos(llh, orb, out="lookangle"):
 
 def getTopOfAtmosphere(xyz, lookvecs, toaheight, factor=None):
     """
-    Get ray intersection at given height
+    Get ray intersection at given height.
+
+    We use simple Newton-Raphson for this computation. This cannot be done
+    exactly since closed form expression from xyz to llh is super compliated.
+
+    If a factor (cos of inc angle) is provided - iterations are lot faster.
+    If factor is not provided solutions converges to
+        - 0.01 mm at heights near zero in 10 iterations
+        - 10 cm at heights above 40km in 10 iterations
+
+    If factor is know, we converge in 3 iterations to less than a micron.
     """
     if factor is not None:
         maxIter = 3

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -625,22 +625,28 @@ def get_radar_pos(llh, orb, out="lookangle"):
         raise NotImplementedError("Unexpected logic in get_radar_pos")
 
 
-def getTopOfAtmosphere(xyz, lookvecs, toaheight):
+def getTopOfAtmosphere(xyz, lookvecs, toaheight, factor=None):
     """
     Get ray intersection at given height
     """
+    if factor is not None:
+        maxIter = 3
+    else:
+        maxIter = 10
+        factor = 1.
+
     # Guess top point
     pos = xyz + toaheight * lookvecs
 
     for niter in range(10):
         pos_llh = ecef2lla(pos[..., 0], pos[..., 1], pos[..., 2])
-        pos = pos + lookvecs * (toaheight - pos_llh[2])[..., None]
+        pos = pos + lookvecs * ((toaheight - pos_llh[2])/factor)[..., None]
 
     # This is for debugging the approach
     # print("Stats for TOA computation: ", toaheight,
-    #      toaheight - np.nanmin(pos_llh[2]),
-    #      toaheight - np.nanmax(pos_llh[2]),
-    #     )
+    #       toaheight - np.nanmin(pos_llh[2]),
+    #       toaheight - np.nanmax(pos_llh[2]),
+    # )
 
     # The converged solution represents top of the rays
     return pos

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -663,6 +663,10 @@ def transform_bbox(wesn, dest_crs=4326, src_crs=4326, margin=100.):
     elif isinstance(src_crs, str):
         src_crs = pyproj.CRS(src_crs)
 
+    # Handle margin for input bbox in degrees
+    if src_crs.axis_info[0].unit_name == "degree":
+        margin = margin / 1.0e5
+
     if isinstance(dest_crs, int):
         dest_crs = pyproj.CRS.from_epsg(dest_crs)
     elif isinstance(dest_crs, str):


### PR DESCRIPTION
## Description
Projection systems and axis orders are a pain. This fixes cube generation in other coordinate systems

## Motivation and Context
NISAR products will use UTM system. 

## How Has This Been Tested?
Template input file used for testing zenith delays on a UTM grid:

```
# vim: set filetype=yaml:

look_dir: right

date_group:
  date_start:
  date_end:
  date_step:
  date_list:  [20200101]

time_group:
  time: "23:00:00"
  end_time:

weather_model: HRES

aoi_group:
  lat_file:
  lon_file:
  height_file_rdr:
  station_file:
  bounding_box: 53.0 56.0 -4.0 -1.0
  utm_zone:
  grid_x:
  grid_y:

height_group:
  dem:
  use_dem_latlon: False
  height_file_rdr:
  height_levels: "-500 0 500 1000 1500 2000 2500 3000 3500 4000 4500 5000 5500 6000 6500 7000 7500 8000 8500 9000"

los_group:
  ray_trace: False  # Use projected slant delay by default
  zref: # Integration height. Only used in raytracing.
  los_file:
  los_convention: isce  # can be "isce" or "hyp3", see *** for details
  los_cube:
  orbit_file:

runtime_group:
  verbose: True
  raster_format: nc # Can be any rasterio-compatible format
  output_directory: current/HR_HRES
  weather_model_directory: current/HR_HRES/weather_files
  cube_spacing_in_m: 2000.
  output_projection:  32630
```

