### PR TITLE
Update environment.yml for Rosetta2 emulation of `x86_64` on ARM64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 + Verify some constants / equations and remove the comments questioning them
 + Relocate the time resolution of wmodels to one spot
 + Skip test_scenario_3 until a new golden dataset is created
-+ Update scipy requirement
++ Update environment with scipy version minimum and requiring pybind11
 
 ## [0.4.2]
 

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
  - numpy
  - pandas
  - progressbar
+ - pybind
  - pydap>3.2.2
  - pyproj>=2.2.0
  - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
  - numpy
  - pandas
  - progressbar
- - pybind
+ - pybind11
  - pydap>3.2.2
  - pyproj>=2.2.0
  - pyyaml


### PR DESCRIPTION
Resolves #520 to support editable `pip install` of raider on Apple's ARM64 with Rosetta2 to emulate `x86_64` following the development install documented [here](https://github.com/dbekaert/RAiDER#5-development).