### PR TITLE
add missing deps

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,11 +31,14 @@ dependencies:
  - progressbar
  - pydap>3.2.2
  - pyproj>=2.2.0
+ - pyyaml
  - rasterio>=1.3.0
+ - requests
  - s3fs
  - scipy
  - shapely
  - sysroot_linux-64
+ - tqdm
  - xarray
  # For packaging and testing
  - autopep8


### PR DESCRIPTION
Adding a few missing dependencies picked up by the conda-forge package dependency analysis in conda-forge/raider-feedstock#2

These all get implicitly installed via other packages, but because they are also explicitly imported, should be in the environment.