### PR TITLE
Fix typo in docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.6.0
 
   call-docker-ghcr-workflow:
-    needs: call-version-info-workflow
+    needs: call-git-object-name-workflow
     uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.6.0
     with:
       version_tag: ${{ needs.call-git-object-name-workflow.outputs.name }}


### PR DESCRIPTION
Workflow didn't run because the `needs:` value was wrong.