### PR TITLE
dont integrate higher than weather model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest updates:
-+ Don't integrate the rays at levels higher than the weather model which introduces nans 
++ Lower the constant used for height integration during ray tracing to 26 km, a km below the top of the lowest weather model currently supported (HRRR)
 + Use native model levels in HRRR which extend up to 2 hPa as opposed to 50 hPa in pressure levels
 + Update tests to account for different interpolation scheme
 + Dont error out when the weather model contains nan values (HRRR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest updates:
-+ Lower the constant used for height integration during ray tracing to 26 km, a km below the top of the lowest weather model currently supported (HRRR)
++ Prevent ray tracing integration from occuring at exactly top of weather model
++ Properly expose z_ref (max integration height) parameter, and dont allow higher than weather model
 + Use native model levels in HRRR which extend up to 2 hPa as opposed to 50 hPa in pressure levels
 + Update tests to account for different interpolation scheme
 + Dont error out when the weather model contains nan values (HRRR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest updates:
++ Don't integrate the rays at levels higher than the weather model which introduces nans 
 + Use native model levels in HRRR which extend up to 2 hPa as opposed to 50 hPa in pressure levels
 + Update tests to account for different interpolation scheme
 + Dont error out when the weather model contains nan values (HRRR)

--- a/test/test_synthetic.py
+++ b/test/test_synthetic.py
@@ -65,7 +65,7 @@ def update_model(wm_file:str, wm_eq_type:str, wm_dir:str='weather_files_synth'):
     return dst
 
 
-def length_of_ray(target_xyz:list, model_zs, los):
+def length_of_ray(target_xyz:list, model_zs, los, max_height):
     """ Build rays at xy locations
 
     Target xyz is a list of lists (xpts, ypts, hgt_levels)
@@ -85,7 +85,7 @@ def length_of_ray(target_xyz:list, model_zs, los):
         llh = [xx, yy, np.full(yy.shape, ht)]
         xyz = np.stack(lla2ecef(llh[1], llh[0], np.full(yy.shape, ht)), axis=-1)
         LOS = los.getLookVectors(ht, llh, xyz, yy)
-        ray_lengths = build_ray(model_zs, ht, xyz, LOS)[0]
+        ray_lengths = build_ray(model_zs, ht, xyz, LOS, max_height)[0]
         outputArrs[hh] = ray_lengths.sum(0)
     return outputArrs
 
@@ -238,8 +238,9 @@ def test_hydrostatic_eq(region, mod='ERA-5'):
 
 
     # now build the rays at the unbuffered wm nodes
+    max_tropo_height = SAobj.wmObj._zlevels[-1] - 1
     targ_xyz   = [da.x.data, da.y.data, da.z.data]
-    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los)
+    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los, max_tropo_height)
 
     # scale by constant (units K/Pa) to match raider (m K / Pa)
     ray_data  = ray_length * SAobj.wmObj._k1
@@ -305,8 +306,9 @@ def test_wet_eq_linear(region, mod='ERA-5'):
     del ds
 
     # now build the rays at the unbuffered wm nodes
+    max_tropo_height = SAobj.wmObj._zlevels[-1] - 1
     targ_xyz   = [da.x.data, da.y.data, da.z.data]
-    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los)
+    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los, max_tropo_height)
 
     # scale by constant (units K/Pa) to match raider (m K / Pa)
     ray_data  = ray_length * SAobj.wmObj._k2
@@ -324,6 +326,7 @@ def test_wet_eq_linear(region, mod='ERA-5'):
 
     da.close()
     del da
+
 
 @pytest.mark.parametrize('region', 'AK LA Fort'.split())
 def test_wet_eq_nonlinear(region, mod='ERA-5'):
@@ -370,8 +373,9 @@ def test_wet_eq_nonlinear(region, mod='ERA-5'):
     del ds
 
     # now build the rays at the unbuffered wm nodes
+    max_tropo_height = SAobj.wmObj._zlevels[-1] - 1
     targ_xyz   = [da.x.data, da.y.data, da.z.data]
-    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los)
+    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los, max_tropo_height)
     # scale by constant (units K/Pa) to match raider (m K^2 / Pa)
     ray_data  = ray_length * SAobj.wmObj._k3
 

--- a/test/test_synthetic.py
+++ b/test/test_synthetic.py
@@ -65,7 +65,7 @@ def update_model(wm_file:str, wm_eq_type:str, wm_dir:str='weather_files_synth'):
     return dst
 
 
-def length_of_ray(target_xyz:list, model_zs, los, max_height):
+def length_of_ray(target_xyz:list, model_zs, los):
     """ Build rays at xy locations
 
     Target xyz is a list of lists (xpts, ypts, hgt_levels)
@@ -85,7 +85,7 @@ def length_of_ray(target_xyz:list, model_zs, los, max_height):
         llh = [xx, yy, np.full(yy.shape, ht)]
         xyz = np.stack(lla2ecef(llh[1], llh[0], np.full(yy.shape, ht)), axis=-1)
         LOS = los.getLookVectors(ht, llh, xyz, yy)
-        ray_lengths = build_ray(model_zs, ht, xyz, LOS, max_height)[0]
+        ray_lengths = build_ray(model_zs, ht, xyz, LOS)[0]
         outputArrs[hh] = ray_lengths.sum(0)
     return outputArrs
 
@@ -238,9 +238,8 @@ def test_hydrostatic_eq(region, mod='ERA-5'):
 
 
     # now build the rays at the unbuffered wm nodes
-    max_tropo_height = SAobj.wmObj._zlevels[-1] - 1
     targ_xyz   = [da.x.data, da.y.data, da.z.data]
-    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los, max_tropo_height)
+    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los)
 
     # scale by constant (units K/Pa) to match raider (m K / Pa)
     ray_data  = ray_length * SAobj.wmObj._k1
@@ -306,9 +305,8 @@ def test_wet_eq_linear(region, mod='ERA-5'):
     del ds
 
     # now build the rays at the unbuffered wm nodes
-    max_tropo_height = SAobj.wmObj._zlevels[-1] - 1
     targ_xyz   = [da.x.data, da.y.data, da.z.data]
-    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los, max_tropo_height)
+    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los)
 
     # scale by constant (units K/Pa) to match raider (m K / Pa)
     ray_data  = ray_length * SAobj.wmObj._k2
@@ -372,9 +370,8 @@ def test_wet_eq_nonlinear(region, mod='ERA-5'):
     del ds
 
     # now build the rays at the unbuffered wm nodes
-    max_tropo_height = SAobj.wmObj._zlevels[-1] - 1
     targ_xyz   = [da.x.data, da.y.data, da.z.data]
-    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los, max_tropo_height)
+    ray_length = length_of_ray(targ_xyz, SAobj.wmObj._zlevels, SAobj.los)
     # scale by constant (units K/Pa) to match raider (m K^2 / Pa)
     ray_data  = ray_length * SAobj.wmObj._k3
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -93,7 +93,7 @@ def read_template_file(fname):
 
         if key == 'los_group':
             template['los']  = get_los(AttributeDict(value))
-            template['zref'] = AttributeDict(value).get('zref', _ZREF)
+            template['zref'] = AttributeDict(value).get('zref')
         if key == 'look_dir':
             if value.lower() not in ['right', 'left']:
                 raise ValueError(f"Unknown look direction {value}")

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 import RAiDER.aria.prepFromGUNW
 import RAiDER.aria.calcGUNW
 from RAiDER import aws
+from RAiDER.constants import _ZREF
 from RAiDER.logger import logger, logging
 from RAiDER.cli import DEFAULT_DICT, AttributeDict
 from RAiDER.cli.parser import add_out, add_cpus, add_verbose
@@ -91,7 +92,8 @@ def read_template_file(fname):
             template['aoi'] = get_query_region(AttributeDict(dct_temp))
 
         if key == 'los_group':
-            template['los'] = get_los(AttributeDict(value))
+            template['los']  = get_los(AttributeDict(value))
+            template['zref'] = AttributeDict(value).get('zref', _ZREF)
         if key == 'look_dir':
             if value.lower() not in ['right', 'left']:
                 raise ValueError(f"Unknown look direction {value}")
@@ -321,6 +323,7 @@ def calcDelays(iargs=None):
                 t, weather_model_file, aoi, los,
                 height_levels = params['height_levels'],
                 out_proj = params['output_projection'],
+                zref=params['zref']
             )
         except RuntimeError:
             logger.exception("Datetime %s failed", t)

--- a/tools/RAiDER/cli/raider.yaml
+++ b/tools/RAiDER/cli/raider.yaml
@@ -104,7 +104,7 @@ height_group:
 ## STD calculation:
 los_group:
   ray_trace: False  # Use projected slant delay by default
-  zref: # Maximum integration height. Only used in raytracing. Default 80km.
+  zref: # Maximum integration height. Only used in raytracing. Default 26km.
 
   # raster file in radar or geocoordinates
   los_file:

--- a/tools/RAiDER/cli/raider.yaml
+++ b/tools/RAiDER/cli/raider.yaml
@@ -104,7 +104,7 @@ height_group:
 ## STD calculation:
 los_group:
   ray_trace: False  # Use projected slant delay by default
-  zref: # Maximum integration height. Only used in raytracing. Default 26km.
+  zref: # Maximum integration height. Only used in raytracing. Default: top of weather model.
 
   # raster file in radar or geocoordinates
   los_file:

--- a/tools/RAiDER/constants.py
+++ b/tools/RAiDER/constants.py
@@ -8,7 +8,7 @@
 import numpy as np
 
 _ZMIN = np.float64(-100)   # minimum required height
-_ZREF = np.float64(26000)  # maximum integration height
+_ZREF = np.float64(26000)  # maximum integration height when not specified by user
 _STEP = np.float64(15.0)   # integration step size in meters
 
 _g0 = np.float64(9.80665) # Standard gravitational constant

--- a/tools/RAiDER/constants.py
+++ b/tools/RAiDER/constants.py
@@ -8,7 +8,7 @@
 import numpy as np
 
 _ZMIN = np.float64(-100)   # minimum required height
-_ZREF = np.float64(80000)  # maximum integration height
+_ZREF = np.float64(26000)  # maximum integration height
 _STEP = np.float64(15.0)   # integration step size in meters
 
 _g0 = np.float64(9.80665) # Standard gravitational constant

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -314,18 +314,6 @@ def _build_cube_ray(
                 # For each interpolator, integrate between levels
                 for mm, out in enumerate(outSubs):
                     val =  interpolators[mm](pts)
-                    if np.isnan(val).any() and ht == 3500:
-                        ray_lengths, low_xyzs, high_xyzs = \
-                            build_ray(model_zs, ht, xyz, LOS,  MAX_TROPO_HEIGHT, bp=True)
-
-                    elif np.isnan(val).any() and ht == 4000:
-                        ray_lengths, low_xyzs, high_xyzs = \
-                            build_ray(model_zs, ht, xyz, LOS,  MAX_TROPO_HEIGHT, bp=True)
-
-                    # if ht == 9000 and zz == 82:
-                    #     ray_lengths, low_xyzs, high_xyzs = \
-                    #         build_ray(model_zs, ht, xyz, LOS,  MAX_TROPO_HEIGHT, bp=True)
-
 
                     # TODO - This should not occur if there is enough padding in model
                     # val[np.isnan(val)] = 0.0

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -81,6 +81,9 @@ def tropo_delay(
         else:
             height_levels = wm_levels
 
+    if not zref:
+        zref = toa
+
     if zref > toa:
         zref = toa
         logger.warning('Requested integration height (zref) is higher than top of weather model. Forcing to top ({toa}).')

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -72,6 +72,7 @@ def tropo_delay(
     # get heights
     with xarray.load_dataset(weather_model_file) as ds:
         wm_levels = ds.z.values
+        toa       = wm_levels.max() - 1
 
 
     if height_levels is None:
@@ -80,8 +81,9 @@ def tropo_delay(
         else:
             height_levels = wm_levels
 
-    if zref > wm_levels.max()-1:
-        logger.warning('Requested integration height (zref) is higher than top of weather. May introduce nans.')
+    if zref > toa:
+        zref = toa
+        logger.warning('Requested integration height (zref) is higher than top of weather model. Forcing to top ({toa}).')
 
 
     #TODO: expose this as library function

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -746,6 +746,10 @@ def build_ray(model_zs, ht, xyz, LOS, MAX_TROPO_HEIGHT=_ZREF):
         low_ht = model_zs[zz]
         high_ht = model_zs[zz + 1]
 
+        # this will force ray lengths to stay within the weather model domain
+        if high_ht == model_zs[-1]:
+            high_ht -= 0.01
+
         # If high_ht < height of point - no contribution to integral
         # If low_ht > max_tropo_height - no contribution to integral
         if (high_ht < ht) or (low_ht >= MAX_TROPO_HEIGHT):

--- a/tools/RAiDER/models/model_levels.py
+++ b/tools/RAiDER/models/model_levels.py
@@ -2,7 +2,7 @@
 Pre-defined model levels and a, b constants for the different weather models
 
 **NOTE**: The fixed heights used here are from ECMWF's _geometric_ altitudes
-(https://www.ecmwf.int/en/forecasts/documentation-and-support/137-model-levels),
+(https://confluence.ecmwf.int/display/UDOC/L137+model+level+definitions),
 where "geopotential altitude is calculated from a mathematical model that adjusts
 the altitude to include the variation of gravity with height, while geometric
 altitude is the standard direct vertical distance above mean sea level (MSL)."

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -675,6 +675,7 @@ class WeatherModel(ABC):
                 _zlevels = self._zlevels
             except BaseException:
                 _zlevels = np.nanmean(self._zs, axis=(0, 1))
+
         new_zs = np.tile(_zlevels, (nx, ny, 1))
 
         # re-assign values to the uniform z


### PR DESCRIPTION
Nan values are introduced when we attempt to integrate rays above the weather model ceiling. 
This change will force the top of the integration to be 1 meter less than the top of the weather model.
Closes #574 