### PR TITLE
Fix buffer raytracing

### DIFF
--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -59,7 +59,6 @@ def tropo_delay(dt, wetFilename, hydroFilename, args):
     """
     # unpacking the dictionairy
     los = args['los']
-    ll_bounds = args['bounding_box']
     heights = args['dem']
     weather_model = args['weather_model']
     wmLoc = args['weather_model_directory']
@@ -68,6 +67,9 @@ def tropo_delay(dt, wetFilename, hydroFilename, args):
     download_only = False
     verbose = args['verbose']
     aoi = args['aoi']
+
+    aoi.update_buffer(los)
+    ll_bounds = aoi.bounds()
 
     # logging
     logger.debug('Starting to run the weather model calculation')

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -68,8 +68,10 @@ def tropo_delay(dt, wetFilename, hydroFilename, args):
     verbose = args['verbose']
     aoi = args['aoi']
 
-    aoi.update_buffer(los)
-    ll_bounds = aoi.bounds()
+    if los.ray_trace():
+        ll_bounds = aoi.add_buffer(buffer=1) # add a buffer for raytracing
+    else:
+        ll_bounds = aoi.bounds()
 
     # logging
     logger.debug('Starting to run the weather model calculation')
@@ -83,9 +85,6 @@ def tropo_delay(dt, wetFilename, hydroFilename, args):
 
     logger.debug('Beginning weather model pre-processing')
     logger.debug('Download-only is {}'.format(download_only))
-
-    if ll_bounds is None:
-        ll_bounds = aoi.bounds()
 
     weather_model_file = prepareWeatherModel(
         weather_model,
@@ -150,10 +149,6 @@ def tropo_delay(dt, wetFilename, hydroFilename, args):
         ifWet, ifHydro = getInterpolators(weather_model_file, 'total')
         wetDelay = ifWet(pnts)
         hydroDelay = ifHydro(pnts)
-
-        # TODO - handle this better during set up of LOS object
-        los._pad = 600
-        los._time = dt
 
         # return the delays (ZTD or STD)
         wetDelay = los(wetDelay)
@@ -264,14 +259,13 @@ def tropo_delay_cube(dt, wf, args, model_file=None):
     logger.debug(f"Output cube spacing: {out_spacing}")
 
     # Load downloaded weather model file to get projection info
-    ds = xarray.load_dataset(weather_model_file)
+    with xarray.load_dataset(weather_model_file):
+        # Output grid points - North up grid
+        if args['height_levels'] is not None:
+            heights = args['height_levels']
+        else:
+            heights = ds.z.values
 
-    # Output grid points - North up grid
-    if args['height_levels'] is not None:
-        heights = args['height_levels']
-    else:
-        heights = ds.z.values
-    ds.close()
     logger.debug(f'Output height range is {min(heights)} to {max(heights)}')
 
     # Load CRS from weather model file
@@ -301,9 +295,13 @@ def tropo_delay_cube(dt, wf, args, model_file=None):
             xpts, ypts, zpts,
             wm_proj, crs,
             [ifWet, ifHydro])
+    
     else:
         out_type = "slant range"
-        out_filename = wf.replace("_ztd", "_std").replace("wet", "tropo")
+        if not los.ray_trace():
+            out_filename = wf.replace("_ztd", "_std").replace("wet", "tropo")
+        else:
+            out_filename = wf.replace("_ztd", "_ray").replace("wet", "tropo")
 
         if args["look_dir"].lower() not in ["right", "left"]:
             raise ValueError(
@@ -311,26 +309,31 @@ def tropo_delay_cube(dt, wf, args, model_file=None):
             )
 
         # Get pointwise interpolators
-        ifWet, ifHydro = getInterpolators(weather_model_file,
-                                          kind="pointwise",
-                                          shared=(nproc > 1))
+        ifWet, ifHydro = getInterpolators(
+            weather_model_file,
+            kind="pointwise",
+            shared=(nproc > 1),
+        )
 
-        # Build cube
-        if nproc == 1:
-            wetDelay, hydroDelay = build_cube_ray(
-                xpts, ypts, zpts,
-                dt, args["los"]._file, args["look_dir"],
-                wm_proj, crs,
-                [ifWet, ifHydro])
+        if los.ray_trace():
+            # Build cube
+            if nproc == 1:
+                wetDelay, hydroDelay = build_cube_ray(
+                    xpts, ypts, zpts,
+                    dt, args["los"]._file, args["look_dir"],
+                    wm_proj, crs,
+                    [ifWet, ifHydro])
 
-        ### Use multi-processing here
+            ### Use multi-processing here
+            else:
+                # Pre-build output arrays
+
+                # Create worker pool
+
+                # Loop over heights
+                raise NotImplementedError
         else:
-            # Pre-build output arrays
-
-            # Create worker pool
-
-            # Loop over heights
-            raise NotImplementedError
+            raise NotImplementedError('Conventional STD is not yet implemented on the cube')
 
     # Write output file
     # Modify this as needed for NISAR / other projects

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -32,19 +32,17 @@ class AOI(object):
     def projection(self):
         return self._proj
     
-    def update_buffer(self, los):
+    def add_buffer(self, buffer):
         '''
         Check whether an extra lat/lon buffer is needed for raytracing
         '''
-        breakpoint()
-        if los.ray_trace():
-            # if raytracing, add a 1-degree buffer all around
-            ll_bounds = self._bounding_box
-            ll_bounds[0] = np.max(ll_bounds[0] - 1, -90)
-            ll_bounds[1] = np.max(ll_bounds[1] + 1,  90)
-            ll_bounds[2] = np.max(ll_bounds[2] - 1,-180)
-            ll_bounds[3] = np.max(ll_bounds[3] + 1, 180)
-            self._bounding_box = ll_bounds
+        # if raytracing, add a 1-degree buffer all around
+        ll_bounds = self._bounding_box.copy()
+        ll_bounds[0] = np.max([ll_bounds[0] - buffer, -90])
+        ll_bounds[1] = np.min([ll_bounds[1] + buffer,  90])
+        ll_bounds[2] = np.max([ll_bounds[2] - buffer,-180])
+        ll_bounds[3] = np.min([ll_bounds[3] + buffer, 180])
+        return ll_bounds
 
 
 

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -32,6 +32,23 @@ class AOI(object):
     def projection(self):
         return self._proj
     
+    def update_buffer(self, los):
+        '''
+        Check whether an extra lat/lon buffer is needed for raytracing
+        '''
+        breakpoint()
+        if los.ray_trace():
+            # if raytracing, add a 1-degree buffer all around
+            ll_bounds = self._bounding_box
+            ll_bounds[0] = np.max(ll_bounds[0] - 1, -90)
+            ll_bounds[1] = np.max(ll_bounds[1] + 1,  90)
+            ll_bounds[2] = np.max(ll_bounds[2] - 1,-180)
+            ll_bounds[3] = np.max(ll_bounds[3] + 1, 180)
+            self._bounding_box = ll_bounds
+
+
+
+    
 
 
 class StationFile(AOI):

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -51,6 +51,9 @@ class LOS(ABC):
             self._lons = lons
             self._heights = heights
     
+    def setTime(self, dt):
+        self._time = dt
+    
     def is_Zenith(self):
         return self._is_zenith
     
@@ -165,6 +168,7 @@ class Raytracing(LOS):
         self._time = time
         self._pad = pad
         self._convention = los_convention
+        self._pad = 600
         if self._convention == 'hyp3':
             raise NotImplementedError()
 

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -28,6 +28,8 @@ class LOS(ABC):
     def __init__(self):
         self._lats, self._lons, self._heights = None, None, None
         self._look_vecs = None
+        self._ray_trace = False
+        self._is_zenith = False
 
     def setPoints(self, lats, lons=None, heights=None):
         '''Set the pixel locations'''
@@ -50,11 +52,17 @@ class LOS(ABC):
             self._heights = heights
     
     def is_Zenith(self):
-        return False
+        return self._is_zenith
+    
+    def ray_trace(self):
+        return self._ray_trace
 
 
 class Zenith(LOS):
     """Special value indicating a look vector of "zenith"."""
+    def __init__(self):
+        LOS.__init__(self)
+        self._is_zenith = True
 
     def setLookVectors(self):
         '''Set point locations and calculate Zenith look vectors'''
@@ -66,9 +74,6 @@ class Zenith(LOS):
     def __call__(self, delays):
         '''Placeholder method for consistency with the other classes'''
         return delays
-    
-    def is_Zenith(self):
-        return True
 
 
 class Conventional(LOS):
@@ -78,7 +83,7 @@ class Conventional(LOS):
     """
 
     def __init__(self, filename=None, los_convention='isce', time=None, pad=None):
-        super().__init__()
+        LOS.__init__(self)
         self._file = filename
         self._time = time
         self._pad = pad
@@ -154,7 +159,8 @@ class Raytracing(LOS):
 
     def __init__(self, filename=None, los_convention='isce', time=None, pad=None):
         '''read in and parse a statevector file'''
-        super().__init__()
+        LOS.__init__(self)
+        self._ray_trace = True
         self._file = filename
         self._time = time
         self._pad = pad

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -63,7 +63,7 @@ def prepareWeatherModel(
             )
             raise RuntimeError(
                 'The weather model passed does not cover all of the input '
-                'points; you need to download a larger area.'
+                'points; please delete or rename it so another can be downloaded.'
             )
 
     # If only downloading, exit now

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -149,6 +149,11 @@ def rio_open(fname, returnProj=False, userNDV=None, band=None):
 
         if data.ndim > 2 and data.shape[0] == 1:
             data = data[0, ...]
+        elif data.ndim > 2:
+            dlist = []
+            for k in range(data.shape[0]):
+                dlist.append(data[k,...].copy())
+            data = dlist
 
     if not returnProj:
         return data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Fixes #387 
- Fixes #374
- Adds a buffer to the weather model *only* when raytracing is requested. Uses 1 degree of buffering as it seemed like that would be simplest, always work, and not add too much overhead. Confirmed that it fixes the edge-effects problem seen by @cmarshak . 
- Also it looks like conventional slant delay is never used with a cube. I added a `NotImplementedError` when ray_trace is set to `False` and changed the file naming convention so that if you run all three you'll get unique names. @piyushrpt can the conventional STD be added easily or shall we drop it as an option on the cube? pinging @dbekaert on this as well. 
- Also fixes an unrelated bug in rio_open that returned a single array instead of list of arrays when opening multi-band rasters. 

## Description
<!--- Describe your changes in detail -->
- Confirmed ZTD and raytracing work for ERA-5 without edge artifacts.

## Screenshots (if appropriate):
Current: 
<img width="614" alt="Screen Shot 2022-11-11 at 2 02 20 PM" src="https://user-images.githubusercontent.com/22203981/201422822-9152ca1b-7a62-42f9-b9b3-8397395bf1fd.png">

After implementing raytracing buffer:
<img width="931" alt="Screen Shot 2022-11-11 at 1 54 01 PM" src="https://user-images.githubusercontent.com/22203981/201421751-3d3437b5-e1e3-4970-bf2a-02263dcb9f3b.png">


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
