### PR TITLE
Better handle package data for conda build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
     with:
-      conda_env_name: RAiDER
       python_version: '3.10'
 
   call-docker-ghcr-workflow:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
     with:
       conda_env_name: RAiDER
       python_version: '3.10'
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.7.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       release_branch: main

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.7.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,12 +14,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/provision-with-micromamba@v14
         with:
-          mamba-version: "*"
-          python-version: '3.10'
-          activate-environment: RAiDER
-          environment-file: environment.yml
+          extra-specs: |
+            python=3.10
 
       - name: install RAiDER
         shell: bash -l {0}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.7.0
     with:
       release_prefix: RAiDER
       develop_branch: dev

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.7.0
     with:
       user: dbekaert
       email: bekaertdavid@gmail.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1]
+
+### Fixed
++ Package data is more explicitly handled so that it is included in the conda-forge build; see [#467](https://github.com/dbekaert/RAiDER/pull/467)
+
 ## [0.4.0]
 
 Adding of new GUNW support to RAiDER. This is an interface delivery allowing for subsequent integration into HYP3 (input/output parsing is not expected to change; computed data is not yet verified). 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include LICENSE2.md
 include README.md
 include CHANGELOG.md
 
-graft tools
+graft tools/RAiDER
 
 global-exclude *.py[cod] __pycache__ *.so

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include LICENSE2.md
+include README.md
+include CHANGELOG.md
+
+graft tools
+
+global-exclude *.py[cod] __pycache__ *.so

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,0 @@
-include LICENSE
-include LICENSE2.md
-include README.md
-include CHANGELOG.md
-
-graft tools/RAiDER
-
-global-exclude *.py[cod] __pycache__ *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ zip-safe = false
 [tool.setuptools.packages.find]
 where = ["tools"]
 
+[tool.setuptools.package-data]
+"*" = ["*.yml", "*.yaml"]
+
 [tool.isort]
 known_first_party = "RAiDER"
 multi_line_output = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ repository = "https://github.com/dbekaert/RAiDER"
 "generateGACOSVRT.py"   = "RAiDER.models.generateGACOSVRT:main"
 
 [tool.setuptools]
+include-package-data = true
 zip-safe = false
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The current conda-forge build is missing a critical "package data" file. This PR explicitly calls out `*.yml` and `*.yaml` files inside `src/RAiDER` as package data so they are included in the archive.

NOTE: while a `MANIFEST.in` works for `pip` and `setuptools` everywhere outside of conda, conda-build would still not include the package data in the conda build. This is the only method that I could get to work. 

---

Explicitely calling out the package data, or including a `MANIFEST.in`, isn't supposed to be needed because everything is included via `setuptools_scm`. Importantly, when building the RAiDER distribution `setuptools_scm`  uses the `git` history (tags, tracked files) to define the package version and included files and produces a built src or binary distribution, which pip uses to install the package. 

when building the conda package, we're not actually cloning the repo, but instead downloading a git archive with **does not** include the `git` history. For the package version, we explicitly tell `setuptools_scm` which version to use:
https://github.com/conda-forge/raider-feedstock/blob/main/recipe/meta.yaml#L14
But we also need to explicitly tell it what files to include, which is what this PR does.

--- 

**Alternatively** we could switch to building the conda package from distribution published to PyPI, which *will* include metadata describing the version package files to include, but `pip` installs from PyPI won't work (easily at least) as we have dependencies that are conda-forge only (e.g., ISCE3) and compiled extensions (we'd need to build binary distributions for a variety of architectures). This is *not* a good user experience so we shouldn't do this unless we do the work to make installing from PyPI relatively easy.
