### PR TITLE
Azimuth time interpolation when input GUNWs have overlapping Orbit XMLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4]
+
+## Fixes
+* For s1-azimuth-time interpolation, overlapping orbits when one orbit does not cover entire GUNW product errors out. We now ensure state-vectors are both unique and in order before creating a orbit object in ISCE3.
+
 ## [0.4.3]
 + Prevent ray tracing integration from occuring at exactly top of weather model
 + Properly expose z_ref (max integration height) parameter, and dont allow higher than weather model

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -98,3 +98,13 @@ def weather_model_dict_for_center_time_test():
                      test_data / 'HRRR_2021_07_11_T02_00_00_33N_36N_120W_115W.nc',
                      ]
             }
+
+
+@pytest.fixture(scope='session')
+def orbit_paths_for_duplicate_orbit_xml_test():
+    test_data = TEST_DIR / 'data_for_overlapping_orbits'
+    orbit_file_names = ['S1A_OPER_AUX_POEORB_OPOD_20230413T080643_V20230323T225942_20230325T005942.EOF',
+                        'S1A_OPER_AUX_POEORB_OPOD_20230413T080643_V20230323T225942_20230325T005942.EOF',
+                        'S1A_OPER_AUX_POEORB_OPOD_20230413T080643_V20230323T225942_20230325T005942.EOF',
+                        'S1A_OPER_AUX_POEORB_OPOD_20230412T080821_V20230322T225942_20230324T005942.EOF']
+    return [test_data / fn for fn in orbit_file_names]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -70,8 +70,9 @@ def orbit_dict_for_azimuth_time_test():
 @pytest.fixture(scope='session')
 def slc_id_dict_for_azimuth_time_test():
     test_data = TEST_DIR / 'gunw_azimuth_test_data'
-    return {'reference': test_data / 'S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9',
-            'secondary': test_data / 'S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404'}
+    return {'reference': [test_data / 'S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9'],
+            'secondary': [test_data / 'S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D',
+                          test_data / 'S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C']}
 
 
 @pytest.fixture(scope='session')

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -169,6 +169,11 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
     ```
 
     Note for azimuth time they are acquired in order of proximity to acq as opposed to chronological.
+
+    For the test GUNW, we have the following input granules:
+
+    ref: S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9
+    sec: S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C, S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D
     """
 
     out_0 = gunw_azimuth_test.name.replace('.nc', '__ct_interp.nc')
@@ -191,9 +196,11 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
                                # For center time
                                (orbit_dict_for_azimuth_time_test['reference'], ''),
                                (orbit_dict_for_azimuth_time_test['secondary'], ''),
+                               (orbit_dict_for_azimuth_time_test['secondary'], ''),
                                # For azimuth time
                                (orbit_dict_for_azimuth_time_test['reference'], ''),
                                (orbit_dict_for_azimuth_time_test['secondary'], ''),
+                               (orbit_dict_for_azimuth_time_test['secondary'], '')
                                ]
                  )
 
@@ -239,7 +246,7 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
     # Calls 6 times for azimuth time and 4 times for center time
     assert RAiDER.processWM.prepareWeatherModel.call_count == 10
     # Only calls for azimuth timing for reference and secondary
-    assert hyp3lib.get_orb.downloadSentinelOrbitFile.call_count == 2
+    # assert hyp3lib.get_orb.downloadSentinelOrbitFile.call_count == 2
     # Once for center-time and azimuth-time each
     assert eof.download.download_eofs.call_count == 2
 

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -215,12 +215,13 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
     mocker.patch('eof.download.download_eofs',
                  side_effect=side_effect)
 
+    # These outputs are not needed since the orbits are specified above
     mocker.patch('RAiDER.s1_azimuth_timing.get_slc_id_from_point_and_time',
                  return_value=[
                                # Center_time
-                               'reference_slc_id', 'secondary_slc_id',
+                               ['reference_slc_id'], ['secondary_slc_id'],
                                # Azimuth time
-                               'reference_slc_id', 'secondary_slc_id',
+                               ['reference_slc_id'], ['secondary_slc_id'],
                                ])
 
     side_effect = (weather_model_dict_for_center_time_test[weather_model_name] +

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -244,7 +244,8 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
 
     # Calls 6 times for azimuth time and 4 times for center time
     assert RAiDER.processWM.prepareWeatherModel.call_count == 10
-    # Only calls for azimuth timing for reference and secondary
+    # Only calls for azimuth timing for reference and secondary;
+    # There is 1 slc for ref and 2 for secondary, totalling 3 calls
     assert hyp3lib.get_orb.downloadSentinelOrbitFile.call_count == 3
     # Only calls for azimuth timing: once for ref and sec
     assert RAiDER.s1_azimuth_timing.get_slc_id_from_point_and_time.call_count == 2

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -173,7 +173,8 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
     For the test GUNW, we have the following input granules:
 
     ref: S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9
-    sec: S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C, S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D
+    sec: S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C,
+         S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D
     """
 
     out_0 = gunw_azimuth_test.name.replace('.nc', '__ct_interp.nc')
@@ -196,11 +197,9 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
                                # For center time
                                (orbit_dict_for_azimuth_time_test['reference'], ''),
                                (orbit_dict_for_azimuth_time_test['secondary'], ''),
-                               (orbit_dict_for_azimuth_time_test['secondary'], ''),
                                # For azimuth time
                                (orbit_dict_for_azimuth_time_test['reference'], ''),
                                (orbit_dict_for_azimuth_time_test['secondary'], ''),
-                               (orbit_dict_for_azimuth_time_test['secondary'], '')
                                ]
                  )
 
@@ -247,7 +246,7 @@ def test_azimuth_timing_against_interpolation(weather_model_name: str,
     # Calls 6 times for azimuth time and 4 times for center time
     assert RAiDER.processWM.prepareWeatherModel.call_count == 10
     # Only calls for azimuth timing for reference and secondary
-    # assert hyp3lib.get_orb.downloadSentinelOrbitFile.call_count == 2
+    assert hyp3lib.get_orb.downloadSentinelOrbitFile.call_count == 4
     # Once for center-time and azimuth-time each
     assert eof.download.download_eofs.call_count == 2
 

--- a/test/test_losreader.py
+++ b/test/test_losreader.py
@@ -1,5 +1,6 @@
 import datetime
 import numpy as np
+import RAiDER
 from RAiDER.losreader import (
     read_ESA_Orbit_file,
     read_txt_file,
@@ -111,15 +112,18 @@ def test_read_txt_file(svs):
     assert [np.allclose(s, ts) for s, ts in zip(svs[1:], true_svs[1:])]
 
 
-def test_get_sv_1(svs):
+def test_get_sv_1(svs, mocker):
     true_svs = svs
     filename = os.path.join(ORB_DIR, 'S1_orbit_example.EOF')
+    # Ensures non-stardard file-name for orbit xml is not filtered out
+    mocker.patch('RAiDER.losreader.filter_ESA_orbit_file', side_effects=[True])
     svs = get_sv(filename, true_svs[0][0], pad=3*60)
     assert [np.allclose(
         [(x-y).total_seconds() for x, y in zip(svs[0], true_svs[0])],
         np.zeros(len(svs[0]))
     )]
     assert [np.allclose(s, ts) for s, ts in zip(svs[1:], true_svs[1:])]
+    assert RAiDER.losreader.filter_ESA_orbit_file.call_count == 1
 
 
 def test_get_sv_2(svs):

--- a/test/test_s1_time_grid.py
+++ b/test/test_s1_time_grid.py
@@ -332,3 +332,6 @@ def test_duplicate_orbits(mocker, orbit_paths_for_duplicate_orbit_xml_test):
     time_grid = get_s1_azimuth_time_grid(lon, lat, hgt, t)
 
     assert time_grid.shape == (len(hgt), len(lat), len(lon))
+
+    assert RAiDER.s1_azimuth_timing.get_slc_id_from_point_and_time.call_count == 1
+    assert hyp3lib.get_orb.downloadSentinelOrbitFile.call_count == 4

--- a/test/test_s1_time_grid.py
+++ b/test/test_s1_time_grid.py
@@ -313,11 +313,21 @@ def test_error_catching_with_s1_grid():
         get_s1_azimuth_time_grid(lon, lat, hgt, dt)
 
 
-def test_duplicate_orbits():
+def test_duplicate_orbits(mocker, orbit_paths_for_duplicate_orbit_xml_test):
     hgt = np.linspace(-500, 26158.0385, 20)
     lat = np.linspace(40.647867694896775, 44.445117773316184, 20)
     lon = np.linspace(-74, -79, 20)
     t = datetime.datetime(2023, 3, 23, 23, 0, 28)
+
+    # These outputs are not needed since the orbits are specified above
+    mocker.patch('RAiDER.s1_azimuth_timing.get_slc_id_from_point_and_time',
+                 side_effect=[['slc_id_0', 'slc_id_1', 'slc_id_2', 'slc_id_3']])
+
+    # Hyp3 Lib returns 2 values
+    side_effect = [(o_path, '') for o_path in orbit_paths_for_duplicate_orbit_xml_test]
+    mocker.patch('hyp3lib.get_orb.downloadSentinelOrbitFile',
+                 side_effect=side_effect
+                 )
 
     time_grid = get_s1_azimuth_time_grid(lon, lat, hgt, t)
 

--- a/test/test_s1_time_grid.py
+++ b/test/test_s1_time_grid.py
@@ -311,3 +311,14 @@ def test_error_catching_with_s1_grid():
     hgt = np.arange(P)
     with pytest.raises(ValueError):
         get_s1_azimuth_time_grid(lon, lat, hgt, dt)
+
+
+def test_duplicate_orbits():
+    hgt = np.linspace(-500, 26158.0385, 20)
+    lat = np.linspace(40.647867694896775, 44.445117773316184, 20)
+    lon = np.linspace(-74, -79, 20)
+    t = datetime.datetime(2023, 3, 23, 23, 0, 28)
+
+    time_grid = get_s1_azimuth_time_grid(lon, lat, hgt, t)
+
+    assert time_grid.shape == (len(hgt), len(lat), len(lon))

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -361,6 +361,7 @@ def calcDelays(iargs=None):
             else:
                 raise NotImplementedError('Azimuth Time is currently only implemented for HRRR')
 
+            breakpoint()
             time_grid = get_s1_azimuth_time_grid(lon,
                                                  lat,
                                                  hgt,

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -361,7 +361,6 @@ def calcDelays(iargs=None):
             else:
                 raise NotImplementedError('Azimuth Time is currently only implemented for HRRR')
 
-            breakpoint()
             time_grid = get_s1_azimuth_time_grid(lon,
                                                  lat,
                                                  hgt,

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -352,7 +352,10 @@ def get_sv(los_file: Union[str, list, PosixPath],
         try:
             los_files = [los_file] if isinstance(los_file, (str, PosixPath)) else los_file
             # Do not need duplicate xml files
-            los_files = list(set(los_files))
+            # It appears that we want to make sure that we get data from first available orbit file first in our tests
+            # TODO: figure out why - maybe tests data occur before midnight and has to do with midnight crossing
+            # Will need to more thoroughly test and investigate the `sorted` piece
+            los_files = sorted(list(set(los_files)))
 
             def filter_ESA_orbit_file_p(path: str) -> bool:
                 return filter_ESA_orbit_file(path, ref_time)

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -351,6 +351,8 @@ def get_sv(los_file: Union[str, list, PosixPath],
     except (ValueError, TypeError):
         try:
             los_files = [los_file] if isinstance(los_file, (str, PosixPath)) else los_file
+            # Do not need duplicate xml files
+            los_files = list(set(los_files))
 
             def filter_ESA_orbit_file_p(path: str) -> bool:
                 return filter_ESA_orbit_file(path, ref_time)

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -9,6 +9,8 @@
 import os
 import datetime
 import shelve
+from typing import Union
+from pathlib import PosixPath
 
 import numpy as np
 try:
@@ -323,30 +325,41 @@ def getZenithLookVecs(lats, lons, heights):
     return np.stack([x, y, z], axis=-1)
 
 
-def get_sv(los_file, ref_time, pad):
+def get_sv(los_file: Union[str, list, PosixPath],
+           ref_time: datetime.datetime,
+           pad: int):
     """
     Read an LOS file and return orbital state vectors
 
     Args:
-        los_file (str):     - user-passed file containing either look
-                              vectors or statevectors for the sensor
-        ref_time (datetime):- User-requested datetime; if not encompassed
-                              by the orbit times will raise a ValueError
-        pad (int):          - number of seconds to keep around the
-                              requested time (should be about 600 seconds)
+        los_file (str, Path, list):     - user-passed file containing either look
+                                          vectors or statevectors for the sensor
+        ref_time (datetime):            - User-requested datetime; if not encompassed
+                                          by the orbit times will raise a ValueError
+        pad (int):                      - number of seconds to keep around the
+                                          requested time (should be about 600 seconds)
 
     Returns:
         svs (list of ndarrays): - the times, x/y/z positions and velocities
         of the sensor for the given window around the reference time
+
+    Warning - if multiple orbit files are pasted the svs returned are not organized and returned in the order
+    with respect to the files inputted (and statevectors within them).
     """
     try:
         svs = read_txt_file(los_file)
     except (ValueError, TypeError):
         try:
-            if isinstance(los_file, list):
-                los_file = pick_ESA_orbit_file(los_file, ref_time)
+            los_files = [los_file] if isinstance(los_file, (str, PosixPath)) else los_file
 
-            svs = read_ESA_Orbit_file(los_file)
+            def filter_ESA_orbit_file_p(path: str) -> bool:
+                return filter_ESA_orbit_file(path, ref_time)
+            los_files = list(filter(filter_ESA_orbit_file_p, los_files))
+            if not los_files:
+                raise ValueError('There are no valid orbit files provided')
+            svs = []
+            for orb_path in los_files:
+                svs.extend(read_ESA_Orbit_file(orb_path))
 
         except BaseException:
             try:
@@ -530,6 +543,27 @@ def pick_ESA_orbit_file(list_files:list, ref_time:datetime.datetime):
     return path
 
 
+def filter_ESA_orbit_file(orbit_xml: str,
+                          ref_time: datetime.datetime) -> bool:
+    """Returns true or false depending on whether orbit file contains ref time
+
+    Parameters
+    ----------
+    orbit_xml : str
+        ESA orbit xml
+    ref_time : datetime.datetime
+
+    Returns
+    -------
+    bool
+        True if ref time is within orbit_xml
+    """
+    f = os.path.basename(orbit_xml)
+    t0 = datetime.datetime.strptime(f.split('_')[6].lstrip('V'), '%Y%m%dT%H%M%S')
+    t1 = datetime.datetime.strptime(f.split('_')[7].rstrip('.EOF'), '%Y%m%dT%H%M%S')
+    return (t0 < ref_time < t1)
+
+
 ############################
 def state_to_los(svs, llh_targets):
     '''
@@ -709,26 +743,30 @@ def getTopOfAtmosphere(xyz, look_vecs, toaheight, factor=None):
     return pos
 
 
-def get_orbit(orbit_file, ref_time, pad):
+def get_orbit(orbit_file: Union[list, str],
+              ref_time: datetime.datetime,
+              pad: int):
     '''
-    Returns state vectors from an orbit file
-    orbit file (str):   - user-passed file containing statevectors
-                          for the sensor (can download with sentineleof libray)
-    pad (int):          - number of seconds to keep around the
-                          requested time (should be about 600 seconds)
+    Returns state vectors from an orbit file; state vectors are unique and ordered in terms of time
+    orbit file (str | list):   - user-passed file(s) containing statevectors
+                                 for the sensor (can be download with sentineleof libray)
+    pad (int):                 - number of seconds to keep around the
+                                 requested time (should be about 600 seconds)
 
     '''
     # First load the state vectors into an isce orbit
     import isce3.ext.isce3 as isce
 
-    svs   = np.stack(get_sv(orbit_file, ref_time, pad), axis=-1)
-    svs_i = []
+    svs = np.stack(get_sv(orbit_file, ref_time, pad), axis=-1)
+    sv_objs = []
     # format for ISCE
     for sv in svs:
-       sv = isce.core.StateVector(isce.core.DateTime(sv[0]), sv[1:4], sv[4:7])
-       svs_i.append(sv)
+        sv = isce.core.StateVector(isce.core.DateTime(sv[0]), sv[1:4], sv[4:7])
+        sv_objs.append(sv)
+    sv_objs = list(set(sv_objs))
+    sv_objs = sorted(sv_objs, key=lambda sv: sv.datetime)
 
-    orb = isce.core.Orbit(svs_i)
+    orb = isce.core.Orbit(sv_objs)
 
     return orb
 

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -765,10 +765,18 @@ def get_orbit(orbit_file: Union[list, str],
     for sv in svs:
         sv = isce.core.StateVector(isce.core.DateTime(sv[0]), sv[1:4], sv[4:7])
         sv_objs.append(sv)
-    sv_objs = list(set(sv_objs))
-    sv_objs = sorted(sv_objs, key=lambda sv: sv.datetime)
 
-    orb = isce.core.Orbit(sv_objs)
+    sv_objs = sorted(sv_objs, key=lambda sv: sv.datetime)
+    # Ensure only unique state vectors; unfortunately builtin set does not work.
+    visited_times = []
+    sv_objs_filtered = []
+    for sv in sv_objs:
+        if sv.datetime in visited_times:
+            continue
+        visited_times.append(sv.datetime)
+        sv_objs_filtered.append(sv)
+
+    orb = isce.core.Orbit(sv_objs_filtered)
 
     return orb
 

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -754,7 +754,8 @@ def get_orbit(orbit_file: Union[list, str],
     '''
     Returns state vectors from an orbit file; state vectors are unique and ordered in terms of time
     orbit file (str | list):   - user-passed file(s) containing statevectors
-                                 for the sensor (can be download with sentineleof libray)
+                                 for the sensor (can be download with sentineleof libray). Lists of files
+                                 are only accepted for Sentinel-1 EOF files.
     pad (int):                 - number of seconds to keep around the
                                  requested time (should be about 600 seconds)
 

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -85,7 +85,7 @@ def get_azimuth_time_grid(lon_mesh: np.ndarray,
     Technically, this is "sensor neutral" since it uses an orb object.
     '''
 
-    num_iteration = 30
+    num_iteration = 100
     residual_threshold = 1.0e-7
 
     elp = isce.core.Ellipsoid()

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -27,7 +27,7 @@ def _asf_query(point: Point,
 def get_slc_id_from_point_and_time(lon: float,
                                    lat: float,
                                    dt: datetime.datetime,
-                                   buffer_seconds: int = 60) -> str:
+                                   buffer_seconds: int = 600) -> list:
     """Obtains a (non-unique) SLC id from the lon/lat and datetime of inputs. The buffere ensures that
     an SLC id is within the queried start/end times. Note an S1 scene takes roughly 30 seconds to acquire.
 
@@ -37,12 +37,12 @@ def get_slc_id_from_point_and_time(lon: float,
     lat : float
     dt : datetime.datetime
     buffer_seconds : int, optional
-        Do not recommend adjusting this, by default 60
+        Do not recommend adjusting this, by default 600, to ensure enough padding for multiple orbit files
 
     Returns
     -------
-    str
-        First slc_id returned by asf_search
+    list
+        All slc_ids returned by asf_search
     """
     point = Point(lon, lat)
     time_delta = datetime.timedelta(seconds=buffer_seconds)
@@ -159,7 +159,6 @@ def get_s1_azimuth_time_grid(lon: np.ndarray,
                          np.datetime64('NaT'),
                          dtype='datetime64[ms]')
         return az_arr
-    breakpoint()
     orb_files = list(map(lambda slc_id: hyp3lib.get_orb.downloadSentinelOrbitFile(slc_id)[0], slc_ids))
     orb = get_isce_orbit(orb_files, dt, pad=600)
 

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -53,7 +53,7 @@ def get_slc_id_from_point_and_time(lon: float,
     if not slc_ids:
         raise ValueError('No results found for input lon/lat and datetime')
 
-    return slc_ids[0]
+    return slc_ids
 
 
 def get_azimuth_time_grid(lon_mesh: np.ndarray,
@@ -151,7 +151,7 @@ def get_s1_azimuth_time_grid(lon: np.ndarray,
     try:
         lon_m = np.mean(lon)
         lat_m = np.mean(lat)
-        slc_id = get_slc_id_from_point_and_time(lon_m, lat_m, dt)
+        slc_ids = get_slc_id_from_point_and_time(lon_m, lat_m, dt)
     except ValueError:
         warnings.warn('No slc id found for the given datetime and grid; returning empty grid')
         m, n, p = hgt_mesh.shape
@@ -159,8 +159,9 @@ def get_s1_azimuth_time_grid(lon: np.ndarray,
                          np.datetime64('NaT'),
                          dtype='datetime64[ms]')
         return az_arr
-    orb_file, _ = hyp3lib.get_orb.downloadSentinelOrbitFile(slc_id)
-    orb = get_isce_orbit(orb_file, dt, pad=600)
+    breakpoint()
+    orb_files = list(map(lambda slc_id: hyp3lib.get_orb.downloadSentinelOrbitFile(slc_id)[0], slc_ids))
+    orb = get_isce_orbit(orb_files, dt, pad=600)
 
     az_arr = get_azimuth_time_grid(lon_mesh, lat_mesh, hgt_mesh, orb)
     return az_arr


### PR DESCRIPTION
Resolves #583.

When a GUNWs input granules have multiple associated orbit files to cover the required spatial area and padding. This PR ensures that state vectors are ordered by their timing and are unique. This is made much easier since state vectors in ISCE3 are hashable (in ISCE2, they are not).

I do not think that ISCE3 orbit creation de-duplicates state vectors or orders them. De-duplication is important because if there are duplicate state-vectors the Newton-Raphson method could have zero-derivatives and will thow `NaN` errors.

For more context and discussion, see https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/pull/149.