### PR TITLE
Allow wm nans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest updates:
++ Dont error out when the weather model contains nan values (HRRR)
 + Fix bug in fillna3D for NaNs at elevations higher than present in the weather model
 + write delays even if they contain nans
 + check that the aoi is contained within HRRR extent

--- a/test/test_delayFcns.py
+++ b/test/test_delayFcns.py
@@ -22,9 +22,10 @@ def test_getInterpolators(wmdata):
     tw, th = getInterpolators(ds, kind='pointwise')
     assert True # always pass unless an error is raised
 
-def test_getInterpolators_2(wmdata):
+def test_getInterpolators_2(wmdata, caplog):
     ds = wmdata
     ds['hydro'][0,0,0] = np.nan
-    with pytest.raises(RuntimeError):
-        getInterpolators(ds, kind='pointwise')
-    
+    # with pytest.raises(RuntimeError):
+    getInterpolators(ds, kind='pointwise')
+    assert 'Weather model contains NaNs!' in caplog.text, 'No warning was raised!'
+

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -100,7 +100,7 @@ def tropo_delay(
         try:
             ifWet, ifHydro = getInterpolators(ds, "ztd")
         except RuntimeError:
-            logger.exception('Weather model %s failed, may contain NaNs', weather_model_file)
+            logger.exception('Failed to get weather model %s interpolators.', weather_model_file)
 
         wetDelay = ifWet(pnts)
         hydroDelay = ifHydro(pnts)
@@ -129,7 +129,7 @@ def _get_delays_on_cube(dt, weather_model_file, wm_proj, aoi, heights, los, crs,
         try:
             ifWet, ifHydro = getInterpolators(weather_model_file, "total")
         except RuntimeError:
-            logger.exception('Weather model {} failed, may contain NaNs'.format(weather_model_file))
+            logger.exception('Failed to get weather model %s interpolators.', weather_model_file)
 
 
         # Build cube
@@ -148,7 +148,7 @@ def _get_delays_on_cube(dt, weather_model_file, wm_proj, aoi, heights, los, crs,
                 shared=(nproc > 1),
             )
         except RuntimeError:
-            logger.exception('Weather model {} failed, may contain NaNs'.format(weather_model_file))
+            logger.exception('Failed to get weather model %s interpolators.', weather_model_file)
 
         # Build cube
         if nproc == 1:

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -12,6 +12,8 @@ import numpy as np
 from scipy.interpolate import RegularGridInterpolator as Interpolator
 
 from RAiDER.utilFcns import transformPoints
+from RAiDER.logger import logger
+
 
 def getInterpolators(wm_file, kind='pointwise', shared=False):
     '''
@@ -37,7 +39,7 @@ def getInterpolators(wm_file, kind='pointwise', shared=False):
     hydro = np.array(hydro).transpose(1, 2, 0)
 
     if np.any(np.isnan(wet)) or np.any(np.isnan(hydro)):
-        raise RuntimeError(f'Weather model {wm_file} contains NaNs')
+        logger.critical(f'Weather model contains NaNs!')
 
     # If shared interpolators are requested
     # The arrays are not modified - so turning off lock for performance

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -281,7 +281,7 @@ class HRRR(WeatherModel):
 
         elif aoi.intersects(self._valid_bounds):
             Mod = self
-            logger.critical('The HRRR weather model extent doesnt completely cover your AOI!')
+            logger.critical('The HRRR weather model extent does not completely cover your AOI!')
 
         else:
             Mod = HRRRAK()
@@ -291,7 +291,7 @@ class HRRR(WeatherModel):
             if Mod._valid_bounds.contains(aoi):
                 pass
             elif aoi.intersects(Mod._valid_bounds):
-                logger.critical('The HRRR-AK weather model extent doesnt completely cover your AOI!')
+                logger.critical('The HRRR-AK weather model extent does not completely cover your AOI!')
 
             else:
                 raise ValueError('The requested location is unavailable for HRRR')

--- a/tools/RAiDER/models/hrrr.py
+++ b/tools/RAiDER/models/hrrr.py
@@ -281,7 +281,7 @@ class HRRR(WeatherModel):
 
         elif aoi.intersects(self._valid_bounds):
             Mod = self
-            log.critical('The HRRR weather model extent doesnt completely cover your AOI!')
+            logger.critical('The HRRR weather model extent doesnt completely cover your AOI!')
 
         else:
             Mod = HRRRAK()
@@ -291,7 +291,7 @@ class HRRR(WeatherModel):
             if Mod._valid_bounds.contains(aoi):
                 pass
             elif aoi.intersects(Mod._valid_bounds):
-                log.critical('The HRRR-AK weather model extent doesnt completely cover your AOI!')
+                logger.critical('The HRRR-AK weather model extent doesnt completely cover your AOI!')
 
             else:
                 raise ValueError('The requested location is unavailable for HRRR')

--- a/tools/RAiDER/models/plotWeather.py
+++ b/tools/RAiDER/models/plotWeather.py
@@ -47,7 +47,7 @@ def plot_pqt(weatherObj, savefig=True, z1=500, z2=15000):
 
     # setup the plot
     f = plt.figure(figsize=(18, 14))
-    f.suptitle(f'{weatherObj._Name} Pressure/Humidity/Temperature at height {z1}m and {z1}m (values should drop as elevation increases)')
+    f.suptitle(f'{weatherObj._Name} Pressure/Humidity/Temperature at height {z1}m and {z2}m (values should drop as elevation increases)')
 
     xind = int(np.floor(weatherObj._xs.shape[0] / 2))
     yind = int(np.floor(weatherObj._ys.shape[0] / 2))
@@ -129,7 +129,7 @@ def plot_wh(weatherObj, savefig=True, z1=500, z2=15000):
 
     # setup the plot
     f = plt.figure(figsize=(14, 10))
-    f.suptitle(f'{weatherObj._Name} Wet and Hydrostatic refractivity at height {z1}m and {z1}m')
+    f.suptitle(f'{weatherObj._Name} Wet and Hydrostatic refractivity at height {z1}m and {z2}m')
 
     # loop over each plot
     for ind, plot, title in zip(range(len(plots)), plots, titles):


### PR DESCRIPTION
In #564 we decided to allow the code to proceed if there are nans in the delays (typically caused by a user specifying an AOI that exceed the weather model bounds). 

Similarly, if the user requests a bounding box (or gnss stations) that are outside of CONUS but wants HRRR, there will be nans in the weather model itself. 

So here we now allow the code to proceed if there are nans in the weather model.