### PR TITLE
Store SLC delays in GUNW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 + `credentials` looks for weather model API credentials RC_file hidden file, and creates it if it does not exists
 + Isolate ISCE3 imports to only those functions that need it.
 + Small bugfixes and updates to docstrings
++ Only orbit file is used (even if multiple specified) to minimize errors and ensure consistency over region
++ GUNW packaging is restructed to store SLC (ref and sec) wet and tropo delays rather than the differential
 
 ## [0.4.1]
 

--- a/tools/RAiDER/aria/calcGUNW.py
+++ b/tools/RAiDER/aria/calcGUNW.py
@@ -20,7 +20,7 @@ TROPO_NAMES = ['troposphereWet', 'troposphereHydrostatic']
 DIM_NAMES   = ['heightsMeta', 'latitudeMeta', 'longitudeMeta']
 
 
-def compute_delays(cube_filenames:list, wavelength):
+def compute_delays_ifg(cube_filenames:list, wavelength):
     """ Difference the delays and convert to radians. Return xr dataset. """
     # parse date from filename
     dct_delays = {}
@@ -65,8 +65,6 @@ def compute_delays(cube_filenames:list, wavelength):
     sec   = f"{sec.date().strftime('%Y%m%d')}"
 
     attrs = {
-             'model': model,
-             'method': 'ray tracing',
              'units': 'radians',
              'grid_mapping': 'crs',
              }
@@ -81,11 +79,73 @@ def compute_delays(cube_filenames:list, wavelength):
         ds_ifg[name] = ds_ifg[name].assign_attrs(da_attrs)
         ds_ifg[name].encoding = encoding
 
-
+    ds_ifg = ds_ifg.assign_attrs(model=model, method='ray tracing')
     return ds_ifg.rename(z=DIM_NAMES[0], y=DIM_NAMES[1], x=DIM_NAMES[2])
 
 
-def update_gunw(path_gunw:str, ds_ifg):
+def compute_delays_slc(cube_filenames:list, wavelength):
+    """ Get delays and convert to radians. Return xr dataset. """
+    # parse date from filename
+    dct_delays = {}
+    for f in cube_filenames:
+        date = datetime.strptime(os.path.basename(f).split('_')[2], '%Y%m%dT%H%M%S')
+        dct_delays[date] = f
+
+    sec, ref = sorted(dct_delays.keys())
+
+    wet_delays = []
+    hyd_delays = []
+    scale      = (-4 * np.pi) / float(wavelength)
+    for dt in [ref, sec]:
+        path = dct_delays[dt]
+        with xr.open_dataset(path) as ds:
+            da_wet   = ds['wet'] * scale
+            da_hydro = ds['hydro'] * scale
+
+            wet_delays.append(da_wet)
+            hyd_delays.append(da_hydro)
+
+            crs = da_wet.rio.crs
+            gt  = da_wet.rio.transform()
+
+    chunk_sizes = da_wet.shape[0], da_wet.shape[1]/3, da_wet.shape[2]/3
+
+    # open one to copy and store new data
+    ds_slc   = xr.open_dataset(path).copy()
+    encoding = ds_slc['wet'].encoding # chunksizes and fill value
+    encoding['contiguous'] = False
+    encoding['_FillValue'] = 0.
+    encoding['chunksizes'] = tuple([np.floor(cs) for cs in chunk_sizes])
+    del ds_slc['wet'], ds_slc['hydro']
+
+    for i, key in enumerate('reference secondary'.split()):
+        ds_slc[f'{key}_{TROPO_NAMES[0]}'] = wet_delays[i]
+        ds_slc[f'{key}_{TROPO_NAMES[1]}'] = hyd_delays[i]
+
+    model = os.path.basename(path).split('_')[0]
+
+    attrs = {
+             'units': 'radians',
+             'grid_mapping': 'crs',
+             }
+
+    ## no data (fill value?) chunk size?
+    for name in TROPO_NAMES:
+        for key in 'reference secondary'.split():
+            descrip  = f"Delay due to {name.lstrip('troposphere')} component of troposphere"
+            da_attrs = {**attrs,  'description':descrip,
+                        'long_name':name, 'standard_name':name,
+                        'RAiDER version': RAiDER.__version__,
+                        }
+            ds_slc[f'{key}_{name}'] = ds_slc[f'{key}_{name}'].assign_attrs(da_attrs)
+            ds_slc[f'{key}_{name}'].encoding = encoding
+
+    ds_slc = ds_slc.assign_attrs(model=model, method='ray tracing')
+
+    return ds_slc.rename(z=DIM_NAMES[0], y=DIM_NAMES[1], x=DIM_NAMES[2])
+
+
+def update_gunw_ifg(path_gunw:str, ds_ifg):
     """ Update the path_gunw file using the interferometric delays in ds_ifg """
     ## first need to delete the variable; only can seem to with h5
     with h5py.File(path_gunw, 'a') as h5:
@@ -133,6 +193,62 @@ def update_gunw(path_gunw:str, ds_ifg):
     return
 
 
+def update_gunw_slc(path_gunw:str, ds_slc):
+    """ Update the path_gunw file using the slc delays in ds_slc """
+    ## first need to delete the variable; only can seem to with h5
+    with h5py.File(path_gunw, 'a') as h5:
+        for k in TROPO_GROUP.split():
+            h5 = h5[k]
+        del h5[TROPO_NAMES[0]]
+        del h5[TROPO_NAMES[1]]
+
+        for k in 'crs'.split():
+            if k in h5.keys():
+                del h5[k]
+
+
+    with Dataset(path_gunw, mode='a') as ds:
+        ds_grp    = ds[TROPO_GROUP]
+        ds_grp.createGroup(ds_slc.attrs['model'].upper())
+        ds_grp_wm = ds_grp[ds_slc.attrs['model'].upper()]
+
+        ## create the new dimensions e.g., corrections/troposphere/GMAO/latitudeMeta
+        for dim in DIM_NAMES:
+            ## dimension may already exist if updating
+            try:
+                ds_grp_wm.createDimension(dim, len(ds_slc.coords[dim]))
+                ## necessary for transform
+                v  = ds_grp_wm.createVariable(dim, np.float32, dim)
+                v[:] = ds_slc[dim]
+                v.setncatts(ds_slc[dim].attrs)
+            except:
+                pass
+
+
+        ## create and store new data e.g., corrections/troposphere/GMAO/reference/troposphereWet
+        for name in TROPO_NAMES:
+            for rs in 'reference secondary'.split():
+                da        = ds_slc[f'{rs}_{name}']
+                nodata    = da.encoding['_FillValue']
+                chunksize = da.encoding['chunksizes']
+
+                ds_grp_wm.createGroup(rs)
+                ds_grp_rs = ds_grp_wm[rs]
+
+                v    = ds_grp_rs.createVariable(name, np.float32, DIM_NAMES,
+                                    chunksizes=chunksize, fill_value=nodata)
+                v[:] = da.data
+                v.setncatts(da.attrs)
+
+        ## add the projection
+        v_proj = ds_grp_wm.createVariable('crs', 'i')
+        v_proj.setncatts(ds_slc["crs"].attrs)
+
+
+    logger.info('Updated %s group in: %s', os.path.basename(TROPO_GROUP), path_gunw)
+    return
+
+
 def update_gunw_version(path_gunw):
     """ temporary hack for updating version to test aria-tools """
     with Dataset(path_gunw, mode='a') as ds:
@@ -141,7 +257,7 @@ def update_gunw_version(path_gunw):
 
 
 ### ------------------------------------------------------------- main function
-def tropo_gunw_inf(cube_filenames:list, path_gunw:str, wavelength, out_dir:str, update_flag:bool):
+def tropo_gunw_inf(cube_filenames:list, path_gunw:str, wavelength, out_dir:str, update_gunw:bool):
     """ Calculate interferometric phase delay
 
     Requires:
@@ -149,25 +265,32 @@ def tropo_gunw_inf(cube_filenames:list, path_gunw:str, wavelength, out_dir:str, 
         path to the gunw file
         wavelength (units: m)
         output directory (where to store the delays)
-        update_flag (to write into the GUNW or not)
     """
     os.makedirs(out_dir, exist_ok=True)
-    ds_ifg = compute_delays(cube_filenames, wavelength)
-    da     = ds_ifg[TROPO_NAMES[0]] # for metadata
+
+
+    ds_slc = compute_delays_slc(cube_filenames, wavelength)
+    da     = ds_slc[f'reference_{TROPO_NAMES[0]}'] # for metadata
+    model    = ds_slc.model
+
+    # ds_ifg = compute_delays_ifg(cube_filenames, wavelength)
+    # da     = ds_ifg[TROPO_NAMES[0]] # for metadata
+    # model    = ds_ifg.model
 
     # write the interferometric delay to disk
     ref, sec = os.path.basename(path_gunw).split('-')[6].split('_')
-    model    = da.model
     dst      = os.path.join(out_dir, f'{model}_interferometric_{ref}_{sec}.nc')
-    ds_ifg.to_netcdf(dst)
-    logger.info ('Wrote interferometric delays to: %s', dst)
+    ds_slc.to_netcdf(dst)
+    # ds_ifg.to_netcdf(dst)
+    # logger.info ('Wrote interferometric delays to: %s', dst)
+    logger.info ('Wrote slc delays to: %s', dst)
 
-    ## optionally update netcdf with the interferometric delay
-    if update_flag:
-        update_gunw(path_gunw, ds_ifg)
+    ## optionally update netcdf with the slc/interferometric delay
+    # update_gunw_ifg(path_gunw, ds_ifg)
+    update_gunw_slc(path_gunw, ds_slc)
 
-        ## temp
-        update_gunw_version(path_gunw)
+    ## temp
+    update_gunw_version(path_gunw)
 
 
 if __name__ == '__main__':

--- a/tools/RAiDER/aria/calcGUNW.py
+++ b/tools/RAiDER/aria/calcGUNW.py
@@ -20,69 +20,6 @@ TROPO_NAMES = ['troposphereWet', 'troposphereHydrostatic']
 DIM_NAMES   = ['heightsMeta', 'latitudeMeta', 'longitudeMeta']
 
 
-def compute_delays_ifg(cube_filenames:list, wavelength):
-    """ Difference the delays and convert to radians. Return xr dataset. """
-    # parse date from filename
-    dct_delays = {}
-    for f in cube_filenames:
-        date = datetime.strptime(os.path.basename(f).split('_')[2], '%Y%m%dT%H%M%S')
-        dct_delays[date] = f
-
-    sec, ref = sorted(dct_delays.keys())
-
-    wet_delays = []
-    hyd_delays = []
-    for dt in [ref, sec]:
-        path = dct_delays[dt]
-        with xr.open_dataset(path) as ds:
-            da_wet   = ds['wet']
-            da_hydro = ds['hydro']
-
-            wet_delays.append(da_wet)
-            hyd_delays.append(da_hydro)
-
-            crs = da_wet.rio.crs
-            gt  = da_wet.rio.transform()
-
-    scale    = (-4 * np.pi) / float(wavelength)
-    wetDelay = (wet_delays[0] - wet_delays[1]) * scale
-    hydDelay = (hyd_delays[0] - hyd_delays[1]) * scale
-
-    chunk_sizes = wetDelay.shape[0], wetDelay.shape[1]/3, wetDelay.shape[2]/3
-
-    ds_ifg   = xr.open_dataset(path).copy()
-    encoding = ds_ifg['wet'].encoding # chunksizes and fill value
-    encoding['contiguous'] = False
-    encoding['_FillValue'] = 0.
-    encoding['chunksizes'] = tuple([np.floor(cs) for cs in chunk_sizes])
-    del ds_ifg['wet'], ds_ifg['hydro']
-
-    ds_ifg[TROPO_NAMES[0]] = wetDelay
-    ds_ifg[TROPO_NAMES[1]] = hydDelay
-
-    model = os.path.basename(path).split('_')[0]
-    ref   = f"{ref.date().strftime('%Y%m%d')}"
-    sec   = f"{sec.date().strftime('%Y%m%d')}"
-
-    attrs = {
-             'units': 'radians',
-             'grid_mapping': 'crs',
-             }
-
-    ## no data (fill value?) chunk size?
-    for name in TROPO_NAMES:
-        descrip  = f"Delay due to {name.lstrip('troposphere')} component of troposphere"
-        da_attrs = {**attrs,  'description':descrip,
-                    'long_name':name, 'standard_name':name,
-                    'RAiDER version': RAiDER.__version__,
-                    }
-        ds_ifg[name] = ds_ifg[name].assign_attrs(da_attrs)
-        ds_ifg[name].encoding = encoding
-
-    ds_ifg = ds_ifg.assign_attrs(model=model, method='ray tracing')
-    return ds_ifg.rename(z=DIM_NAMES[0], y=DIM_NAMES[1], x=DIM_NAMES[2])
-
-
 def compute_delays_slc(cube_filenames:list, wavelength):
     """ Get delays and convert to radians. Return xr dataset. """
     # parse date from filename
@@ -143,54 +80,6 @@ def compute_delays_slc(cube_filenames:list, wavelength):
     ds_slc = ds_slc.assign_attrs(model=model, method='ray tracing')
 
     return ds_slc.rename(z=DIM_NAMES[0], y=DIM_NAMES[1], x=DIM_NAMES[2])
-
-
-def update_gunw_ifg(path_gunw:str, ds_ifg):
-    """ Update the path_gunw file using the interferometric delays in ds_ifg """
-    ## first need to delete the variable; only can seem to with h5
-    with h5py.File(path_gunw, 'a') as h5:
-        for k in TROPO_GROUP.split():
-            h5 = h5[k]
-        del h5[TROPO_NAMES[0]]
-        del h5[TROPO_NAMES[1]]
-
-        for k in 'crs'.split():
-            if k in h5.keys():
-                del h5[k]
-
-
-    with Dataset(path_gunw, mode='a') as ds:
-        ds_grp = ds[TROPO_GROUP]
-
-        for dim in DIM_NAMES:
-            ## dimension may already exist if updating
-            try:
-                ds_grp.createDimension(dim, len(ds_ifg.coords[dim]))
-                ## necessary for transform
-                v  = ds_grp.createVariable(dim, np.float32, dim)
-                v[:] = ds_ifg[dim]
-                v.setncatts(ds_ifg[dim].attrs)
-            except:
-                pass
-
-
-        for name in TROPO_NAMES:
-            da        = ds_ifg[name]
-            nodata    = da.encoding['_FillValue']
-            chunksize = da.encoding['chunksizes']
-
-            v    = ds_grp.createVariable(name, np.float32, DIM_NAMES,
-                                chunksizes=chunksize, fill_value=nodata)
-            v[:] = da.data
-            v.setncatts(da.attrs)
-
-        ## add the projection
-        v_proj = ds_grp.createVariable('crs', 'i')
-        v_proj.setncatts(ds_ifg["crs"].attrs)
-
-
-    logger.info('Updated %s group in: %s', os.path.basename(TROPO_GROUP), path_gunw)
-    return
 
 
 def update_gunw_slc(path_gunw:str, ds_slc):
@@ -257,8 +146,8 @@ def update_gunw_version(path_gunw):
 
 
 ### ------------------------------------------------------------- main function
-def tropo_gunw_inf(cube_filenames:list, path_gunw:str, wavelength, out_dir:str, update_gunw:bool):
-    """ Calculate interferometric phase delay
+def tropo_gunw_slc(cube_filenames:list, path_gunw:str, wavelength, out_dir:str, update_gunw:bool):
+    """ Calculate ref/sec phase delay
 
     Requires:
         list with filename of delay cube for ref and sec date (netcdf)
@@ -273,20 +162,13 @@ def tropo_gunw_inf(cube_filenames:list, path_gunw:str, wavelength, out_dir:str, 
     da     = ds_slc[f'reference_{TROPO_NAMES[0]}'] # for metadata
     model    = ds_slc.model
 
-    # ds_ifg = compute_delays_ifg(cube_filenames, wavelength)
-    # da     = ds_ifg[TROPO_NAMES[0]] # for metadata
-    # model    = ds_ifg.model
-
     # write the interferometric delay to disk
     ref, sec = os.path.basename(path_gunw).split('-')[6].split('_')
     dst      = os.path.join(out_dir, f'{model}_interferometric_{ref}_{sec}.nc')
     ds_slc.to_netcdf(dst)
-    # ds_ifg.to_netcdf(dst)
-    # logger.info ('Wrote interferometric delays to: %s', dst)
     logger.info ('Wrote slc delays to: %s', dst)
 
-    ## optionally update netcdf with the slc/interferometric delay
-    # update_gunw_ifg(path_gunw, ds_ifg)
+    ## optionally update netcdf with the slc delay
     update_gunw_slc(path_gunw, ds_slc)
 
     ## temp

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -377,7 +377,7 @@ def downloadGNSS():
 ## ------------------------------------------------------------ prepFromGUNW.py
 def calcDelaysGUNW():
     from RAiDER.aria.prepFromGUNW import main as GUNW_prep
-    from RAiDER.aria.calcGUNW import tropo_gunw_inf as GUNW_calc
+    from RAiDER.aria.calcGUNW import tropo_gunw_slc as GUNW_calc
 
     p = argparse.ArgumentParser(
         description='Calculate a cube of interferometic delays for GUNW files',
@@ -404,12 +404,12 @@ def calcDelaysGUNW():
     )
 
     p.add_argument(
-        '-uid', '--api_uid', default=None, type=str, 
+        '-uid', '--api_uid', default=None, type=str,
         help='Weather model API UID [uid, email, username], depending on model.'
     )
 
     p.add_argument(
-        '-key', '--api_key', default=None, type=str, 
+        '-key', '--api_key', default=None, type=str,
         help='Weather model API KEY [key, password], depending on model.'
     )
 
@@ -438,7 +438,7 @@ def calcDelaysGUNW():
         args.file = aws.get_s3_file(args.bucket, args.bucket_prefix, '.nc')
     elif not args.file:
         raise ValueError('Either argument --file or --bucket must be provided')
-    
+
     # prep the config needed for delay calcs
     path_cfg, wavelength = GUNW_prep(args)
 

--- a/tools/RAiDER/models/credentials.py
+++ b/tools/RAiDER/models/credentials.py
@@ -117,16 +117,19 @@ def check_api(model: str,
             api_filename_path.unlink(missing_ok=True)
         
         # Check if API_RC file already exists
-        if not api_filename_path.exists() and UID and KEY:
+        if api_filename_path.exists():
+            return None
+        
+        # if it does not exist, put UID/KEY inserted, create it
+        elif not api_filename_path.exists() and UID and KEY:
             # Create file with inputs, do it only once
             print(f'Writing {api_filename_path} locally!')
             api_filename_path.write_text(API_CREDENTIALS_DICT[api_filename]['api'].format(uid=UID,
                                                                                           key=KEY,
                                                                                           host=URL))
             api_filename_path.chmod(0o000600)
-
+        # Raise ERROR message
         else:
-            # Raise ERROR message
             help_url = API_CREDENTIALS_DICT[api_filename]['help_url']
 
             # Raise ERROR in case only UID or KEY is inserted

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -218,6 +218,8 @@ class ECMWF(WeatherModel):
 
         # round to the closest legal time
         corrected_date = util.round_date(acqTime, datetime.timedelta(hours=self._time_res))
+        if not corrected_date == acqTime:
+            logger.warning('Rounded given datetime from  %s to %s', acqTime, corrected_date)
 
         # I referenced https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5
         dataDict = {
@@ -252,6 +254,8 @@ class ECMWF(WeatherModel):
 
         # round to the closest legal time
         corrected_date = util.round_date(time, datetime.timedelta(hours=self._time_res))
+        if not corrected_date == time:
+            logger.warning('Rounded given datetime from  %s to %s', time, corrected_date)
 
         if self._model_level_type == 'ml':
             param = "129/130/133/152"

--- a/tools/RAiDER/models/gmao.py
+++ b/tools/RAiDER/models/gmao.py
@@ -71,7 +71,7 @@ class GMAO(WeatherModel):
         time1 = time
         time = round_time(time, 3 * 60 * 60)
         if not time1 == time:
-            logger.warning('Rounded given hour from  %d to %d', time1.hour, time.hour)
+            logger.warning('Rounded given hour from  %d to %d. May be incorrect near beginning/end of day.', time1.hour, time.hour)
 
         DT = time - T0
         time_ind = int(DT.total_seconds() / 3600.0 / 3.0)


### PR DESCRIPTION
Change the method of storing delays in the GUNW from interferometric (ref-sec) to single SLC (ref and sec).
See groups in image as discussed last week.

@sssangha I believe this will require you making some adjustments to AT and then I can double check the conversion from meters to radians.

@mgovorcin this should also make your life easier in prepping aria for MintPy.

Note this is built on top of #495 

![image](https://user-images.githubusercontent.com/15522503/221716916-60a5d403-f03c-4f2b-9cb0-40d584417a7f.png)

