### PR TITLE
add truncation option for HRES comparing with HRRR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixes
 * For s1-azimuth-time interpolation, overlapping orbits when one orbit does not cover entire GUNW product errors out. We now ensure state-vectors are both unique and in order before creating a orbit object in ISCE3.
+* Use single date when center_time is specified and requested occurs on model hour
 
 ## [0.4.3]
 + Prevent ray tracing integration from occuring at exactly top of weather model

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -305,17 +305,17 @@ def calcDelays(iargs=None):
 
         # nearest weather model time via 'none' is specified
         # When interp_method is 'none' only 1 weather model file and one relevant time
-        elif len(wfiles) == 1 and len(times) == 1:
-            if interp_method == 'none':
-                weather_model_file = wfiles[0]
-            else:
+        elif (interp_method == 'none') and (len(wfiles) == 1) and (len(times) == 1):
+            weather_model_file = wfiles[0]
+
+        elif (interp_method == 'center_time') and (len(wfiles) == 1) and (len(times) == 1):
                 ## check if requested time is coincident with model time
                 valid_hours = np.arange(0, 24, model._time_res)
                 if model._time.hour in valid_hours:
                     weather_model_file = wfiles[0]
                 else:
                     n = len(wfiles)
-                    raise NotImplementedError(f'The {interp_method} with {n} retrieved weather model files was not well posed '
+                    raise NotImplementedError(f'The center_time with {n} retrieved weather model files was not well posed '
                                       'for the dela current workflow.')
 
         # only one time in temporal interpolation worked

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -305,8 +305,18 @@ def calcDelays(iargs=None):
 
         # nearest weather model time via 'none' is specified
         # When interp_method is 'none' only 1 weather model file and one relevant time
-        elif (interp_method == 'none') and (len(wfiles) == 1) and (len(times) == 1):
-            weather_model_file = wfiles[0]
+        elif len(wfiles) == 1 and len(times) == 1:
+            if interp_method == 'none':
+                weather_model_file = wfiles[0]
+            else:
+                ## check if requested time is coincident with model time
+                valid_hours = np.arange(0, 24, model._time_res)
+                if model._time.hour in valid_hours:
+                    weather_model_file = wfiles[0]
+                else:
+                    n = len(wfiles)
+                    raise NotImplementedError(f'The {interp_method} with {n} retrieved weather model files was not well posed '
+                                      'for the dela current workflow.')
 
         # only one time in temporal interpolation worked
         # TODO: this seems problematic - unexpected behavior possibly for 'center_time'

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -78,7 +78,12 @@ def tropo_delay(
         else:
             height_levels = wm_levels
 
-    zref = float(zref)
+    if isinstance(zref, str):
+        try:
+            zref = float(zref)
+        except:
+            log.warning('Cannot convert zref={%s} to a number', zref)
+
     if not zref:
         zref = toa
 

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -78,6 +78,7 @@ def tropo_delay(
         else:
             height_levels = wm_levels
 
+    zref = float(zref)
     if not zref:
         zref = toa
 

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -84,7 +84,7 @@ def tropo_delay(
 
     if zref > toa:
         zref = toa
-        logger.warning('Requested integration height (zref) is higher than top of weather model. Forcing to top ({toa}).')
+        logger.warning(f'Requested integration height (zref) is higher than top of weather model. Forcing to top ({toa}).')
 
 
     #TODO: expose this as library function

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -94,6 +94,8 @@ class ECMWF(WeatherModel):
         self._t = t
         self._q = q
 
+        # reset the model levels to allow truncation to work with temporal interpolation
+        self.__model_levels__()
         geo_hgt, pres, hgt = self._calculategeoh(z, lnsp)
 
         TRUNCATE = True

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -83,11 +83,6 @@ def prepareWeatherModel(
     f = weather_model.load()
 
     if f is not None:
-        logger.warning(
-            'The processed weather model file already exists,'
-            ' so I will use that.'
-        )
-
         containment = weather_model.checkContainment(ll_bounds)
         if not containment and weather_model.Model() in 'GMAO ERA5 ERA5T HRES'.split():
             msg = 'The weather model passed does not cover all of the input ' \


### PR DESCRIPTION
We would like to compare zenith delays of HRRR with HRES.

To do that we need to fix the same height levels for each model, as HRRR doesn't go as high as HRES.
Here I hardcoded in a TRUNCATE option for HRES which will force it to use the same height levels as HRRR.

I've attached an image showing the difference in HRES for full (137) and truncating (matching HRRR, 50) height levels. The residual is as expected. 

**This isn't to be merged, just want to put here for now and allow any comments. Currently using this to compute HRES delays at GNSS in CONUS.**

![Figure_1](https://github.com/dbekaert/RAiDER/assets/15522503/b45a0a4d-c863-40e7-a670-f2be7489dfd4)
