### PR TITLE
initial attempt at library interface

### DIFF
--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1,0 +1,14 @@
+import datetime
+from RAiDER.delay import main
+
+wetFilename   = '/Users/buzzanga/Software_InSAR/RAiDER-docs_git/notebooks/RAiDER_tutorial/GMAO_wet_20200103T000000_ztd.GTiff'
+hydroFilename = '/Users/buzzanga/Software_InSAR/RAiDER-docs_git/notebooks/RAiDER_tutorial/GMAO_hydro_20200103T000000_ztd.GTiff'
+dt = datetime.datetime(2020, 1, 3, 0, 0)
+height_levels = [0, 50, 100, 500, 1000]
+bounding_box  = [28, 39, -123, -112]
+weather_model = 'GMAO'
+
+main(dt, wetFilename, hydroFilename,
+        bounding_box=bounding_box,
+        weather_model=weather_model,
+        height_levels=height_levels)

--- a/tools/RAiDER/checkArgs.py
+++ b/tools/RAiDER/checkArgs.py
@@ -15,7 +15,7 @@ from RAiDER.losreader import Zenith
 from RAiDER.llreader import BoundingBox
 
 
-def checkArgs(args):
+def checkArgs(args, download_only=False):
     '''
     Helper fcn for checking argument compatibility and returns the
     correct variables
@@ -65,6 +65,14 @@ def checkArgs(args):
             wetNames.append(wetFilename)
             hydroNames.append(hydroFilename)
 
+
+    ## enables both download only flag in config yaml and command line
+    # command line yes will overwrite config file
+    if not download_only:
+        args.download_only = args.get('download_only', False)
+    else:
+        args.download_only = True
+
     args.wetFilenames = wetNames
     args.hydroFilenames = hydroNames
 
@@ -94,6 +102,3 @@ def makeDelayFileNames(time, los, outformat, weather_model_name, out):
     hydro_file_name = os.path.join(out, hydroname)
     wet_file_name = os.path.join(out, wetname)
     return wet_file_name, hydro_file_name
-
-
-

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -69,6 +69,7 @@ DEFAULT_DICT = dict(
             os.getcwd(),
             'weather_files'
         ),
+        download_only=False,
         output_projection='EPSG:4236',
     )
 
@@ -94,7 +95,7 @@ def create_parser():
         help='generate default template (if it does not exist) and exit.'
     )
 
-    
+
     p.add_argument(
         '--download-only',
         action='store_true',
@@ -189,6 +190,8 @@ def read_template_file(fname):
                     template[k] = v
         if key == 'weather_model':
             template[key]= enforce_wm(value)
+        if key == 'download_only':
+            template[key] = bool(value)
         if key == 'time_group':
             template.update(enforce_time(AttributeDict(value)))
         if key == 'date_group':
@@ -240,13 +243,10 @@ def main(iargs=None):
     params = read_template_file(inps.customTemplateFile)
 
     # Argument checking
-    params = checkArgs(params)
-
-    params['download_only'] = inps.download_only
+    params = checkArgs(params, inps.download_only)
 
     if not params.verbose:
         logger.setLevel(logging.INFO)
-
 
     for t, w, f in zip(
         params['date_list'],
@@ -254,7 +254,30 @@ def main(iargs=None):
         params['hydroFilenames']
     ):
         try:
-            (_, _) = main_delay(t, w, f, params)
+            (_, _) = main_delay(t, w, f, params['los'], params['aoi'], params['ray_trace'],
+                                params['zref'], params['los_file'],
+                                params['height_levels'], params['dem'],
+                                params['use_dem_latlon'], params['bounding_box'],
+                                params['lat_file'], params['lon_file'],
+                                params['height_file_rdr'], params['station_file'],
+                                params['geocoded_file'], params['weather_model_directory'],
+                                params['weather_model'], params['cube_spacing_in_m'],
+                                params['download_only'],
+                                params['raster_format'], params['output_projection'],
+                                params['look_dir'], params['verbose'])
+
+
         except RuntimeError:
             logger.exception("Date %s failed", t)
             continue
+
+
+    # <RAiDER.losreader.Zenith object at 0x1a1354dc0>
+    # heights = None
+    # weather_model = <RAiDER.models.gmao.GMAO object at 0x1a0a239d0>
+    # wmLoc = /Users/buzzanga/Software_InSAR/RAiDER-docs_git/notebooks/RAiDER_tutorial/weather_files
+    # zref = 15000
+    # outformat=GTiff
+    # verboase = True
+    # aoi = <RAiDER.llreader.BoundingBox object at 0x1a0a239a0>
+    # download_only=False

--- a/tools/RAiDER/cli/raider.yaml
+++ b/tools/RAiDER/cli/raider.yaml
@@ -30,6 +30,7 @@ look_dir: right
 ## See https://github.com/dbekaert/RAiDER/blob/10686ee3f3533a33ca0788d866003c363f58fd5e/WeatherModels.md
 ## for more details and information on licensing
 weather_model:
+download_only: False # Download the weather model and do nothing further.
 
 
 ########## 2. Date

--- a/tools/RAiDER/cli/validators.py
+++ b/tools/RAiDER/cli/validators.py
@@ -33,17 +33,18 @@ def enforce_wm(value):
 
 
 def get_los(args):
-    if ('orbit_file' in args.keys()) and (args['orbit_file'] is not None):
+    if args.get('orbit_file'):
         if args.ray_trace:
             los = Raytracing(args.orbit_file)
         else:
             los = Conventional(args.orbit_file)
-    elif ('los_file' in args.keys()) and (args['los_file'] is not None):
+    elif args.get('los_file'):
         if args.ray_trace:
             los = Raytracing(args.los_file, args.los_convention)
         else:
             los = Conventional(args.los_file, args.los_convention)
-    elif ('los_cube' in args.keys()) and (args['los_cube'] is not None):
+
+    elif args.get('los_cube'):
         raise NotImplementedError('LOS_cube is not yet implemented')
 #        if args.ray_trace:
 #            los = Raytracing(args.los_cube)
@@ -114,7 +115,7 @@ def get_query_region(args):
     '''
     # Get bounds from the inputs
     # make sure this is first
-    if ('use_dem_latlon' in args.keys()) and args['use_dem_latlon']:
+    if 'use_dem_latlon' in args.keys():
         query = GeocodedFile(args.dem, is_dem=True)
 
     elif 'lat_file' in args.keys():
@@ -130,7 +131,7 @@ def get_query_region(args):
             raise ValueError('Lats are out of N/S bounds; are your lat/lon coordinates switched? Should be SNWE')
         query = BoundingBox(bbox)
 
-    elif 'geocoded_file' in args.keys():
+    elif'geocoded_file' in args.keys():
         query = GeocodedFile(args.geocoded_file, is_dem=False)
 
     ## untested
@@ -149,7 +150,7 @@ def enforce_bbox(bbox):
     """
     Enforce a valid bounding box
     """
-    bbox = [float(d) for d in bbox.strip().split()]
+    bbox = [float(d) for d in bbox.strip().split()] if isinstance(bbox, str) else bbox
 
     # Check the bbox
     if len(bbox) != 4:


### PR DESCRIPTION
I've changed the function calls to `main` and `tropo_delay_cube` to expose all arguments and allowing calling as a library.

It's pretty ugly.

I wonder if we should still force the library version to take a config file, as there are a lot of options.

I pushed a script `./test/test_library.py` that can be run to showcase how to use it.