### PR TITLE
Fix content type error

### DIFF
--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -31,7 +31,7 @@ def get_content_type(file_location: Union[Path, str]) -> str:
 def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str = ''):
     path_to_file = Path(path_to_file)
     key = str(Path(prefix) / path_to_file)
-    extra_args = {'ContentType': guess_type(key)}
+    extra_args = {'ContentType': get_content_type(key)}
 
     logger.info(f'Uploading s3://{bucket}/{key}')
     S3_CLIENT.upload_file(str(path_to_file), bucket, key, extra_args)


### PR DESCRIPTION
I called the wrong function :roll_eyes: so introduced a bug that fails with:

[`botocore.exceptions.ParamValidationError: Parameter validation failed: Invalid type for parameter ContentType, value: ('application/x-netcdf', None), type: <class 'tuple'>, valid types: <class 'str'>`](https://sandbox-insar-isce-contentbucket-ht0a62ksntf0.s3.us-west-2.amazonaws.com/41d9d85b-e12c-45be-bc3d-af9ff18eabf3/41d9d85b-e12c-45be-bc3d-af9ff18eabf3.log)