### PR TITLE
temporary gdal fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
  - dask
  - dem_stitcher>=2.3.0
  - ecmwf-api-client
+ - gdal<3.6
  - h5py
  - herbie-data
  - h5netcdf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- conda updated gdal dependency to 3.6 and might be breaking our other deps
- adds gdal back to environment.yml and pins to <3.6 

