### PR TITLE
Fix fillna3d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest updates:
++ Fix bug in fillna3D for NaNs at elevations higher than present in the weather model
 + write delays even if they contain nans
 + check that the aoi is contained within HRRR extent
 + move the ray building out of the _build_cube_ray and into its own function for cleaner testing

--- a/test/test_HRRR_ztd.py
+++ b/test/test_HRRR_ztd.py
@@ -18,13 +18,12 @@ def test_scenario_1():
 
     new_data  = xr.load_dataset(os.path.join(SCENARIO_DIR, 'HRRR_tropo_20200101T120000_ztd.nc'))
     new_data1 = new_data.sel(x=-91.84, y=36.84, z=0, method='nearest')
-    golden_data = 3.36171181, 0.03765481 # hydro|wet
+    golden_data = 2.2011017, 0.03755665 # hydro|wet
 
-    assert np.isclose(new_data1['hydro'].data, golden_data[0])
-    assert np.isclose(new_data1['wet'].data, golden_data[1])
-
+    np.testing.assert_almost_equal(golden_data[0], new_data1['hydro'].data)
+    np.testing.assert_almost_equal(golden_data[1], new_data1['wet'].data)
 
     # Clean up files
     for f in glob.glob(os.path.join(SCENARIO_DIR, 'HRRR*')):
         os.remove(f)
-    # shutil.rmtree(os.path.join(SCENARIO_DIR, 'weather_files'))
+    shutil.rmtree(os.path.join(SCENARIO_DIR, 'weather_files'))

--- a/test/test_interpolator.py
+++ b/test/test_interpolator.py
@@ -18,13 +18,14 @@ def nanArr():
     array[1, 0, 0] = np.nan
     array[0, 1, 1] = np.nan
     array[1, 1, 2] = np.nan
+
     true_array = array.copy()
-    true_array[0, 0, 0] = np.nan
-    true_array[0, 0, 1] = np.nan
-    true_array[0, 0, 2] = np.nan
+    true_array[0, 0, 0] = 0
+    true_array[0, 0, 1] = 0
+    true_array[0, 0, 2] = 0
     true_array[1, 0, 0] = true_array[1, 0, 1]
     true_array[0, 1, 1] = (true_array[0, 1, 0] + true_array[0, 1, 2]) / 2
-    true_array[1, 1, 2] = true_array[1, 1, 1]
+    true_array[1, 1, 2] = 0
     return array, true_array
 
 

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -97,7 +97,7 @@ def interpVector(vec, Nx):
     return f(xnew)
 
 
-def fillna3D(array, axis=-1):
+def fillna3D(array, axis=-1, fill_value=0.):
     '''
     This function fills in NaNs in 3D arrays, specifically using the nearest non-nan value
     for "low" NaNs and 0s for "high" NaNs. 
@@ -117,7 +117,7 @@ def fillna3D(array, axis=-1):
 
     # fill upper NaNs with 0s
     outmat = np.moveaxis(out, -1, axis)
-    outmat[np.isnan(outmat)] = 0.
+    outmat[np.isnan(outmat)] = fill_value
     return outmat
 
 

--- a/tools/RAiDER/interpolator.py
+++ b/tools/RAiDER/interpolator.py
@@ -98,13 +98,27 @@ def interpVector(vec, Nx):
 
 
 def fillna3D(array, axis=-1):
+    '''
+    This function fills in NaNs in 3D arrays, specifically using the nearest non-nan value
+    for "low" NaNs and 0s for "high" NaNs. 
 
+    Arguments: 
+        array   - 3D array, where the last axis is the "z" dimension
+    
+    Returns: 
+        3D array with low NaNs filled as nearest neighbors and high NaNs filled as 0s
+    '''
+
+    # fill lower NaNs with nearest neighbor
     narr = np.moveaxis(array, axis, -1)
     nars = narr.reshape((np.prod(narr.shape[:-1]),) + (narr.shape[-1],))
-    dfd = pd.DataFrame(data=nars).interpolate(axis=1, limit_direction='both')
+    dfd = pd.DataFrame(data=nars).interpolate(axis=1, limit_direction='backward')
     out = dfd.values.reshape(array.shape)
 
-    return np.moveaxis(out, -1, axis)
+    # fill upper NaNs with 0s
+    outmat = np.moveaxis(out, -1, axis)
+    outmat[np.isnan(outmat)] = 0.
+    return outmat
 
 
 def interpolateDEM(demFile, outLL, method='nearest'):

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -681,7 +681,7 @@ class WeatherModel(ABC):
         Fill in NaN-values
         '''
         self._p = fillna3D(self._p)
-        self._t = fillna3D(self._t)
+        self._t = fillna3D(self._t, fill_value=1e16)
         self._e = fillna3D(self._e)
 
 

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -681,7 +681,7 @@ class WeatherModel(ABC):
         Fill in NaN-values
         '''
         self._p = fillna3D(self._p)
-        self._t = fillna3D(self._t, fill_value=1e16)
+        self._t = fillna3D(self._t, fill_value=1e16) # to avoid division by zero later on
         self._e = fillna3D(self._e)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix a bug in `fillna3D` that resulted in too large of integrated delays

## Description
<!--- Describe your changes in detail -->
`fillna3D` was designed to infill NaNs that are below topography with the nearest non-NaN value. However, there was previously no check for whether there were NaNs _above_ the highest elevation provided by the weather model. For most models this is not an issue because the weather model extends to the highest levels we use in RAiDER. However, HRRR only extends to ~20 km, which left up to 60 km of heights compared to our standard fixed heights (e.g., `LEVELS_137_HEIGHTS`). This fixes the issue by replace "upper" NaNs with 0s, except for temperature, which occurs in the denominator of the refractivity equation, so we replace it with a very high positive value. 

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
<!--- Please describe how you tested your changes. -->
- verified that the issue is correctly handled and fixed in HRRR
- no existing unit tests tested this functionality. I will add unit tests to my other PR but think this is important enough to push now. 

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
