### PR TITLE
Fix CircleCI buid and cleanup config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,11 @@ jobs:
             apt install -y --no-install-recommends wget ca-certificates git
             cd $HOME
             curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-            eval "$(./bin/micromamba shell hook -s posix)"
-            ./bin/micromamba shell init -s bash -p $HOME/micromamba
 
       - run:
-          name: Setup environment and run tests
+          name: Setup environment
           command: |
+            eval "$($HOME/bin/micromamba shell hook -s posix)"
             micromamba create -f environment.yml
             micromamba activate RAiDER
             pip install coveralls
@@ -41,19 +40,23 @@ jobs:
       - run:
           name: Install RAiDER and test the install
           command: |
+            eval "$($HOME/bin/micromamba shell hook -s posix)"
             micromamba activate RAiDER
             python -m pip install .
             python -c "import RAiDER; from RAiDER.delay import main"
             python -c "import RAiDER; from RAiDER.interpolator import interp_along_axis"
       - run:
           name: Run unit tests
+          shell: /bin/bash -l
           command: |
+            eval "$($HOME/bin/micromamba shell hook -s posix)"
             micromamba activate RAiDER
             COV_OPTIONS=`python -c "import importlib;print(*(' --cov='+p for p in importlib.util.find_spec('RAiDER').submodule_search_locations))"`
             pytest -m "not long" test/ $COV_OPTIONS --cov-report=
       - run:
           name: Report coverage
           command: |
+            eval "$($HOME/bin/micromamba shell hook -s posix)"
             micromamba activate RAiDER
             python .circleci/fix_coverage_paths.py .coverage $(pwd)/tools/RAiDER/
             coverage report -mi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,32 +2,25 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/python:3.10.6
+      - image: cimg/base:current
         user: root
-    environment:
-      PYTHON_VERSION: 3.10.6
     steps:
       - checkout
       - run:
-          name: Setup Miniconda
+          name: Setup micromamba
           command: |
             apt update --yes && apt-get upgrade --yes
             apt install -y --no-install-recommends wget ca-certificates git
             cd $HOME
-            wget "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh" -O miniconda.sh
-            printf '%s' "78f39f9bae971ec1ae7969f0516017f2413f17796670f7040725dd83fcff5689  miniconda.sh" | sha256sum -c
-            bash miniconda.sh -b -p $HOME/miniconda
+            curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+            eval "$(./bin/micromamba shell hook -s posix)"
+            ./bin/micromamba shell init -s bash -p $HOME/micromamba
+
       - run:
           name: Setup environment and run tests
           command: |
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda install mamba -n base -c conda-forge --yes
-            mamba update -y conda
-            mamba update -y mamba
-            mamba create -n myenv python=$PYTHON_VERSION -c conda-forge
-            source activate myenv
-            mamba env create -f environment.yml
-            conda activate RAiDER
+            micromamba create -f environment.yml
+            micromamba activate RAiDER
             pip install coveralls
             echo url: https://cds.climate.copernicus.eu/api/v2 > $HOME/.cdsapirc
             echo key: $cdsak >> $HOME/.cdsapirc
@@ -48,26 +41,20 @@ jobs:
       - run:
           name: Install RAiDER and test the install
           command: |
-            export PATH="$HOME/miniconda/bin:$PATH"
-            source activate myenv
-            conda activate RAiDER
+            micromamba activate RAiDER
             python -m pip install .
             python -c "import RAiDER; from RAiDER.delay import main"
             python -c "import RAiDER; from RAiDER.interpolator import interp_along_axis"
       - run:
           name: Run unit tests
           command: |
-            export PATH="$HOME/miniconda/bin:$PATH"
-            source activate myenv
-            conda activate RAiDER
+            micromamba activate RAiDER
             COV_OPTIONS=`python -c "import importlib;print(*(' --cov='+p for p in importlib.util.find_spec('RAiDER').submodule_search_locations))"`
             pytest -m "not long" test/ $COV_OPTIONS --cov-report=
       - run:
           name: Report coverage
           command: |
-            export PATH="$HOME/miniconda/bin:$PATH"
-            source activate myenv
-            conda activate RAiDER
+            micromamba activate RAiDER
             python .circleci/fix_coverage_paths.py .coverage $(pwd)/tools/RAiDER/
             coverage report -mi
             coveralls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
     with:
       conda_env_name: RAiDER
+      python_version: '3.10'
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
  - h5py
  - herbie-data
  - h5netcdf
- - isce3==0.8.0=py310hc48c5ce_2
+ - isce3==0.8.0=*_2
  - lxml
  - matplotlib
  - netcdf4

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
  - dask
  - dem_stitcher>=2.3.0
  - ecmwf-api-client
- - gdal<3.6
  - h5py
  - herbie-data
  - h5netcdf

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
  - dask
  - dem_stitcher>=2.3.0
  - ecmwf-api-client
+ - gdal<3.6
  - h5py
  - herbie-data
  - h5netcdf

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
  - h5py
  - herbie-data
  - h5netcdf
- - isce3>=0.8.0
+ - isce3==0.8.0=py310hc48c5ce_2
  - lxml
  - matplotlib
  - netcdf4


### PR DESCRIPTION
The ISCE3 removed the [`libgdal` runtime requirement](https://github.com/conda-forge/isce3-feedstock/pull/31/commits/904315f78dede14d70be85bb86cad34e293fee25#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aL48
) in conda-forge/isce3-feedstock#31, which resulted in ISCE3 build number 3.  

This change is causing CircleCI `build` workflow failures like:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/miniconda/envs/RAiDER/lib/python3.10/site-packages/RAiDER/delay.py", line 18, in <module>
    import isce3.ext.isce3 as isce
  File "/root/miniconda/envs/RAiDER/lib/python3.10/site-packages/isce3/__init__.py", line 2, in <module>
    from .ext import extisce3
  File "/root/miniconda/envs/RAiDER/lib/python3.10/site-packages/isce3/ext/__init__.py", line 3, in <module>
    from . import isce3 as extisce3
ImportError: libgdal.so.32: cannot open shared object file: No such file or directory

Exited with code exit status 1
```

I can get the build to work by pinning ISCE3 to build 2. We should be able to remove that constraint when conda-forge/isce3-feedstock#33 is resolved.

I also cleaned up the conda/mamba environment setup in the CircleCI config and switched over to micromamba as it's significantly faster for CI/CD applications. 

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
