### PR TITLE
Update CHANGELOG.md for re-release attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 + Add assert statement to raise error if the delay cube for each SAR date in a GUNW IFG is not written 
 
-## [0.4.2]
+## [0.5.0]
 
 ### New/Updated Features
 + `calcDelaysGUNW` allows processing with any supported weather model as listed in [`RAiDER.models.allowed.ALLOWED_MODELS`](https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/models/allowed.py).
-+ Removed NCMR removed from supported model list till re-tested 
-+ `credentials` looks for weather model API credentials RC_file hidden file, and creates it if it does not exists
-+ Isolate ISCE3 imports to only those functions that need it.
++ Removed NCMR from supported model list untill it is re-tested 
++ `credentials` looks for weather model API credentials from hidden `.nertc` file, and creates it if it does not exists
++ Isolate ISCE3 imports to only those functions that need it
 + Small bugfixes and updates to docstrings
 
 ## [0.4.1]


### PR DESCRIPTION
Okay, I've deleted the bad `v0.5.0` tag, and by merging this into develop, we can re-do the release.