### PR TITLE
Projection bounds

### DIFF
--- a/tools/RAiDER/cli/validators.py
+++ b/tools/RAiDER/cli/validators.py
@@ -110,7 +110,7 @@ def get_query_region(args):
     '''
     # Get bounds from the inputs
     # make sure this is first
-    if 'use_dem_latlon' in args.keys():
+    if ('use_dem_latlon' in args.keys()) and args['use_dem_latlon']:
         query = GeocodedFile(args.dem, is_dem=True)
 
     elif 'lat_file' in args.keys():

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -269,6 +269,8 @@ class HRRR(WeatherModel):
             save_dir=Path(os.path.dirname(out)),
         )
         pf = H.download(":(SPFH|PRES|TMP|HGT):", verbose=verbose)
+        # breakpoint()
+        # ds = H.xarray('q')
 
         self._makeDataCubes(pf, out)
 

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -269,8 +269,6 @@ class HRRR(WeatherModel):
             save_dir=Path(os.path.dirname(out)),
         )
         pf = H.download(":(SPFH|PRES|TMP|HGT):", verbose=verbose)
-        # breakpoint()
-        # ds = H.xarray('q')
 
         self._makeDataCubes(pf, out)
 

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -444,7 +444,7 @@ class WeatherModel(ABC):
         weather_model_box = box(xmin, ymin, xmax, ymax)
 
         world_box  = box(-180, -90, 180, 90)
-        if self._proj.is_projected and world_box.contains(input_box):
+        if world_box.contains(input_box):
             xmin, ymin = transform_coords(self._proj, 4326, xmin, ymin)
             xmax, ymax = transform_coords(self._proj, 4326, xmax, ymax)
             weather_model_box = box(xmin, ymin, xmax, ymax)

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -1075,3 +1075,17 @@ def calcgeoh(lnsp, t, q, z, a, b, R_d, num_levels):
         z_h += TRd * dlogP
 
     return geopotential, pressurelvs, geoheight
+
+
+
+
+def transform_coords(proj1, proj2, x, y):
+    """
+    Transform coordinates from proj1 to proj2 (can be EPSG or crs from proj).
+    e.g. x, y = transform_coords(4326, 4087, lon, lat)
+    """
+    from pyproj import Transformer
+
+    transformer = Transformer.from_crs(proj1, proj2, always_xy=True)
+
+    return transformer.transform(x, y)


### PR DESCRIPTION
This adds support for reusing a weather model file that is in projected coordinates. 
I.e., if HRRR is already downloaded, and you pass a bounding box in lat/lon, it will mismatch because HRRR is in meters.