### PR TITLE
Fix ecmwf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest updates:
++ Update ERA5 model coordinates to reflect changes in support of HRRR
 + Re-work the HRRR weather model to use herbie (https://github.com/blaylockbk/Herbie) for weather model access. HRRR conus and Alaska validation periods are respectively 2016-7-15 and 2018-7-13 onwards.
 + minor bug fixes and unit test updates
 + add log file write location as a top-level command-line option and within Python as a user-specified option

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -104,7 +104,7 @@ class ECMWF(WeatherModel):
         self._lons, self._lats = np.meshgrid(lons, lats)
 
         # ys is latitude
-        self._get_heights(self._lats, hgt)
+        self._get_heights(self._lats, hgt.transpose(1, 2, 0))
         h = self._zs.copy()
 
         # We want to support both pressure levels and true pressure grids.
@@ -317,8 +317,7 @@ class ECMWF(WeatherModel):
         geo_hgt = z / self._g0
 
         # re-assign lons, lats to match heights
-        _lons = lons
-        _lats = lats
+        self._lons, self._lats = np.meshgrid(lons, lats)
 
         # correct heights for latitude
         self._get_heights(_lats, geo_hgt)

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -71,6 +71,7 @@ class ECMWF(WeatherModel):
         '''
         self._load_model_level(*self.files)
 
+
     def _load_model_level(self, fname):
         # read data from netcdf file
         lats, lons, xs, ys, t, q, lnsp, z = self._makeDataCubes(
@@ -116,11 +117,9 @@ class ECMWF(WeatherModel):
             self._p = pres
 
         # Re-structure everything from (heights, lats, lons) to (lons, lats, heights)
-        self._p = np.transpose(self._p, (1, 2, 0))
-        self._t = np.transpose(self._t, (1, 2, 0))
-        self._q = np.transpose(self._q, (1, 2, 0))
-        h = np.transpose(h, (1, 2, 0))
-
+        self._p = self._p.transpose(1, 2, 0)
+        self._t = self._t.transpose(1, 2, 0)
+        self._q = self._q.transpose(1, 2, 0)
 
         # Flip all the axis so that zs are in order from bottom to top
         # lats / lons are simply replicated to all heights so they don't need flipped
@@ -130,6 +129,7 @@ class ECMWF(WeatherModel):
         self._ys = self._lats.copy()
         self._xs = self._lons.copy()
         self._zs = np.flip(h, axis=2)
+
 
     def _fetch(self, out):
         '''

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -101,11 +101,10 @@ class ECMWF(WeatherModel):
         self._q = q
         geo_hgt, pres, hgt = self._calculategeoh(z, lnsp)
 
-        # re-assign lons, lats to match heights
-        _lons = np.broadcast_to(lons[np.newaxis, np.newaxis, :], hgt.shape)
-        _lats = np.broadcast_to(lats[np.newaxis, :, np.newaxis], hgt.shape)
+        self._lons, self._lats = np.meshgrid(lons, lats)
+
         # ys is latitude
-        self._get_heights(_lats, hgt)
+        self._get_heights(self._lats, hgt)
         h = self._zs.copy()
 
         # We want to support both pressure levels and true pressure grids.
@@ -121,8 +120,7 @@ class ECMWF(WeatherModel):
         self._t = np.transpose(self._t, (1, 2, 0))
         self._q = np.transpose(self._q, (1, 2, 0))
         h = np.transpose(h, (1, 2, 0))
-        self._lats = np.transpose(_lats, (1, 2, 0))
-        self._lons = np.transpose(_lons, (1, 2, 0))
+
 
         # Flip all the axis so that zs are in order from bottom to top
         # lats / lons are simply replicated to all heights so they don't need flipped

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -55,11 +55,11 @@ class HRRR(WeatherModel):
         self._zlevels = np.flipud(LEVELS_137_HEIGHTS)
 
         # Projection
-        # NOTE: The HRRR projection will get read directly from the downloaded weather model file; however, 
-        # we also define it here so that the projection can be used without downloading any data. This is 
-        # used for consistency with the other weather models and allows for some nice features, such as 
+        # NOTE: The HRRR projection will get read directly from the downloaded weather model file; however,
+        # we also define it here so that the projection can be used without downloading any data. This is
+        # used for consistency with the other weather models and allows for some nice features, such as
         # buffering.
-        # 
+
         # See https://github.com/blaylockbk/pyBKB_v2/blob/master/demos/HRRR_earthRelative_vs_gridRelative_winds.ipynb and code lower down
         # '262.5:38.5:38.5:38.5 237.280472:1799:3000.00 21.138123:1059:3000.00'
         # 'lov:latin1:latin2:latd lon1:nx:dx lat1:ny:dy'
@@ -103,7 +103,7 @@ class HRRR(WeatherModel):
                 download_hrrr_file(bounds, corrected_DT, out, model='hrrrak')
             else:
                 raise ValueError('The requested location is unavailable for HRRR')
-            
+
 
     def load_weather(self, *args, filename=None, **kwargs):
         '''
@@ -130,7 +130,7 @@ class HRRR(WeatherModel):
 
 class HRRRAK(WeatherModel):
     def __init__(self):
-        # The HRRR-AK model has a few different parameters than HRRR-CONUS. 
+        # The HRRR-AK model has a few different parameters than HRRR-CONUS.
         # These will get used if a user requests a bounding box in Alaska
         super().__init__()
 
@@ -159,8 +159,8 @@ class HRRRAK(WeatherModel):
         self._lag_time = datetime.timedelta(hours=3)
         self._valid_bounds =  Polygon(((195, 40), (157, 55), (175, 70), (260, 77), (232, 52)))
 
-        # The projection information gets read directly from the  weather model file but we 
-        # keep this here for object instantiation. 
+        # The projection information gets read directly from the  weather model file but we
+        # keep this here for object instantiation.
         self._proj = CRS.from_string(
             '+proj=stere +ellps=sphere +a=6371229.0 +b=6371229.0 +lat_0=90 +lon_0=225.0 ' +
             '+x_0=0.0 +y_0=0.0 +lat_ts=60.0 +no_defs +type=crs'
@@ -172,7 +172,7 @@ class HRRRAK(WeatherModel):
             corrected_DT = round_date(self._time, datetime.timedelta(hours=self._time_res))
             if not corrected_DT == self._time:
                 print('Rounded given datetime from {} to {}'.format(self._time, corrected_DT))
-            
+
             self.checkTime(corrected_DT)
             download_hrrr_file(bounds, corrected_DT, out, model='hrrrak')
 
@@ -197,16 +197,16 @@ def download_hrrr_file(ll_bounds, DATE, out, model='hrrr', product='prs', fxx=0,
     '''
     Download a HRRR weather model using Herbie
 
-    Args: 
+    Args:
         DATE (Python datetime)  - Datetime as a Python datetime. Herbie will automatically return the closest valid time,
-                                    which is currently hourly. 
+                                    which is currently hourly.
         out (string)            - output location as a string
         model (string)          - model can be "hrrr" or "hrrrak"
         product (string)        - 'prs' for pressure levels, 'nat' for native levels
         fxx (int)               - forecast time in hours. Can be up to 48 for 00/06/12/18
         verbose (bool)          - True for extra printout of information
-    
-    Returns: 
+
+    Returns:
         None, writes data to a netcdf file
     '''
     H = Herbie(
@@ -229,8 +229,8 @@ def download_hrrr_file(ll_bounds, DATE, out, model='hrrr', product='prs', fxx=0,
 
     # subset the full file by AOI
     x_min, x_max, y_min, y_max = get_bounds_indices(
-        ll_bounds, 
-        ds_out.latitude.to_numpy(), 
+        ll_bounds,
+        ds_out.latitude.to_numpy(),
         ds_out.longitude.to_numpy(),
     )
 
@@ -244,7 +244,7 @@ def download_hrrr_file(ll_bounds, DATE, out, model='hrrr', product='prs', fxx=0,
         ds_out.proj.attrs[k] = v
     for var in ds_out.data_vars:
         ds_out[var].attrs['grid_mapping'] = 'proj'
-    
+
 
     # pull the grid information
     proj = CRS.from_cf(ds_out['proj'].attrs)
@@ -270,7 +270,7 @@ def get_bounds_indices(SNWE, lats, lons):
     '''
     Convert SNWE lat/lon bounds to index bounds
     '''
-    # Unpack the bounds and find the relevent indices 
+    # Unpack the bounds and find the relevent indices
     S, N, W, E = SNWE
 
     # Need to account for crossing the international date line
@@ -332,5 +332,5 @@ def load_weather_hrrr(filename):
                             geo_hgt.shape)
     _ys = np.broadcast_to(yArr[:, np.newaxis, np.newaxis],
                             geo_hgt.shape)
-    
+
     return _xs, _ys, lons, lats, qs, temps, pl, geo_hgt, proj

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -324,11 +324,8 @@ class WeatherModel(ABC):
         Transform geo heights to WGS84 ellipsoidal heights
         '''
         geo_ht_fix = np.where(geo_hgt != geo_ht_fill, geo_hgt, np.nan)
-        print ('LATS SHAPE', lats.shape)
-        print (geo_ht_fix.shape)
         lats_full  = np.broadcast_to(lats[...,np.newaxis], geo_ht_fix.shape)
-        # lats_full = lats
-        self._zs = util.geo_to_ht(lats_full, geo_ht_fix)
+        self._zs   = util.geo_to_ht(lats_full, geo_ht_fix)
 
 
     def _find_e(self):

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -324,7 +324,10 @@ class WeatherModel(ABC):
         Transform geo heights to WGS84 ellipsoidal heights
         '''
         geo_ht_fix = np.where(geo_hgt != geo_ht_fill, geo_hgt, np.nan)
-        lats_full = np.broadcast_to(lats[...,np.newaxis], geo_ht_fix.shape)
+        print ('LATS SHAPE', lats.shape)
+        print (geo_ht_fix.shape)
+        lats_full  = np.broadcast_to(lats[...,np.newaxis], geo_ht_fix.shape)
+        # lats_full = lats
         self._zs = util.geo_to_ht(lats_full, geo_ht_fix)
 
 
@@ -732,7 +735,7 @@ class WeatherModel(ABC):
             'wet_total': (('z', 'y', 'x'), self._wet_ztd.swapaxes(0, 2).swapaxes(1, 2)),
             'hydro_total': (('z', 'y', 'x'), self._hydrostatic_ztd.swapaxes(0, 2).swapaxes(1, 2)),
         }
-        
+
         ds = xarray.Dataset(data_vars=dataset_dict, coords=dimension_dict, attrs=attrs_dict)
 
         # Define units
@@ -751,7 +754,7 @@ class WeatherModel(ABC):
         ds['wet'].attrs['standard_name'] = 'wet_refractivity'
         ds['hydro'].attrs['standard_name'] = 'hydrostatic_refractivity'
         ds['wet_total'].attrs['standard_name'] = 'total_wet_refractivity'
-        ds['hydro_total'].attrs['standard_name'] = 'total_hydrostatic_refractivity' 
+        ds['hydro_total'].attrs['standard_name'] = 'total_hydrostatic_refractivity'
 
         # projection information
         ds["proj"] = int()
@@ -759,7 +762,7 @@ class WeatherModel(ABC):
             ds.proj.attrs[k] = v
         for var in ds.data_vars:
             ds[var].attrs['grid_mapping'] = 'proj'
-        
+
         # write to file and return the filename
         ds.to_netcdf(f)
         return f


### PR DESCRIPTION
ERA5 failed during cropping of the weather model to the user specified AOI due to changes in how the coordinate arrays are set up (#538).

I've corrected the shape broadcasting for ERA5 to pass, and verified that delays produced on this PR for ERA5, HRES, GMAO and HRRR are equivalent to delays produced on dev prior to #538  (#525).

Tests pass locally.