### PR TITLE
Move imports around to make raider-base cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 + Update the integration height for raytracing from 50 km to 80 km
 + Reinstate test 3 (slant proj and ray trace), remove unused calls with ZREF
 + Add buffer to W/E for ERA5
++ refactor imports to allow for a cleaner raider-base
 + Add buffer to HRES when downloading as with the other models
 + Refactor to pass a weather file directly to fetch
 + Update staged weather models to reflect update to aligned grid

--- a/test/test_HRRR_ztd.py
+++ b/test/test_HRRR_ztd.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 import subprocess
 import shutil
 import glob
@@ -24,6 +23,7 @@ def test_scenario_1():
     np.testing.assert_almost_equal(golden_data[1], new_data1['wet'].data)
 
     # Clean up files
+    assert False
     for f in glob.glob(os.path.join(SCENARIO_DIR, 'HRRR*')):
         os.remove(f)
     shutil.rmtree(os.path.join(SCENARIO_DIR, 'weather_files'))

--- a/test/test_HRRR_ztd.py
+++ b/test/test_HRRR_ztd.py
@@ -23,7 +23,6 @@ def test_scenario_1():
     np.testing.assert_almost_equal(golden_data[1], new_data1['wet'].data)
 
     # Clean up files
-    assert False
     for f in glob.glob(os.path.join(SCENARIO_DIR, 'HRRR*')):
         os.remove(f)
     shutil.rmtree(os.path.join(SCENARIO_DIR, 'weather_files'))

--- a/test/test_delayFcns.py
+++ b/test/test_delayFcns.py
@@ -4,12 +4,27 @@ import pytest
 import numpy as np
 import xarray as xr
 
-
+from pyproj import CRS, Transformer
 from test import TEST_DIR
 
 from RAiDER.delayFcns import getInterpolators
+from RAiDER.delay import transformPoints
 
 SCENARIO1_DIR = os.path.join(TEST_DIR, "scenario_1", "golden_data")
+
+
+@pytest.fixture
+def hrrr_proj():
+    lon0 = 262.5
+    lat0 = 38.5
+    lat1 = 38.5
+    lat2 = 38.5
+    x0 = 0
+    y0 = 0
+    earth_radius = 6371229
+    proj = CRS(f'+proj=lcc +lat_1={lat1} +lat_2={lat2} +lat_0={lat0} +lon_0={lon0} +x_0={x0} +y_0={y0} +a={earth_radius} +b={earth_radius} +units=m +no_defs')
+
+    return proj
 
 
 @pytest.fixture
@@ -29,3 +44,57 @@ def test_getInterpolators_2(wmdata, caplog):
     getInterpolators(ds, kind='pointwise')
     assert 'Weather model contains NaNs!' in caplog.text, 'No warning was raised!'
 
+
+def test_transformPoints():
+    lats = np.array([10, 20, 30, 45, 75, 80, 90])
+    lons = np.array([0,-180,180, 90,-90,-20, 10])
+    hts  = np.array([0,   0,  0,  0,  0,  0,  0])
+
+    epsg4326 = CRS.from_epsg(4326)
+    ecef = CRS.from_epsg(4978)
+
+    out = transformPoints(lats, lons, hts, epsg4326, ecef)
+    y,x,z=out[:,0], out[:,1], out[:,2]
+
+    T = Transformer.from_crs(4978, 4326)
+
+    test = T.transform(x,y,z)
+    assert np.allclose(test[0], lats)
+    assert np.allclose(test[1], lons)
+    assert np.allclose(test[2], hts)
+
+
+def test_transformPoints_2(hrrr_proj):
+    hrrr_proj = hrrr_proj
+    lats = np.array([40, 45, 55])
+    lons = np.array([-90,-90, -90])
+    hts  = np.array([0,   0,  0])
+
+    epsg4326 = CRS.from_epsg(4326)
+
+    out = transformPoints(lats, lons, hts, epsg4326, hrrr_proj)
+    y,x,z=out[:,0], out[:,1], out[:,2]
+
+    T = Transformer.from_crs(hrrr_proj, 4326)
+
+    test = T.transform(x,y,z)
+    assert np.allclose(test[0], lats)
+    assert np.allclose(test[1], lons)
+    assert np.allclose(test[2], hts)
+
+
+def test_transformPoints_3():
+    lats = np.array([0, 0, 0])
+    lons = np.array([0,-90, 180])
+    hts  = np.array([0,   0,  0])
+
+    epsg4326 = CRS.from_epsg(4326)
+    ecef = CRS.from_epsg(4978)
+
+    out = transformPoints(lats, lons, hts, epsg4326, ecef)
+    y,x,z=out[:,0], out[:,1], out[:,2]
+
+    assert np.allclose(x, [6378137., 0, -6378137])
+    assert np.allclose(y, [0, -6378137., 0])
+    assert np.allclose(z, [0, 0, 0])
+    

--- a/test/test_delayFcns.py
+++ b/test/test_delayFcns.py
@@ -97,4 +97,7 @@ def test_transformPoints_3():
     assert np.allclose(x, [6378137., 0, -6378137])
     assert np.allclose(y, [0, -6378137., 0])
     assert np.allclose(z, [0, 0, 0])
+
+
+
     

--- a/test/test_intersect.py
+++ b/test/test_intersect.py
@@ -1,7 +1,8 @@
 import pandas as pd
-import rasterio
+# import rasterio
 
-from scipy.interpolate import griddata
+# from scipy.interpolate import griddata
+import rioxarray as xrr
 
 from test import *
 
@@ -13,10 +14,10 @@ def test_cube_intersect(wm):
     os.makedirs(SCENARIO_DIR, exist_ok=True)
 
     ## make the lat lon grid
-    S, N, W, E = 33.5, 34, -118.0, -117.5
+    # S, N, W, E = 33.5, 34, -118.0, -117.5
     date       = 20200130
     time       ='13:52:45'
-    f_lat, f_lon = makeLatLonGrid([S, N, W, E], 'LA', SCENARIO_DIR, 0.25)
+    # f_lat, f_lon = makeLatLonGrid([S, N, W, E], 'LA', SCENARIO_DIR, 0.25)
 
     ## make the template file
     grp = {

--- a/test/test_intersect.py
+++ b/test/test_intersect.py
@@ -1,8 +1,8 @@
 import pandas as pd
 # import rasterio
 
-# from scipy.interpolate import griddata
-import rioxarray as xrr
+from scipy.interpolate import griddata
+import rasterio
 
 from test import *
 
@@ -47,11 +47,15 @@ def test_cube_intersect(wm):
     gold = {'ERA5': 2.2787, 'GMAO': np.nan, 'HRRR': np.nan}
 
     path_delays = os.path.join(SCENARIO_DIR, f'{wm}_hydro_{date}T{time.replace(":", "")}_ztd.tiff')
-    da  = xrr.open_rasterio(path_delays, band_as_variable=True)['band_1']
-    hyd = da.sel(x=-117.8, y=33.4, method='nearest').item()
-    np.testing.assert_almost_equal(hyd, gold[WM], decimal=4)
+    latf = os.path.join(SCENARIO_DIR, 'lat.rdr')
+    lonf = os.path.join(SCENARIO_DIR, 'lon.rdr')
 
-    return
+    hyd = rasterio.open(path_delays).read(1)
+    lats = rasterio.open(latf).read(1)
+    lons = rasterio.open(lonf).read(1)
+    hyd = griddata(np.stack([lons.flatten(), lats.flatten()], axis=-1), hyd.flatten(), (-100.6, 16.15), method='nearest')
+
+    np.testing.assert_almost_equal(hyd, gold[wm], decimal=4)
 
 
 

--- a/test/test_intersect.py
+++ b/test/test_intersect.py
@@ -46,16 +46,9 @@ def test_cube_intersect(wm):
     gold = {'ERA5': 2.2787, 'GMAO': np.nan, 'HRRR': np.nan}
 
     path_delays = os.path.join(SCENARIO_DIR, f'{wm}_hydro_{date}T{time.replace(":", "")}_ztd.tiff')
-    latf = os.path.join(SCENARIO_DIR, 'lat.rdr')
-    lonf = os.path.join(SCENARIO_DIR, 'lon.rdr')
-
-    hyd = rasterio.open(path_delays).read(1)
-    lats = rasterio.open(latf).read(1)
-    lons = rasterio.open(lonf).read(1)
-    hyd = griddata(np.stack([lons.flatten(), lats.flatten()], axis=-1), hyd.flatten(), (-100.6, 16.15), method='nearest')
-
-    # test for equality with golden data
-    np.testing.assert_almost_equal(hyd, gold[wm], decimal=4)
+    da  = xrr.open_rasterio(path_delays, band_as_variable=True)['band_1']
+    hyd = da.sel(x=-117.8, y=33.4, method='nearest').item()
+    np.testing.assert_almost_equal(hyd, gold[WM], decimal=4)
 
     return
 

--- a/test/test_synthetic.py
+++ b/test/test_synthetic.py
@@ -5,10 +5,9 @@ from datetime import datetime
 from RAiDER.llreader import BoundingBox
 from RAiDER.models.weatherModel import make_weather_model_filename
 from RAiDER.losreader import Raytracing, build_ray
-from RAiDER.utilFcns import lla2ecef, ecef2lla
+from RAiDER.utilFcns import lla2ecef
 from RAiDER.cli.validators import modelName2Module
 
-from RAiDER.constants import _ZREF
 from test import *
 
 
@@ -61,7 +60,6 @@ def update_model(wm_file:str, wm_eq_type:str, wm_dir:str='weather_files_synth'):
 
     ds.close()
     del ds
-    print ('Wrote synthetic weather model file to:', dst)
     return dst
 
 
@@ -172,7 +170,7 @@ class StudyArea(object):
         return dct
 
 
-@pytest.mark.skip()
+@pytest.mark.long()
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_dl_real(region, mod='ERA5'):
     """ Download the real weather model to overwrite
@@ -193,7 +191,7 @@ def test_dl_real(region, mod='ERA5'):
     proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
     assert proc.returncode == 0, 'RAiDER did not complete successfully'
 
-
+@pytest.mark.long()
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_hydrostatic_eq(region, mod='ERA-5'):
     """ Test hydrostatic equation: Hydro Refractivity = k1 * (Pressure/Temp)
@@ -257,7 +255,7 @@ def test_hydrostatic_eq(region, mod='ERA-5'):
     da.close()
     del da
 
-
+@pytest.mark.long()
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_wet_eq_linear(region, mod='ERA-5'):
     """ Test linear part of wet equation.
@@ -324,7 +322,7 @@ def test_wet_eq_linear(region, mod='ERA-5'):
     da.close()
     del da
 
-
+@pytest.mark.long()
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_wet_eq_nonlinear(region, mod='ERA-5'):
     """ Test the nonlinear part of the wet equation.

--- a/test/test_synthetic.py
+++ b/test/test_synthetic.py
@@ -170,7 +170,7 @@ class StudyArea(object):
         return dct
 
 
-@pytest.mark.long()
+@pytest.mark.skip()
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_dl_real(region, mod='ERA5'):
     """ Download the real weather model to overwrite

--- a/test/test_synthetic.py
+++ b/test/test_synthetic.py
@@ -191,7 +191,7 @@ def test_dl_real(region, mod='ERA5'):
     proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
     assert proc.returncode == 0, 'RAiDER did not complete successfully'
 
-@pytest.mark.long()
+
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_hydrostatic_eq(region, mod='ERA-5'):
     """ Test hydrostatic equation: Hydro Refractivity = k1 * (Pressure/Temp)
@@ -255,7 +255,7 @@ def test_hydrostatic_eq(region, mod='ERA-5'):
     da.close()
     del da
 
-@pytest.mark.long()
+
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_wet_eq_linear(region, mod='ERA-5'):
     """ Test linear part of wet equation.
@@ -322,7 +322,7 @@ def test_wet_eq_linear(region, mod='ERA-5'):
     da.close()
     del da
 
-@pytest.mark.long()
+
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_wet_eq_nonlinear(region, mod='ERA-5'):
     """ Test the nonlinear part of the wet equation.

--- a/test/test_weather_model.py
+++ b/test/test_weather_model.py
@@ -15,7 +15,6 @@ from RAiDER.models.weatherModel import (
     make_raw_weather_data_filename,
     make_weather_model_filename,
 )
-from RAiDER.llreader import BoundingBox
 from RAiDER.models.erai import ERAI
 from RAiDER.models.era5 import ERA5
 from RAiDER.models.era5t import ERA5T

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -12,9 +12,11 @@ tropospheric wet and hydrostatic delays from a weather model. Weather
 models are accessed as NETCDF files and should have "wet" "hydro"
 "wet_total" and "hydro_total" fields specified.
 """
+import os
 import pyproj
 import xarray
 
+from datetime import datetime
 from pyproj import CRS, Transformer
 from typing import List, Union
 
@@ -406,18 +408,12 @@ def transformPoints(lats: np.ndarray, lons: np.ndarray, hgts: np.ndarray, old_pr
     if not isinstance(old_proj, CRS):
         old_proj = CRS.from_epsg(old_proj.lstrip('EPSG:'))
 
-    t = Transformer.from_crs(old_proj, new_proj)
+    t = Transformer.from_crs(old_proj, new_proj, always_xy=True)
 
     in_flip = old_proj.axis_info[0].direction
     out_flip = new_proj.axis_info[0].direction
 
-    if in_flip == 'east':
-        res = t.transform(lons, lats, hgts)
-    else:
-        res = t.transform(lats, lons, hgts)
-    
-    if out_flip == 'east':
-        return np.stack((res[1], res[0], res[2]), axis=-1).T
-    else:
-        return np.stack(res, axis=-1).T
+    res  = t.transform(lons, lats, hgts)
 
+    # lat/lon/height
+    return  np.stack([res[1], res[0], res[2]], axis=-1)

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -26,9 +26,6 @@ from RAiDER.constants import _ZREF
 from RAiDER.delayFcns import getInterpolators
 from RAiDER.logger import logger
 from RAiDER.losreader import build_ray
-from RAiDER.utilFcns import (
-    writeResultsToXarray, transformPoints,
-)
 
 ###############################################################################
 def tropo_delay(

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -244,7 +244,7 @@ def _build_cube_ray(
         else:
             llh = [xx, yy, np.full(yy.shape, ht)]
 
-        xyz = np.stack(T.transform(llh[1], llh[0], np.full(yy.shape, ht)), axis=-1)
+        xyz = np.stack(T.transform(llh[0], llh[1], np.full(yy.shape, ht)), axis=-1)
 
         # Step 2 - get LOS vectors for targets
         LOS = los.getLookVectors(ht, llh, xyz, yy)

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -61,7 +61,7 @@ def tropo_delay(
     # Load CRS from weather model file
     with xarray.load_dataset(weather_model_file) as ds:
         try:
-            wm_proj = CRS.from_wkt(ds['t'].attrs['crs'].to_wkt())
+            wm_proj = CRS.from_wkt(ds['proj'].attrs['crs_wkt'])
         except KeyError:
             logger.warning("WARNING: I can't find a CRS in the weather model file, so I will assume you are using WGS84")
             wm_proj = CRS.from_epsg(4326)
@@ -242,7 +242,7 @@ def _build_cube_ray(
         else:
             llh = [xx, yy, np.full(yy.shape, ht)]
 
-        xyz = np.stack(T.transform(llh[0], llh[1], np.full(yy.shape, ht)), axis=-1)
+        xyz = np.stack(T.transform(llh[0], llh[1], llh[2]), axis=-1)
 
         # Step 2 - get LOS vectors for targets
         LOS = los.getLookVectors(ht, llh, xyz, yy)

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -227,10 +227,8 @@ def _build_cube_ray(
 
     # Various transformers needed here
     epsg4326 = CRS.from_epsg(4326)
-    cube_to_llh = Transformer.from_crs(pts_crs, epsg4326,
-                                       always_xy=True)
-    ecef_to_model = Transformer.from_crs(CRS.from_epsg(4978), model_crs,
-                                         always_xy=True)
+    cube_to_llh = Transformer.from_crs(pts_crs, epsg4326, always_xy=True)
+    ecef_to_model = Transformer.from_crs(CRS.from_epsg(4978), model_crs, always_xy=True)
 
     # Loop over heights of output cube and compute delays
     for hh, ht in enumerate(zpts):
@@ -407,8 +405,8 @@ def transformPoints(lats: np.ndarray, lons: np.ndarray, hgts: np.ndarray, old_pr
 
     t = Transformer.from_crs(old_proj, new_proj, always_xy=True)
 
-    in_flip = old_proj.axis_info[0].direction
-    out_flip = new_proj.axis_info[0].direction
+    # in_flip = old_proj.axis_info[0].direction
+    # out_flip = new_proj.axis_info[0].direction
 
     res  = t.transform(lons, lats, hgts)
 

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -5,10 +5,15 @@
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import multiprocessing as mp
+try:
+    import multiprocessing as mp
+except ImportError:
+    mp = None
+
 import xarray
 
 import numpy as np
+
 from scipy.interpolate import RegularGridInterpolator as Interpolator
 
 from RAiDER.utilFcns import transformPoints
@@ -62,6 +67,9 @@ def make_shared_raw(inarr):
     Make numpy view array of mp.Array
     """
     # Create flat shared array
+    if mp is None:
+        raise ImportError('multiprocessing is not available')
+    
     shared_arr = mp.RawArray('d', inarr.size)
     # Create a numpy view of it
     shared_arr_np = np.ndarray(inarr.shape, dtype=np.float64,

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -54,7 +54,7 @@ def getInterpolators(wm_file, kind='pointwise', shared=False):
         wet   = make_shared_raw(wet)
         hydro = make_shared_raw(hydro)
 
-
+    
     ifWet = Interpolator((ys_wm, xs_wm, zs_wm), wet, fill_value=np.nan, bounds_error = False)
     ifHydro = Interpolator((ys_wm, xs_wm, zs_wm), hydro, fill_value=np.nan, bounds_error = False)
 

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from scipy.interpolate import RegularGridInterpolator as Interpolator
 
-from RAiDER.utilFcns import transformPoints
 from RAiDER.logger import logger
 
 

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -18,6 +18,7 @@ except ImportError:
 
 from abc import ABC
 
+from RAiDER.constants import _ZREF
 from RAiDER.utilFcns import (
     cosd, sind, rio_open, lla2ecef, ecef2lla
 )

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -10,15 +10,17 @@ import os
 import datetime
 import shelve
 
-import xml.etree.ElementTree as ET
 import numpy as np
+try:
+    import xml.etree.ElementTree as ET
+except ImportError:
+    ET = None
+
 from abc import ABC
-from scipy.interpolate import interp1d
 
 from RAiDER.utilFcns import (
-    cosd, sind, rio_open, enu2ecef, lla2ecef, ecef2enu, ecef2lla
+    cosd, sind, rio_open, lla2ecef, ecef2lla
 )
-from RAiDER.constants import _ZREF
 
 
 class LOS(ABC):
@@ -478,6 +480,8 @@ def read_ESA_Orbit_file(filename):
     x, y, z: Nt x 1 ndarrays    - x/y/z positions of the sensor at the times t
     vx, vy, vz: Nt x 1 ndarrays - x/y/z velocities of the sensor at the times t
     '''
+    if ET is None:
+        raise ImportError('read_ESA_Orbit_file: cannot import xml.etree.ElementTree')
     tree = ET.parse(filename)
     root = tree.getroot()
     data_block = root[1]

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -13,9 +13,8 @@ from shapely.geometry import Polygon, box
 
 from RAiDER.utilFcns import round_date, transform_coords, rio_profile, rio_stats
 from RAiDER.models.weatherModel import WeatherModel, TIME_RES
-from RAiDER.models.model_levels import LEVELS_50_HEIGHTS
+from RAiDER.models.model_levels import LEVELS_50_HEIGHTS, LEVELS_137_HEIGHTS
 from RAiDER.logger import logger
-
 
 HRRR_CONUS_COVERAGE_POLYGON = Polygon(((-125, 21), (-133, 49), (-60, 49), (-72, 21)))
 HRRR_AK_COVERAGE_POLYGON = Polygon(((195, 40), (157, 55), (175, 70), (260, 77), (232, 52)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactor raider to make the raider-base lighter

## Description
<!--- Describe your changes in detail -->
- By cleaning up import statements and moving isolated imports to their calling functions, this PR provides for a more flexible RAiDER that **may** not need as many 3rd party package installs. 
- TBD: 
   - clean up conda installs 
   - add pre-processing functionality for nisar
- I'll update this PR with these TBDs but wanted to post now to solicit feedback on the general idea

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Addresses #533

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
- Not tested yet. 

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
