### PR TITLE
calcDelaysGUNW - added api credentials check and writing locally [Issue: #483]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 + Removed NCMR removed from supported model list till re-tested 
 
 
-## [0.4.1]
 
 ### New/Updated Features
 + Reorder target points for intersection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### New/Updated Features
 + `calcDelaysGUNW` allows processing with any supported weather model as listed in [`RAiDER.models.allowed.ALLOWED_MODELS`](https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/models/allowed.py).
 + Removed NCMR removed from supported model list till re-tested 
++ `credentials` looks for weather model API credentials RC_file hidden file, and creates it if it does not exists [#483]
 
-
+## [0.4.1]
 
 ### New/Updated Features
 + Reorder target points for intersection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New/Updated Features
 + `calcDelaysGUNW` allows processing with any supported weather model as listed in [`RAiDER.models.allowed.ALLOWED_MODELS`](https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/models/allowed.py).
++ Added function to look for weather model API credentials [RAIDER/tools/models/credentials.py] RC hidden file, and creates it if it does not exists [#483] 
+Added api_key and api_uid to `calcDelaysGUNW` args, to allow passing API credentials 
 
 ## [0.4.1]
 

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -1,0 +1,69 @@
+import os
+from RAiDER.models import credentials
+
+# Test checking/creating ECMWF_RC CAPI file
+def test_ecmwfApi_createFile():
+    import ecmwfapi
+    
+    # Test creation of ~/.ecmwfapirc file
+    ecmwf_file = os.path.expanduser('./.') + credentials.API_FILENAME['ERAI']
+    credentials.check_api('ERAI', 'dummy', 'dummy', './', update_flag=True)
+    assert os.path.exists(ecmwf_file) == True,f'{ecmwf_file} does not exist' 
+
+    # Get existing ECMWF_API_RC env if exist
+    default_ecmwf_file = os.getenv("ECMWF_API_RC_FILE")
+    if default_ecmwf_file is None:
+        default_ecmwf_file = ecmwfapi.api.DEFAULT_RCFILE_PATH
+
+    #Set it to current dir to avoid overwriting ~/.ecmwfapirc file 
+    os.environ["ECMWF_API_RC_FILE"] = ecmwf_file
+    key, url, uid = ecmwfapi.api.get_apikey_values()
+    
+    # Return to default_ecmwf_file and remove local API file
+    os.environ["ECMWF_API_RC_FILE"] = default_ecmwf_file 
+    os.remove(ecmwf_file)
+
+    #Check if API is written correctly
+    assert uid ==  'dummy', f'{ecmwf_file}: UID was not written correctly'
+    assert key == 'dummy', f'{ecmwf_file}: KEY was not written correctly'
+
+
+# Test checking/creating Copernicus Climate Data Store
+#   CDS_RC CAPI file 
+def test_cdsApi_createFile():
+    import cdsapi
+    
+    # Test creation of .cdsapirc file in current dir
+    cds_file = os.path.expanduser('./.') + credentials.API_FILENAME['ERA5']
+    credentials.check_api('ERA5', 'dummy', 'dummy', './', update_flag=True)
+    assert os.path.exists(cds_file) == True,f'{cds_file} does not exist' 
+
+    # Check the content
+    cds_credentials = cdsapi.api.read_config(cds_file)
+    uid, key = cds_credentials['key'].split(':')
+
+    # Remove local API file
+    os.remove(cds_file)
+    
+    assert uid ==  'dummy', f'{cds_file}: UID was not written correctly'
+    assert key == 'dummy', f'{cds_file}: KEY was not written correctly'
+
+# Test checking/creating EARTHDATA_RC API file 
+def test_netrcApi_createFile():
+    import netrc
+    
+    # Test creation of ~/.cdsapirc file
+    netrc_file = os.path.expanduser('./.') + credentials.API_FILENAME['GMAO']
+    credentials.check_api('GMAO', 'dummy', 'dummy', './', update_flag=True)
+    assert os.path.exists(netrc_file) == True,f'{netrc_file} does not exist' 
+
+    # Check the content
+    host = credentials.API_URLS[credentials.API_FILENAME['GMAO']]
+    netrc_credentials = netrc.netrc(netrc_file)
+    uid, _, key = netrc_credentials.authenticators(host)
+
+    # Remove local API file
+    os.remove(netrc_file)
+    
+    assert uid ==  'dummy', f'{netrc_file}: UID was not written correctly'
+    assert key == 'dummy', f'{netrc_file}: KEY was not written correctly'

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -1,12 +1,16 @@
 import os
+from platform import system
 from RAiDER.models import credentials
 
 # Test checking/creating ECMWF_RC CAPI file
 def test_ecmwfApi_createFile():
     import ecmwfapi
     
+    #Check extension for hidden files
+    hidden_ext = '_' if system()=="Windows" else '.'
+
     # Test creation of ~/.ecmwfapirc file
-    ecmwf_file = os.path.expanduser('./.') + credentials.API_FILENAME['ERAI']
+    ecmwf_file = os.path.expanduser('./') + hidden_ext + credentials.API_FILENAME['ERAI']
     credentials.check_api('ERAI', 'dummy', 'dummy', './', update_flag=True)
     assert os.path.exists(ecmwf_file) == True,f'{ecmwf_file} does not exist' 
 
@@ -32,9 +36,12 @@ def test_ecmwfApi_createFile():
 #   CDS_RC CAPI file 
 def test_cdsApi_createFile():
     import cdsapi
+
+    #Check extension for hidden files
+    hidden_ext = '_' if system()=="Windows" else '.'
     
     # Test creation of .cdsapirc file in current dir
-    cds_file = os.path.expanduser('./.') + credentials.API_FILENAME['ERA5']
+    cds_file = os.path.expanduser('./') + hidden_ext + credentials.API_FILENAME['ERA5']
     credentials.check_api('ERA5', 'dummy', 'dummy', './', update_flag=True)
     assert os.path.exists(cds_file) == True,f'{cds_file} does not exist' 
 
@@ -52,13 +59,16 @@ def test_cdsApi_createFile():
 def test_netrcApi_createFile():
     import netrc
     
+    #Check extension for hidden files
+    hidden_ext = '_' if system()=="Windows" else '.'
+
     # Test creation of ~/.cdsapirc file
-    netrc_file = os.path.expanduser('./.') + credentials.API_FILENAME['GMAO']
+    netrc_file = os.path.expanduser('./') + hidden_ext + credentials.API_FILENAME['GMAO']
     credentials.check_api('GMAO', 'dummy', 'dummy', './', update_flag=True)
     assert os.path.exists(netrc_file) == True,f'{netrc_file} does not exist' 
 
     # Check the content
-    host = credentials.API_URLS[credentials.API_FILENAME['GMAO']]
+    host = 'urs.earthdata.nasa.gov'
     netrc_credentials = netrc.netrc(netrc_file)
     uid, _, key = netrc_credentials.authenticators(host)
 

--- a/tools/RAiDER/aria/prepFromGUNW.py
+++ b/tools/RAiDER/aria/prepFromGUNW.py
@@ -15,6 +15,7 @@ import shapely.wkt
 import RAiDER
 from RAiDER.utilFcns import rio_open, writeArrayToRaster
 from RAiDER.logger import logger
+from RAiDER.models import credentials
 from eof.download import download_eofs
 
 ## cube spacing in degrees for each model
@@ -230,6 +231,10 @@ def update_yaml(dct_cfg:dict, dst:str='GUNW.yaml'):
 
 def main(args):
     """ Read parameters needed for RAiDER from ARIA Standard Products (GUNW) """
+
+    # Check if WEATHER MODEL API credentials exists, if not create them or raise ERROR
+    credentials.check_api(args.weather_model, args.api_uid, args.api_key,
+                          prompt_flag=False, update_flag=False)
 
     GUNWObj = GUNW(args.file, args.weather_model, args.output_directory)
     GUNWObj()

--- a/tools/RAiDER/aria/prepFromGUNW.py
+++ b/tools/RAiDER/aria/prepFromGUNW.py
@@ -232,7 +232,7 @@ def update_yaml(dct_cfg:dict, dst:str='GUNW.yaml'):
 def main(args):
     """ Read parameters needed for RAiDER from ARIA Standard Products (GUNW) """
 
-    # Check if WEATHER MODEL API credentials exists, if not create them or raise ERROR
+    # Check if WEATHER MODEL API credentials hidden file exists, if not create it or raise ERROR
     credentials.check_api(args.weather_model, args.api_uid, args.api_key,
                           prompt_flag=False, update_flag=False)
 

--- a/tools/RAiDER/aria/prepFromGUNW.py
+++ b/tools/RAiDER/aria/prepFromGUNW.py
@@ -233,8 +233,7 @@ def main(args):
     """ Read parameters needed for RAiDER from ARIA Standard Products (GUNW) """
 
     # Check if WEATHER MODEL API credentials hidden file exists, if not create it or raise ERROR
-    credentials.check_api(args.weather_model, args.api_uid, args.api_key,
-                          prompt_flag=False, update_flag=False)
+    credentials.check_api(args.weather_model, args.api_uid, args.api_key)
 
     GUNWObj = GUNW(args.file, args.weather_model, args.output_directory)
     GUNWObj()

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -404,6 +404,16 @@ def calcDelaysGUNW():
     )
 
     p.add_argument(
+        '-uid', '--api_uid', default=None, type=str, 
+        help='Weather model API UID [uid, email, username], depending on model.'
+    )
+
+    p.add_argument(
+        '-key', '--api_key', default=None, type=str, 
+        help='Weather model API KEY [key, password], depending on model.'
+    )
+
+    p.add_argument(
         '-o', '--output-directory', default=os.getcwd(), type=str,
         help='Directory to store results.'
     )
@@ -428,7 +438,7 @@ def calcDelaysGUNW():
         args.file = aws.get_s3_file(args.bucket, args.bucket_prefix, '.nc')
     elif not args.file:
         raise ValueError('Either argument --file or --bucket must be provided')
-
+    
     # prep the config needed for delay calcs
     path_cfg, wavelength = GUNW_prep(args)
 

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -1,6 +1,6 @@
 '''
-dict that hold api information and help url for downloading weather model data
-   -  api information is stored in hidden file in home directory 
+dict that holds api information and help url for downloading weather model data
+   -  api information is stored in a hidden file in home directory 
 
         api filename      weather models          uid           key
         cdsapirc          ERA5, ERA5T             uid           key

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -113,8 +113,8 @@ def check_api(model: str,
         api_filename_path = api_filename_path.expanduser()
 
         # if update flag is on, overwrite existing file 
-        if update_flag:
-            api_filename_path.unlink() if update_flag==True and api_filename_path.exists() else None
+        if update_flag is True:
+            api_filename_path.unlink(missing_ok=True)
         
         # Check if API_RC file already exists
         if not api_filename_path.exists() and UID and KEY:

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -2,7 +2,7 @@
 API credential information and help url for downloading weather model data 
     saved in a hidden file in home directory 
 
-api filename      weather models          uid           key           host
+api filename      weather models          UID           KEY         URL
 _________________________________________________________________________________
 cdsapirc          ERA5, ERA5T             uid           key         https://cds.climate.copernicus.eu/api/v2
 ecmwfapirc        ERAI, HRES              email         key         https://api.ecmwf.int/v1
@@ -11,6 +11,8 @@ netrc             GMAO, MERRA2            username      password    urs.earthdat
 '''
 
 import os
+from pathlib import Path
+from platform import system
 
 # Filename for the hidden file per model
 API_FILENAME = {'ERA5'  : 'cdsapirc',
@@ -18,35 +20,8 @@ API_FILENAME = {'ERA5'  : 'cdsapirc',
                 'ERAI'  : 'ecmwfapirc',
                 'HRES'  : 'ecmwfapirc',
                 'GMAO'  : 'netrc',
-                'MERRA2': 'netrc',
                 'HRRR'  :  None
                 }
-
-# system environmental variables for API credentials
-'''
-cdsapi : already has as default set to look for CDSAPI_URL, CDSAPI_KEY
-         https://github.com/ecmwf/cdsapi/blob/master/cdsapi/api.py LINE:253, 254
-         however, if hidden file CDSAPI_RC exists, it overwrites CDSAPI_URL, CDSAPI_KEY
-
-         CDSAPI_KEY = UID:KEY
-
-ecmwfapir : same as above, looks for the envs however they are not selected as default input (default: anonymous)
-            https://github.com/ecmwf/ecmwf-api-client/blob/master/ecmwfapi/api.py
-'''
-
-API_ENVIRONMENTS= {
-    'cdsapirc'   : {'uid' : 'CDSAPI_KEY', #Not Needed
-                    'key' : 'CDSAPI_KEY',
-                    'host': 'CDSAPI_URL'},
-
-    'ecmwfapirc' : {'uid' : 'ECMWF_API_EMAIL',
-                    'key' : 'ECMWF_API_KEY',
-                    'host': 'ECMWF_API_URL'},
-                    
-    'netrc'      : {'uid' : 'EARTHDATA_USERNAME',
-                    'key' : 'EARTHDATA_PASSWORD',
-                    'host': 'EARTHDATA_URL'} #Added this one in case of url change
-                    }
 
 # API urls
 API_URLS = {'cdsapirc'   : 'https://cds.climate.copernicus.eu/api/v2',
@@ -77,38 +52,39 @@ API_CREDENTIALS_DICT = {
                        'help_url': 'https://wiki.earthdata.nasa.gov/display/EL/How+To+Access+Data+With+cURL+And+Wget'
                        }
                 }
-# List existing API variables
-def find_existing_APIenvs():
-    env_api_dict = {}
-    for rc in API_ENVIRONMENTS.keys():
-        uid = API_ENVIRONMENTS [rc]['uid']
-        key = API_ENVIRONMENTS [rc]['key'] 
-        host = API_ENVIRONMENTS [rc]['host']
-        env_api_dict[uid] = os.getenv(uid)
-        env_api_dict[key] = os.getenv(key)
-        env_api_dict[host] = os.getenv(host)
-    return env_api_dict
+
+# system environmental variables for API credentials
+'''
+ENV variables in cdsapi and ecmwapir
+
+cdsapi ['cdsapirc'] : CDSAPI_KEY [UID:KEY], 'CDSAPI_URL'
+ecmwfapir [ecmwfapirc] : 'ECMWF_API_KEY', 'ECMWF_API_EMAIL','ECMWF_API_URL'  
+
+'''
 
 # Check if API enviroments exists
-def _check_envs(api):
-    # First check if API host env exist, if not use the default ones
-    try:
-        host = os.getenv(API_ENVIRONMENTS[api]['host'])
-    except (RuntimeError):
-        pass
-    else:
-        host = API_URLS[api] 
+def _check_envs(model):
+    if model in ('ERA5', 'ERA5T'):
+        uid = os.getenv('RAIDER_ECMWF_ERA5_UID')
+        key = os.getenv('RAIDER_ECMWF_ERA5_API_KEY')
+        host = API_URLS['cdsapirc']
 
-    # Second check for API env credentials
-    try:
-        if api == 'cdsapirc':
-            uid, key  = os.getenv(API_ENVIRONMENTS[api]['key']).split(':')
-        else:
-            uid  = os.getenv(API_ENVIRONMENTS[api]['uid'])
-            key = os.getenv(API_ENVIRONMENTS[api]['key']) 
-        return uid, key, host
-    except:
-        return None, None, host
+    elif model in ('HRES'):
+        uid = os.getenv('RAIDER_HRES_EMAIL') 
+        key = os.getenv('RAIDER_HRES_API_KEY')
+        host = os.getenv('RAIDER_HRES_URL')
+        if host is None:
+            host = API_URLS['ecmwfapirc']
+
+    elif model in ('GMAO'):
+        uid = os.getenv('EARTHDATA_USERNAME') # same as in Dockerized
+        key = os.getenv('EARTHDATA_PASSWORD')
+        host = API_URLS['netrc']
+
+    else:
+        uid, key, host = None, None, None
+
+    return uid, key, host
 
 # Check and write MODEL API_RC_FILE for downloading weather model data
 def check_api(model: str,
@@ -123,43 +99,46 @@ def check_api(model: str,
 
     # Get API credential from os.env if UID/KEY are not inserted
     if UID is None and KEY is None:
-        UID, KEY, URL = _check_envs(api_filename)
+        UID, KEY, URL = _check_envs(model)
     else:
         URL = API_URLS[api_filename]
+
+    # Get hidden ext for Windows
+    hidden_ext = '_' if system()=="Windows" else '.'
 
     # skip below if model is HRRR as it does not need API
     if api_filename:    
         # Check if the credential api file exists
-        api_filename_path = os.path.expanduser(output_dir) + f'.{api_filename}'
+        api_filename_path = Path(output_dir) / (hidden_ext + api_filename)
+        api_filename_path = api_filename_path.expanduser()
 
         # if update flag is on, overwrite existing file 
         if update_flag:
-            if os.path.exists(api_filename_path):
-                os.remove(api_filename_path) 
+            api_filename_path.unlink() if update_flag==True and api_filename_path.exists() else None
         
         # Check if API_RC file already exists
-        if not os.path.exists(api_filename_path): 
-
-            # Credential API file does not exist, create it
-            if UID is None or KEY is None:
-                url = API_CREDENTIALS_DICT[api_filename]['help_url']
-
-                # Raise ERROR in case only UID or KEY is inserted
-                if UID is not None and KEY is None:
-                    raise ValueError('ERROR: API UID not inserted!')
-                elif UID is None and KEY is not None:
-                    raise ValueError('ERROR: API KEY not inserted!')
-                else:
-                    #Raise ERROR is both UID/KEY are none
-                    raise ValueError(
-                            f'{api_filename_path}, API ENVIRONMENTALS'
-                            f' and API UID and KEY, do not exist !!'
-                            f'\nGet API info from ' + '\033[1m' f'{url}' + '\033[0m, and add it!')
-                    
+        if not api_filename_path.exists() and UID and KEY:
             # Create file with inputs, do it only once
             print(f'Writing {api_filename_path} locally!')
-            with open(api_filename_path, 'w') as f:
-                f.write(API_CREDENTIALS_DICT[api_filename]['api'].format(uid=UID,
-                                                                         key=KEY,
-                                                                         host=URL))
-            os.system(f'chmod 0600 {api_filename_path}')
+            api_filename_path.write_text(API_CREDENTIALS_DICT[api_filename]['api'].format(uid=UID,
+                                                                                          key=KEY,
+                                                                                          host=URL))
+            api_filename_path.chmod(0o000600)
+
+        else:
+            # Raise ERROR message
+            help_url = API_CREDENTIALS_DICT[api_filename]['help_url']
+
+            # Raise ERROR in case only UID or KEY is inserted
+            if UID is not None and KEY is None:
+                raise ValueError(f'ERROR: API UID not inserted'
+                                    f' or does not exist in ENVIRONMENTALS!')
+            elif UID is None and KEY is not None:
+                raise ValueError(f'ERROR: API KEY not inserted'
+                                    f' or does not exist in ENVIRONMENTALS!')
+            else:
+                #Raise ERROR is both UID/KEY are none
+                raise ValueError(
+                        f'{api_filename_path}, API ENVIRONMENTALS'
+                        f' and API UID and KEY, do not exist !!'
+                        f'\nGet API info from ' + '\033[1m' f'{help_url}' + '\033[0m, and add it!')

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -56,7 +56,7 @@ API_URLS = {'cdsapirc'   : 'https://cds.climate.copernicus.eu/api/v2',
 # api credentials dict
 API_CREDENTIALS_DICT = {
         'cdsapirc' :   {'api' : """\
-                                url: {host}\
+                                \nurl: {host}\
                                 \nkey: {uid}:{key}
                                 """,
                         'help_url' : 'https://cds.climate.copernicus.eu/api-how-to'
@@ -77,6 +77,17 @@ API_CREDENTIALS_DICT = {
                        'help_url': 'https://wiki.earthdata.nasa.gov/display/EL/How+To+Access+Data+With+cURL+And+Wget'
                        }
                 }
+# List existing API variables
+def find_existing_APIenvs():
+    env_api_dict = {}
+    for rc in API_ENVIRONMENTS.keys():
+        uid = API_ENVIRONMENTS [rc]['uid']
+        key = API_ENVIRONMENTS [rc]['key'] 
+        host = API_ENVIRONMENTS [rc]['host']
+        env_api_dict[uid] = os.getenv(uid)
+        env_api_dict[key] = os.getenv(key)
+        env_api_dict[host] = os.getenv(host)
+    return env_api_dict
 
 # Check if API enviroments exists
 def _check_envs(api):
@@ -84,7 +95,7 @@ def _check_envs(api):
     try:
         host = os.getenv(API_ENVIRONMENTS[api]['host'])
     except (RuntimeError):
-        print('Unable to get API url env!')
+        pass
     else:
         host = API_URLS[api] 
 
@@ -103,37 +114,48 @@ def _check_envs(api):
 def check_api(model: str,
               UID: str = None,
               KEY: str = None,
+              output_dir : str = '~/',
               update_flag: bool = False) -> None:
 
-    # Weather model credential filename
+    # Weather model API filename
     # typically stored in home dir as hidden file
     api_filename = API_FILENAME[model]
 
-    # Get API credential from os.env if they exist
-    UID, KEY, URL = _check_envs(api_filename)
+    # Get API credential from os.env if UID/KEY are not inserted
+    if UID is None and KEY is None:
+        UID, KEY, URL = _check_envs(api_filename)
+    else:
+        URL = API_URLS[api_filename]
 
     # skip below if model is HRRR as it does not need API
     if api_filename:    
         # Check if the credential api file exists
-        api_filename_path = os.path.expanduser('~/.') + f'{api_filename}'
+        api_filename_path = os.path.expanduser(output_dir) + f'.{api_filename}'
 
-        # if update flag is on, delete existing file and update it
+        # if update flag is on, overwrite existing file 
         if update_flag:
             if os.path.exists(api_filename_path):
                 os.remove(api_filename_path) 
-            
+        
+        # Check if API_RC file already exists
         if not os.path.exists(api_filename_path): 
+
             # Credential API file does not exist, create it
-            # Need api information
             if UID is None or KEY is None:
                 url = API_CREDENTIALS_DICT[api_filename]['help_url']
-                
-                #Raise ERROR
-                msg = f'{api_filename_path}, API ENVIRONMENTALS and weather model'
-                msg += 'credentials API UID and KEY, do not exist !!'
-                msg += '\nGet API info from ' + '\033[1m' f'{url}' + '\033[0m, and add it!'
-                raise ValueError(msg)
-                
+
+                # Raise ERROR in case only UID or KEY is inserted
+                if UID is not None and KEY is None:
+                    raise ValueError('ERROR: API UID not inserted!')
+                elif UID is None and KEY is not None:
+                    raise ValueError('ERROR: API KEY not inserted!')
+                else:
+                    #Raise ERROR is both UID/KEY are none
+                    raise ValueError(
+                            f'{api_filename_path}, API ENVIRONMENTALS'
+                            f' and API UID and KEY, do not exist !!'
+                            f'\nGet API info from ' + '\033[1m' f'{url}' + '\033[0m, and add it!')
+                    
             # Create file with inputs, do it only once
             print(f'Writing {api_filename_path} locally!')
             with open(api_filename_path, 'w') as f:

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -44,7 +44,7 @@ def check_api(model: str,
     # Weather model credential filename
     # typically stored in home dir as hidden file
     if model in ('ERA5', 'ERA5T'):
-        ap_filename = 'cdsapirc'
+        api_filename = 'cdsapirc'
     elif model in ('ERAI, HRES'):
         api_filename = 'ecmwfapirc'
     elif model in ('GMAO'):

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -99,7 +99,7 @@ def _check_envs(api):
     except:
         return None, None, host
 
-# Check and write MODEL API credential for downloading weather model data
+# Check and write MODEL API_RC_FILE for downloading weather model data
 def check_api(model: str,
               UID: str = None,
               KEY: str = None,

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -1,0 +1,90 @@
+'''
+dict that hold api information and help url for downloading weather model data
+   -  api information is stored in hidden file in home directory 
+
+        api filename      weather models          uid           key
+        cdsapirc          ERA5, ERA5T             uid           key
+        ecmwfapirc        ERAI, HRES              email         key
+        netrc             GMAO, MERRA2            username      password
+        <NAN>             HRRR [public access]    <NAN>         <NAN> 
+'''
+
+MODEL_API_DICT = {
+        'cdsapirc' :   {'api' : """\
+                                url: https://cds.climate.copernicus.eu/api/v2\
+                                \nkey: {uid}:{key}
+                                """,
+                        'url' : 'https://cds.climate.copernicus.eu/api-how-to'
+                        },
+        'ecmwfapirc' : {'api' : """{{\
+                                 \n"url"   : "https://api.ecmwf.int/v1",\
+                                 \n"key"   : "{key}",\
+                                 \n"email" : "{uid}"\
+                                 \n}}
+                                """,
+                        'url' : 'https://confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets#AccessECMWFPublicDatasets-key'
+                        },
+        'netrc' :       {'api' : """\
+                                \nmachine urs.earthdata.nasa.gov\
+                                \n        login {uid}\
+                                \n        password {key}\
+                                """,
+                       'url': 'https://wiki.earthdata.nasa.gov/display/EL/How+To+Access+Data+With+cURL+And+Wget'
+                       }
+                }
+
+# Function to check and write MODEL API credential for downloading weather model data
+def check_api(model: str,
+              UID: str = None,
+              KEY: str = None,
+              prompt_flag: bool = True,
+              update_flag: bool = False) -> None:
+    import os
+
+    # Weather model credential filename
+    # typically stored in home dir as hidden file
+    if model in ('ERA5', 'ERA5T'):
+        ap_filename = 'cdsapirc'
+    elif model in ('ERAI, HRES'):
+        api_filename = 'ecmwfapirc'
+    elif model in ('GMAO'):
+        api_filename = 'netrc'
+    else:
+        api_filename = None #for HRRR
+
+    if api_filename:    
+        # Check if the credential api file exists
+        api_filename_path = os.path.expanduser('~/.')+ f'{api_filename}'
+
+        # if update flag is on, delete existing file and update it
+        if update_flag:
+            if os.path.exists(api_filename_path):
+                os.remove(api_filename_path) 
+            
+        if not os.path.exists(api_filename_path): 
+            # Credential API file does not exist, create it
+            # Need api information
+            if UID is None or KEY is None:
+                url = MODEL_API_DICT[api_filename]['url']
+
+                #if prompt flag selected, ask user to input the API uid & key
+                if prompt_flag:
+                    print(f'GET MODEL API credentials, link: {url}')
+                    UID = input('Please type your UID [uid, email, username]:')
+                    KEY = input('Please type your KEY [key, password]')
+                    if UID == '' or KEY == '':
+                        raise ValueError('ERROR : UID and/or KEY are empty, define them !!')
+
+                # Raise ERROR
+                else:
+                    msg = f'{api_filename_path} and weather model credential API UID and KEY,'
+                    msg += ' do not exist !!'
+                    msg += '\nGet API info from ' + '\033[1m' f'{url}' + '\033[0m, and added it!'
+                    raise ValueError(msg)
+                
+            # Create file with inputs, Needed only once
+            print(f'Writing {api_filename_path} locally!')
+            with open(api_filename_path, 'w') as f:
+                f.write(MODEL_API_DICT[api_filename]['api'].format(uid=UID,
+                                                                    key=KEY))
+                    

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -77,11 +77,11 @@ def _check_envs(model):
             host = API_URLS['ecmwfapirc']
 
     elif model in ('GMAO'):
-        uid = os.getenv('EARTHDATA_USERNAME') # same as in Dockerized
+        uid = os.getenv('EARTHDATA_USERNAME') # same as in DockerizedTopsApp
         key = os.getenv('EARTHDATA_PASSWORD')
         host = API_URLS['netrc']
 
-    else:
+    else: # for HRRR
         uid, key, host = None, None, None
 
     return uid, key, host

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -87,4 +87,4 @@ def check_api(model: str,
             with open(api_filename_path, 'w') as f:
                 f.write(MODEL_API_DICT[api_filename]['api'].format(uid=UID,
                                                                     key=KEY))
-                    
+            os.system(f'chmod 0600 {api_filename_path}')


### PR DESCRIPTION
Added option to add weather model API credentials and write it locally to a hidden file 
Issue: [#481](https://github.com/dbekaert/RAiDER/issues/483)

## Description
 added credentials.py to RAiDER.models with function check_api that check if env API credential file already exists, if not it looks for api: UID and KEY  in args and writes it locally. Added options to raider.py **process calcDelysGUNW to add api key and uid 

Added args parms to calcDelaysGUNW: --api_uid, --api_key
```
raider.py ++process calcDelaysGUNW -finput_file -m model -o output --api_uid UID --api_key KEY
```
NOTE: if API_RC hidden file exists such as ~/.cdsapirc, inserted UID and KEY will be ignored, There is an update flag that overwrites hidden file, but for calcGUNWDelays is set to be False. It can be added ``` if api_key is not None and api_uid is not None: update_flag=True``` . This is will give priority to user input?

Another option to add API credentials is through ENV variable, if API_UID and API_KEY are None. **Credentials.py** searches for the env and use them to populate API_RC hidden file: List of environmental API variables:

cdsapirc : models(ERA5, ERA5T):
    $RAIDER_ECMWF_ERA5_API_KEY
    $RAIDER_ECMWF_ERA5_UID

ecmwfapirc : models(HRES, ERAI):
    $RAIDER_HRES_URL
    $RAIDER_HRES_API_KEY
    $RAIDER_HRES_EMAIL

netrc : models (GMAO)
     $EARTHDATA_USERNAME
     $EARTHDATA_PASSWORD

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
