### PR TITLE
Prepare for Hyp3 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.2]
+
+## [0.4.1]
+
+### New/Updated Features
 + Reorder target points for intersection
 + Use exact coordinates of DEM to interpolate heights to target lat/lons
 + Support DEM interpolation to station file
-+ Implement end to end test for intersection of cube with lat/lon files
-+ Implement end to end test for calculation at stations delay
++ Implement end-to-end test for intersection of cube with lat/lon files
++ Implement end-to-end test for calculation at stations delay
 + Update AOI to store the output directory so DEM is written to right place
++ `calcDelaysGUNW` will optionally download a GUNW product from AWS S3, process it, and upload a new version of the GUNW product in-place with the tropospheric correction layers added so that RAiDER can be used in ARIA GUNW production via HyP3 
 
-## [0.4.1]
 ### Fixed
 + Package data is more explicitly handled so that it is included in the conda-forge build; see [#467](https://github.com/dbekaert/RAiDER/pull/467)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.profile && \
 
 RUN python -m pip install --no-cache-dir /RAiDER/
 
-ENTRYPOINT ["/usr/bin/bash"]
-CMD ["-l"]
+ENTRYPOINT ["/RAiDER/tools/RAiDER/etc/entrypoint.sh"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ or the current development version:
 docker pull ghcr.io/dbekaert/raider:test
 ```
 
-To run the container and jump into a bash shell inside:
+To run `raider.py` inside the container:
 ```
 docker run -it --rm ghcr.io/dbekaert/raider:latest
 ```
@@ -68,6 +68,11 @@ To mount your current directory inside the container so that files will be writt
 docker run -it -v ${PWD}:/home/raider/work --rm ghcr.io/dbekaert/raider:latest
 cd work
 ```
+To jump into a `bash` shell inside the container:
+```
+docker run -it --rm --entrypoint /bin/bash ghcr.io/dbekaert/raider:latest -l
+```
+
 For more docker run options, see: <https://docs.docker.com/engine/reference/run/>.
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
  - python>=3.8
  - pip
  # For running
+ - boto3
  - cdsapi
  - cfgrib
  - cmake

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -1,12 +1,11 @@
+import glob
 import os
 import shutil
-import glob
-import numpy as np
-import pytest
-import shutil
 import subprocess
-import xarray as xr
+
+import numpy as np
 import rasterio as rio
+import xarray as xr
 
 from test import TEST_DIR
 
@@ -38,7 +37,7 @@ def test_GUNW():
     # proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
     # assert np.isclose(proc.returncode, 0)
 
-    cmd  = f'raider.py ++process calcDelaysGUNW {updated_GUNW} -m {WM} -o {SCENARIO_DIR}'
+    cmd  = f'raider.py ++process calcDelaysGUNW -f {updated_GUNW} -m {WM} -o {SCENARIO_DIR}'
     proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
     assert np.isclose(proc.returncode, 0)
 

--- a/tools/RAiDER/aria/prepFromGUNW.py
+++ b/tools/RAiDER/aria/prepFromGUNW.py
@@ -231,11 +231,11 @@ def update_yaml(dct_cfg:dict, dst:str='GUNW.yaml'):
 def main(args):
     """ Read parameters needed for RAiDER from ARIA Standard Products (GUNW) """
 
-    GUNWObj = GUNW(args.file, args.model, args.output_directory)
+    GUNWObj = GUNW(args.file, args.weather_model, args.output_directory)
     GUNWObj()
 
     raider_cfg  = {
-           'weather_model': args.model,
+           'weather_model': args.weather_model,
            'look_dir':  GUNWObj.look_dir,
            'cube_spacing_in_m': GUNWObj.spacing_m,
            'aoi_group' : {'bounding_box': GUNWObj.SNWE},

--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -30,9 +30,6 @@ def get_content_type(file_location: Union[Path, str]) -> str:
 
 def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str = ''):
     path_to_file = Path(path_to_file)
-    if not path_to_file.suffix == '.nc':
-        raise ValueError(f'Expected ARIA GUNW NetCDF file. Got {path_to_file.suffix}. Exiting.')
-
     key = str(Path(prefix) / path_to_file)
     extra_args = {'ContentType': guess_type(key)}
 

--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -1,3 +1,4 @@
+from mimetypes import guess_type
 from pathlib import Path
 from typing import Union
 
@@ -20,13 +21,20 @@ def get_tag_set() -> dict:
     return tag_set
 
 
+def get_content_type(file_location: Union[Path, str]) -> str:
+    content_type = guess_type(file_location)[0]
+    if not content_type:
+        content_type = 'application/octet-stream'
+    return content_type
+
+
 def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str = ''):
     path_to_file = Path(path_to_file)
     if not path_to_file.suffix == '.nc':
         raise ValueError(f'Expected ARIA GUNW NetCDF file. Got {path_to_file.suffix}. Exiting.')
 
     key = str(Path(prefix) / path_to_file)
-    extra_args = {'ContentType': 'application/geo+json'}
+    extra_args = {'ContentType': guess_type(key)}
 
     logger.info(f'Uploading s3://{bucket}/{key}')
     S3_CLIENT.upload_file(str(path_to_file), bucket, key, extra_args)

--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -1,8 +1,9 @@
-import logging
 from pathlib import Path
 from typing import Union
 
 import boto3
+
+from RAiDER.logger import logger
 
 S3_CLIENT = boto3.client('s3')
 
@@ -27,7 +28,7 @@ def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str =
     key = str(Path(prefix) / path_to_file)
     extra_args = {'ContentType': 'application/geo+json'}
 
-    logging.info(f'Uploading s3://{bucket}/{key}')
+    logger.info(f'Uploading s3://{bucket}/{key}')
     S3_CLIENT.upload_file(str(path_to_file), bucket, key, extra_args)
 
     tag_set = get_tag_set()
@@ -41,6 +42,7 @@ def get_s3_file(bucket_name, bucket_prefix, file_type: str):
         key = s3_object['Key']
         if key.endswith(file_type):
             file_name = Path(key).name
+            logger.info(f'Downloading s3://{bucket_name}/{key} to {file_name}')
             S3_CLIENT.download_file(bucket_name, key, file_name)
             return file_name
 

--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -1,0 +1,46 @@
+import logging
+from pathlib import Path
+from typing import Union
+
+import boto3
+
+S3_CLIENT = boto3.client('s3')
+
+
+def get_tag_set() -> dict:
+    tag_set = {
+        'TagSet': [
+            {
+                'Key': 'file_type',
+                'Value': 'product'
+            }
+        ]
+    }
+    return tag_set
+
+
+def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str = ''):
+    path_to_file = Path(path_to_file)
+    if not path_to_file.suffix == '.nc':
+        raise ValueError(f'Expected ARIA GUNW NetCDF file. Got {path_to_file.suffix}. Exiting.')
+
+    key = str(Path(prefix) / path_to_file)
+    extra_args = {'ContentType': 'application/geo+json'}
+
+    logging.info(f'Uploading s3://{bucket}/{key}')
+    S3_CLIENT.upload_file(str(path_to_file), bucket, key, extra_args)
+
+    tag_set = get_tag_set()
+
+    S3_CLIENT.put_object_tagging(Bucket=bucket, Key=key, Tagging=tag_set)
+
+
+def get_s3_file(bucket_name, bucket_prefix, file_type: str):
+    result = S3_CLIENT.list_objects_v2(Bucket=bucket_name, Prefix=bucket_prefix)
+    for s3_object in result['Contents']:
+        key = s3_object['Key']
+        if key.endswith(file_type):
+            file_name = Path(key).name
+            S3_CLIENT.download_file(bucket_name, key, file_name)
+            return file_name
+

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -397,7 +397,7 @@ def calcDelaysGUNW():
         )
 
     p.add_argument(
-        '-m', '--model', default='HRRR', type=str,
+        '-m', '--weather_model', default='HRRR', type=str,
         help='Weather model.'
         )
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -6,9 +6,7 @@ import yaml
 
 from textwrap import dedent
 
-import RAiDER
 from RAiDER import aws
-from RAiDER.constants import _ZREF, _CUBE_SPACING_IN_M
 from RAiDER.logger import logger, logging
 from RAiDER.cli import DEFAULT_DICT, AttributeDict
 from RAiDER.cli.parser import add_out, add_cpus, add_verbose
@@ -45,8 +43,9 @@ def read_template_file(fname):
     >>> template = read_template_file('raider.yaml')
 
     """
-    from RAiDER.cli.validators import (enforce_time, enforce_bbox, parse_dates,
-                            get_query_region, get_heights, get_los, enforce_wm)
+    from RAiDER.cli.validators import (
+        enforce_time, parse_dates, get_query_region, get_heights, get_los, enforce_wm
+    )
     with open(fname, 'r') as f:
         try:
             params = yaml.safe_load(f)
@@ -162,7 +161,7 @@ def calcDelays(iargs=None):
         dst = os.path.join(os.getcwd(), 'raider.yaml')
         shutil.copyfile(template_file, dst)
         logger.info('Wrote %s', dst)
-        os.sys.exit()
+        sys.exit()
 
 
     # check: existence of input template files
@@ -383,35 +382,37 @@ def calcDelaysGUNW():
         description='Calculate a cube of interferometic delays for GUNW files',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    p.add_argument('--bucket',
-                   help='S3 bucket containing ARIA GUNW NetCDF file. Will be ignored if the --file argument is provided.'
-                   )
+    p.add_argument(
+        '--bucket',
+        help='S3 bucket containing ARIA GUNW NetCDF file. Will be ignored if the --file argument is provided.'
+    )
 
-    p.add_argument('--bucket-prefix', default='',
-                   help='S3 bucket containing ARIA GUNW NetCDF file. Will be ignored if the --file argument is provided.'
-                   )
+    p.add_argument(
+        '--bucket-prefix', default='',
+        help='S3 bucket prefix containing ARIA GUNW NetCDF file. Will be ignored if the --file argument is provided.'
+    )
 
     p.add_argument(
         '--file', type=str,
         help='1 ARIA GUNW netcdf file'
-        )
+    )
 
     p.add_argument(
         '-m', '--weather_model', default='HRRR', type=str,
         choices=['None', 'HRRR', 'HRES', 'GMAO'], help='Weather model.'
-        )
+    )
 
     p.add_argument(
         '-o', '--output_directory', default=os.getcwd(), type=str,
         help='Directory to store results.'
-        )
+    )
 
     p.add_argument(
         '-u', '--update_GUNW', default=True,
         help='Optionally update the GUNW by writing the delays into the troposphere group.'
-        )
+    )
     
-    args       = p.parse_args()
+    args = p.parse_args()
 
     if args.weather_model == 'None':
         # NOTE: HyP3's current step function implementation does not have a good way of conditionally
@@ -430,15 +431,15 @@ def calcDelaysGUNW():
         raise ValueError('Either argument --file or --bucket must be provided')
 
     # prep the config needed for delay calcs
-    path_cfg, wavelength   = GUNW_prep(args)
+    path_cfg, wavelength = GUNW_prep(args)
 
-    ## write delay cube (nc) to disk using config
-    ## return a list with the path to cube for each date
+    # write delay cube (nc) to disk using config
+    # return a list with the path to cube for each date
     cube_filenames = calcDelays([path_cfg])
 
-    ## calculate the interferometric phase and write it out
+    # calculate the interferometric phase and write it out
     GUNW_calc(cube_filenames, args.file, wavelength, args.output_directory, args.update_GUNW)
 
-    ## upload to s3
+    # upload to s3
     if args.bucket:
         aws.upload_file_to_s3(args.file, args.bucket, args.bucket_prefix)

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -414,6 +414,10 @@ def calcDelaysGUNW():
     args       = p.parse_args()
 
     if args.weather_model == 'None':
+        # NOTE: HyP3's current step function implementation does not have a good way of conditionally
+        #       running processing steps. This allows HyP3 to always run this step but exit immediately
+        #       and do nothing if tropospheric correction via RAiDER is not selected. This should not cause
+        #       any appreciable cost increase to GUNW product generation.
         print('Nothing to do!')
         return
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -411,11 +411,12 @@ def calcDelaysGUNW():
         help='Optionally update the GUNW by writing the delays into the troposphere group.'
         )
     
+    args       = p.parse_args()
+
     if args.weather_model == 'None':
         print('Nothing to do!')
         return
 
-    args       = p.parse_args()
     # args.files = glob.glob(args.files) # eventually support multiple files
     if args.file:
         pass

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -423,11 +423,9 @@ def calcDelaysGUNW():
         return
 
     # args.files = glob.glob(args.files) # eventually support multiple files
-    if args.file:
-        pass
-    elif args.bucket:
+    if not args.file and args.bucket:
         args.file = aws.get_s3_file(args.bucket, args.bucket_prefix, '.nc')
-    else:
+    elif not args.file:
         raise ValueError('Either argument --file or --bucket must be provided')
 
     # prep the config needed for delay calcs

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -398,17 +398,17 @@ def calcDelaysGUNW():
     )
 
     p.add_argument(
-        '-m', '--weather_model', default='HRRR', type=str,
+        '-m', '--weather-model', default='HRRR', type=str,
         choices=['None', 'HRRR', 'HRES', 'GMAO'], help='Weather model.'
     )
 
     p.add_argument(
-        '-o', '--output_directory', default=os.getcwd(), type=str,
+        '-o', '--output-directory', default=os.getcwd(), type=str,
         help='Directory to store results.'
     )
 
     p.add_argument(
-        '-u', '--update_GUNW', default=True,
+        '-u', '--update-GUNW', default=True,
         help='Optionally update the GUNW by writing the delays into the troposphere group.'
     )
     

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -393,7 +393,7 @@ def calcDelaysGUNW():
     )
 
     p.add_argument(
-        '--file', type=str,
+        '-f', '--file', type=str,
         help='1 ARIA GUNW netcdf file'
     )
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -398,7 +398,7 @@ def calcDelaysGUNW():
 
     p.add_argument(
         '-m', '--weather_model', default='HRRR', type=str,
-        help='Weather model.'
+        choices=['None', 'HRRR', 'HRES', 'GMAO'], help='Weather model.'
         )
 
     p.add_argument(
@@ -410,7 +410,10 @@ def calcDelaysGUNW():
         '-u', '--update_GUNW', default=True,
         help='Optionally update the GUNW by writing the delays into the troposphere group.'
         )
-
+    
+    if args.weather_model == 'None':
+        print('Nothing to do!')
+        return
 
     args       = p.parse_args()
     # args.files = glob.glob(args.files) # eventually support multiple files

--- a/tools/RAiDER/etc/entrypoint.sh
+++ b/tools/RAiDER/etc/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash --login
 set -e
-conda activate raider
+conda activate RAiDER
 exec raider.py "$@"

--- a/tools/RAiDER/etc/entrypoint.sh
+++ b/tools/RAiDER/etc/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash --login
+set -e
+conda activate raider
+exec raider.py "$@"


### PR DESCRIPTION
To support RAiDER processing of GUNW's in HyP3, we need:
* to download the GUNW from S3
* Replace the GUNW in S3 with an updated version including the tropospheric corrections

which is all handled via the new `RAiDER.aws` module (adds `boto3` as a dependency)

This PR changes the GUNW interface to:
* make `file` argument optional `--file`
* if `--file` is not provided:
  * and a `--bucket` argument is provided: download GUNW from S3
  * and a `--bucket` argument is *not* provided: throw an error
* changes the `--model` argument to `--weather-model`
* replaces `_` with `-` in arguments. E.g., `--output-directory` instead of `--output_directory` (argparse automatically casts `-` to `_` in argument variable names)
  
This PR also
* changes the Docker entrypoint from `bash` to `raider.py`
* Fixes next version number in Changelog
* removes a bunch of unused imports  

