### PR TITLE
specify un-buffered python output in docker entrypoint script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 + add CLI for the old processDelayFiles script and rename to raiderCombine
 + Fix gridding bug in accessing HRRR-AK 
 + misc clean-up
++ specify unbuffered python output in the docker entrypoint script
 
 ## [0.4.3]
 + add unit tests for the hydro and two pieces of wet equation

--- a/tools/RAiDER/etc/entrypoint.sh
+++ b/tools/RAiDER/etc/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash --login
 set -e
 conda activate RAiDER
-exec raider.py "$@"
+exec python -u raider.py "$@"


### PR DESCRIPTION
Python output is buffered by default; when running a python script in a docker environment, log messages often show up in batches rather than line-by-line. When a container is terminated it's possible the last batch of un-flushed log messages are lost.

This PR adds the "python -u" (unbuffered) flag to the docker entrypoint script to make sure log messages get written out immediately; this follows the pattern used by a handful of other HyP3 plugins: https://github.com/search?q=org%3AASFHyP3%20%22python%20-u%22&type=code