### PR TITLE
patch for model timing=requested time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixes
 * For s1-azimuth-time interpolation, overlapping orbits when one orbit does not cover entire GUNW product errors out. We now ensure state-vectors are both unique and in order before creating a orbit object in ISCE3.
+* Use single date when center_time is specified and requested occurs on model hour
 
 ## [0.4.3]
 + Prevent ray tracing integration from occuring at exactly top of weather model

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -256,8 +256,11 @@ def calcDelays(iargs=None):
         # The two datetimes will be combined to a single file and processed
         # TODO: make more transparent control flow for GUNW and non-GUNW workflow
         if (interp_method in ['none', 'center_time']):
-            times = get_nearest_wmtimes(t, [model.dtime() if \
-                                        model.dtime() is not None else 6][0]) if interp_method == 'center_time' else [t]
+            if interp_method == 'center_time':
+                times = get_nearest_wmtimes(t, [model.dtime() if \
+                                        model.dtime() is not None else 6][0])
+            else:
+                times = [t]
         elif interp_method == 'azimuth_time_grid':
             n_target_dates = 3
             step = model.dtime()
@@ -311,7 +314,7 @@ def calcDelays(iargs=None):
             else:
                 ## check if requested time is coincident with model time
                 valid_hours = np.arange(0, 24, model._time_res)
-                if model._time.hour in valid_hours:
+                if tt.hour in valid_hours:
                     weather_model_file = wfiles[0]
                 else:
                     n = len(wfiles)

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -305,8 +305,18 @@ def calcDelays(iargs=None):
 
         # nearest weather model time via 'none' is specified
         # When interp_method is 'none' only 1 weather model file and one relevant time
-        elif (interp_method == 'none') and (len(wfiles) == 1) and (len(times) == 1):
-            weather_model_file = wfiles[0]
+        elif len(wfiles) == 1 and len(times) == 1:
+            if interp_method == 'none':
+                weather_model_file = wfiles[0]
+            else:
+                ## check if requested time is coincident with model time
+                valid_hours = np.arange(0, 24, model._time_res)
+                if model._time.hour in valid_hours:
+                    weather_model_file = wfiles[0]
+                else:
+                    n = len(wfiles)
+                    raise NotImplementedError(f'The {interp_method} with {n} retrieved weather model files was not well posed '
+                                      'for the dela current workflow.')
 
         # only one time in temporal interpolation worked
         # TODO: this seems problematic - unexpected behavior possibly for 'center_time'

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -78,7 +78,12 @@ def tropo_delay(
         else:
             height_levels = wm_levels
 
-    zref = float(zref)
+    if isinstance(zref, str):
+        try:
+            zref = float(zref)
+        except:
+            log.warning('Cannot convert zref={%s} to a number', zref)
+
     if not zref:
         zref = toa
 

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -78,6 +78,7 @@ def tropo_delay(
         else:
             height_levels = wm_levels
 
+    zref = float(zref)
     if not zref:
         zref = toa
 

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -83,11 +83,6 @@ def prepareWeatherModel(
     f = weather_model.load()
 
     if f is not None:
-        logger.warning(
-            'The processed weather model file already exists,'
-            ' so I will use that.'
-        )
-
         containment = weather_model.checkContainment(ll_bounds)
         if not containment and weather_model.Model() in 'GMAO ERA5 ERA5T HRES'.split():
             msg = 'The weather model passed does not cover all of the input ' \


### PR DESCRIPTION
When the center time is specified, but the requested time is at the same time as a model time, raider control logic fails. 
Added more logic that enables it to proceed