### PR TITLE
update GUNW test to be agnostic of data shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 + minor bug fixes and unit test updates
 + add log file write location as a top-level command-line option and within Python as a user-specified option
 + account for grid spacing impact on bounding box before downloading weather model 
++ update the GUNW test to account for change in grid spacing on affine transform
 
 ## [0.4.3]
 + add unit tests for the hydro and two pieces of wet equation


### PR DESCRIPTION
the GUNW test is failing on dev because the new buffering from #525 changes the `golden` affine transform.
I've updated the test to calculate manually an affine transform and compare that to the one embedded in the GUNW.
This update to the test is backward compatible. Also note the original purpose of this test was merely to check whether the CRS transformation was correctly set in the GUNW such that it can be read by rasterio / xarray.