### PR TITLE
Fixes prefix logic for GUNW workflow to ensure dates can be extracted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [#583](https://github.com/dbekaert/RAiDER/issues/583): it appears that since the issues with geo2rdr cropped up during our processing campaign, there has been a new release of ISCE3 that resolves these failures with `geo2rdr` and the time interpolation that uses this ISCE3 routine.
 * [#584](https://github.com/dbekaert/RAiDER/issues/584): failed Raider step function in hyp3 job submission when HRRR model times are not available (even within the valid model range) - to resolve, we check availability of files when delay workflow called with a) azimuth_grid_interpolation and b) input to workflow is GUNW. If weather model files are unavailable and the GUNW is on s3, do nothing to GUNW (i.e. do not add tropo delay) and exit successfully. If weather model files are unavailable and the GUNW is on local disk, raise `ValueError`
 * [#587](https://github.com/dbekaert/RAiDER/issues/587): similar to 584 except added here to the mix is control flow in RAiDER.py passes over numerous exceptions in workflow. This is fixed identically as above.
+* [#596](https://github.com/dbekaert/RAiDER/issues/596): the "prefix" for aws does not include the final netcdf file name, just the sub-directories in the bucket and therefore extra logic must be added to determine the GUNW netcdf file name (and the assocaited reference/secondary dates). We proceed by downloading the data which is needed regardless. Test are updated.
 
 ## Removed
 * Removes `update` option (either `True` or `False`) from calcGUNW workflow which asks whether the GUNW should be updated or not. In existing code, it was not being used/applied, i.e. previous workflow always updated GUNW. Removed input arguments related from respective functions so that it can be updated later.
@@ -35,6 +36,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * hrrr_download to ensure that `hybrid` coordinate is obtained regardless how herbie returns datacubes and ensures test_HRRR_ztd passes consistently
    * Remove the command line call in `test_HRRR_ztd.py` and call using the python mock up of CLI for better error handling and data mocking.
 * Return xarray.Dataset types for RAiDER.calcGUNW.tropo_gunw_slc and RAiDER.raider.calcDelayGUNW for easier inspection and testing
+* Fixes tests for checking availability of HRRR due Issue #596 (above).
 
 ## [0.4.4]
 

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -439,7 +439,6 @@ def test_hrrr_availability_check_using_gunw_ids(mocker):
 
     # All dates in 2023 are available
     gunw_id = 'S1-GUNW-A-R-106-tops-20230108_20230101-225947-00078W_00041N-PP-4be8-v3_0_0'
-
     assert check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id)
 
     # 2016-08-09 16:00:00 is a missing date
@@ -454,10 +453,13 @@ def test_hyp3_exits_succesfully_when_hrrr_not_available(mocker):
     # 2016-08-09 16:00:00 is a missing date
     mocker.patch('RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation',
                  side_effect=[False])
+    # The gunw id should not have a hyp3 file associated with it
+    # This call will still hit the HRRR s3 API as done in the previous test
+    mocker.patch("RAiDER.aws.get_s3_file", side_effect=['weirdly-named-prefix_-3ad24/S1-GUNW-A-R-106-tops-20160809_20140101-160001-00078W_00041N-PP-4be8-v3_0_0'])
     mocker.patch('RAiDER.aria.prepFromGUNW.check_weather_model_availability')
     iargs = [
                '--bucket', 's3://foo',
-               '--bucket-prefix', 'bar.nc',
+               '--bucket-prefix', 'weirdly-named-prefix_-3ad24',
                '--weather-model', 'HRRR',
                '-interp', 'azimuth_time_grid'
                ]

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -610,15 +610,16 @@ def calcDelaysGUNW(iargs: list[str] = None) -> xr.Dataset:
 
     if not iargs.file and iargs.bucket:
         # only use GUNW ID for checking if HRRR available
+        iargs.file = aws.get_s3_file(iargs.bucket, iargs.bucket_prefix, '.nc')
         if iargs.weather_model == 'HRRR' and (iargs.interpolate_time == 'azimuth_time_grid'):
-            gunw_nc_name = iargs.bucket_prefix.split('/')[-1]
+            file_name_str = str(iargs.file)
+            gunw_nc_name = file_name_str.split('/')[-1]
             gunw_id = gunw_nc_name.replace('.nc', '')
             if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id):
                 print('The required HRRR data for time-grid interpolation is not available; returning None and not modifying GUNW dataset')
                 return
 
         # Download file to obtain metadata
-        iargs.file = aws.get_s3_file(iargs.bucket, iargs.bucket_prefix, '.nc')
         if not RAiDER.aria.prepFromGUNW.check_weather_model_availability(iargs.file, iargs.weather_model):
             # NOTE: We want to submit jobs that are outside of acceptable weather model range
             #       and still deliver these products to the DAAC without this layer. Therefore


### PR DESCRIPTION
Resolves #596.

What's important here is that the input arguments for hyp3 are (can see the job parameters in the issue ticket to confirm):

```
["++process","calcDelaysGUNW","--bucket","hyp3-a19-jpl-contentbucket-1wfnatpznlg8b","--bucket-prefix","9023f2fe-991d-4e8d-af73-4e8862ee11dd","--weather-model","HRRR"]
```

Therefore the netcdf name needs to be obtained either after downloading netcdf or listing items in the bucket/prefix. We are pursuing former, utilizing existing function in the hyp3lib library to download the corresponding netcdf from the job bucket and prefix to obtain the netcdf file name.

Using this new PR with AWS config correctly set locally, we get the following for the referenced problematic job:

```
raider.py ++process calcDelaysGUNW --bucket hyp3-a19-jpl-cont
entbucket-1wfnatpznlg8b --bucket-prefix 9023f2fe-991d-4e8d-af73-4e8862ee11dd -m HRRR -interp azimuth_time
_grid
Downloading s3://hyp3-a19-jpl-contentbucket-1wfnatpznlg8b/9023f2fe-991d-4e8d-af73-4e8862ee11dd/S1-GUNW-A-R-048-tops-20171203_20161126-233044-00084W_00035N-PP-7fef-v3_0_0.nc to S1-GUNW-A-R-048-tops-20171203_20161126-233044-00084W_00035N-PP-7fef-v3_0_0.nc
✅ Found ┊ model=hrrr ┊ product=nat ┊ 2017-Dec-04 00:00 UTC F00 ┊ GRIB2 @ aws ┊ IDX @ aws
✅ Found ┊ model=hrrr ┊ product=nat ┊ 2017-Dec-03 23:00 UTC F00 ┊ GRIB2 @ aws ┊ IDX @ aws
💔 Did not find ┊ model=hrrr ┊ product=nat ┊ 2016-Nov-27 00:00 UTC F00
💔 Did not find ┊ model=hrrr ┊ product=nat ┊ 2016-Nov-26 23:00 UTC F00
The required HRRR data for time-grid interpolation is not available; returning None and not modifying GUNW dataset
```