### PR TITLE
catch latency issue for era5

### DIFF
--- a/tools/RAiDER/models/era5.py
+++ b/tools/RAiDER/models/era5.py
@@ -1,9 +1,11 @@
 import datetime
+from dateutil.relativedelta import relativedelta
 
 from pyproj import CRS
 
 from RAiDER.models.ecmwf import ECMWF
 from RAiDER.logger import logger
+
 
 
 class ERA5(ECMWF):
@@ -20,9 +22,11 @@ class ERA5(ECMWF):
         self._proj = CRS.from_epsg(4326)
 
         # Tuple of min/max years where data is available.
-        self._valid_range = (datetime.datetime(1950, 1, 1), "Present")
+        end_date = datetime.datetime.today() - relativedelta(months=3)
+        self._valid_range = (datetime.datetime(1950, 1, 1), end_date)
+
         # Availability lag time in days
-        self._lag_time = datetime.timedelta(days=30)
+        self._lag_time = relativedelta(months=3)
 
         # Default, need to change to ml
         self.setLevelType('pl')

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -262,19 +262,25 @@ class WeatherModel(ABC):
         '''
         Checks the time against the lag time and valid date range for the given model type
         '''
+        end_time = self._valid_range[1]
+        end_time = end_time if isinstance(end_time, str) else end_time.date()
+
         logger.info(
-            'Weather model %s is available from %s-%s',
-            self.Model(), self._valid_range[0], self._valid_range[1]
+            'Weather model %s is available from %s to %s',
+            self.Model(), self._valid_range[0].date(), end_time
         )
+
         if time < self._valid_range[0]:
-            raise RuntimeError("Weather model {} is not available at {}".format(self.Model(), time))
+            raise RuntimeError(f"Weather model {self.Model()} is not available at {time}")
+
         if self._valid_range[1] is not None:
             if self._valid_range[1] == 'Present':
                 pass
             elif self._valid_range[1] < time:
-                raise RuntimeError("Weather model {} is not available at {}".format(self.Model(), time))
+                raise RuntimeError(f"Weather model {self.Model()} is not available at {time}")
+
         if time > datetime.datetime.utcnow() - self._lag_time:
-            raise RuntimeError("Weather model {} is not available at {}".format(self.Model(), time))
+            raise RuntimeError(f"Weather model {self.Model()} is not available at {time}")
 
     def _convertmb2Pa(self, pres):
         '''


### PR DESCRIPTION
See #503 
ERA5T replaces ERA5 for data within three months of today.

["Initial release data, i.e. data no more than three months behind real time, is called ERA5T."](https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation)

@dbekaert @jlmaurer 

I've updated the 'valid_date' parameter to reflect this, such that the dates will be skipped and log reflect it when the requested date is within three months.

1) How do we want to handle GUNW/HYP3? 
- We could automatically adjust the weather model to ERA5T but these weather data are not final.

2) How do we want to handle temporal interpolation?
- For example, latest available date is currently Dec 15, 2022. If use requests 23:01:00, then Dec 16, 2022 weather model file will try to get used and fail. We could revert to regular interpolation or automatically use 5T in this case as well


