### PR TITLE
make isce3 an optional import for `s1_azimuth_timing.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixes
 * make weather file directory when it doesn't exist
 * Ensures the `models/data/alaska.geojson.zip` file is packaged when building from the source tarball
+* Make ISCE3 an optional dependency in `s1_azimuth_timing.py`
 
 ## [0.4.5]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,34 @@ If you get stuck at any point you can create an [issue on GitHub](https://github
 For more information on contributing to open source projects, [GitHub's own guide](https://guides.github.com/activities/contributing-to-open-source/)
 is a great starting point if you are new to version control.
 
+## Optional Dependencies
+
+In order to better support the NISAR SDS (see: [#533](https://github.com/dbekaert/RAiDER/issues/533)), RAiDER has some optional dependencies:
+
+* ISCE3
+* Pandas
+* Rasterio
+* Progressbar
+
+RAiDER distributes two conda packages, `raider-base` a lighter-weight package that does depend on the optional dependencies, and `raider` which includes all dependencies. When using, or adding new, optional dependenices in RAiDER, please follow this pattern:
+1. When you import the optional dependency, handle import errors like:
+   ```python
+   try:
+    import optional_dependency
+   except ImportError:
+    optional_dependency = None
+   ```
+   Note: you *do not* need to delay imports until use with this pattern.
+2. At the top of any function/method that uses the optional dependency, throw if it's missing like:
+   ```python
+   if optional_dependency is None:
+       raise ImportError('optional_dependency is required for this function. Use conda to install optional_dependency')
+   ```
+3. If you want to add type hints for objects in the optional_dependency, use a forward declaration like:
+   ```python
+   def function_that_uses_optional_dependency(obj: 'optional_dependency.obj'):
+   ```
+   Note: the typehint is a string here.
 
 ## Git workflows ##
 

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -9,6 +9,7 @@
 import os
 import datetime
 import shelve
+from abc import ABC
 from typing import Union
 from pathlib import PosixPath
 
@@ -17,8 +18,10 @@ try:
     import xml.etree.ElementTree as ET
 except ImportError:
     ET = None
-
-from abc import ABC
+try:
+    import isce3.ext.isce3 as isce
+except ImportError:
+    isce = None
 
 from RAiDER.constants import _ZREF
 from RAiDER.utilFcns import (
@@ -178,8 +181,12 @@ class Raytracing(LOS):
     >>> from RAiDER.losreader import Raytracing
     >>> import numpy as np
     """
+
     def __init__(self, filename=None, los_convention='isce', time=None, look_dir = 'right', pad=600):
         '''read in and parse a statevector file'''
+        if isce is None:
+            raise ImportError(f'isce3 is required for this class. Use conda to install isce3`')
+
         super().__init__()
         self._ray_trace = True
         self._file = filename
@@ -191,7 +198,6 @@ class Raytracing(LOS):
             raise NotImplementedError()
 
         # ISCE3 data structures
-        import isce3.ext.isce3 as isce
         if self._time is not None:
             # __call__ called in checkArgs; keep for modularity
             self._orbit = get_orbit(self._file, self._time, pad=pad)
@@ -231,13 +237,14 @@ class Raytracing(LOS):
         '''
         Calculate look vectors for raytracing
         '''
+        if isce is None:
+            raise ImportError(f'isce3 is required for this method. Use conda to install isce3`')
+
         # TODO - Modify when isce3 vectorization is available
         los = np.full(yy.shape + (3,), np.nan)
         llh = llh.copy()
         llh[0] = np.deg2rad(llh[0])
         llh[1] = np.deg2rad(llh[1])
-
-        import isce3.ext.isce3 as isce
 
         for ii in range(yy.shape[0]):
             for jj in range(yy.shape[1]):
@@ -598,6 +605,9 @@ def state_to_los(svs, llh_targets):
     >>> svs = losr.read_ESA_Orbit_file(esa_orbit_file)
     >>> LOS = losr.state_to_los(*svs, [lats, lons, heights], xyz)
     '''
+    if isce is None:
+        raise ImportError(f'isce3 is required for this function. Use conda to install isce3`')
+
     # check the inputs
     if np.min(svs.shape) < 4:
         raise RuntimeError(
@@ -606,7 +616,6 @@ def state_to_los(svs, llh_targets):
         )
 
     # Convert svs to isce3 orbit
-    import isce3.ext.isce3 as isce
     orb = isce.core.Orbit([
         isce.core.StateVector(
             isce.core.DateTime(row[0]),
@@ -660,6 +669,8 @@ def get_radar_pos(llh, orb):
     los: ndarray  - Satellite incidence angle
     sr:  ndarray  - Slant range in meters
     '''
+    if isce is None:
+        raise ImportError(f'isce3 is required for this function. Use conda to install isce3`')
 
     num_iteration = 30
     residual_threshold = 1.0e-7
@@ -670,7 +681,6 @@ def get_radar_pos(llh, orb):
     )
 
     # Get some isce3 constants for this inversion
-    import isce3.ext.isce3 as isce
     # TODO - Assuming right-looking for now
     elp = isce.core.Ellipsoid()
     dop = isce.core.LUT2d()
@@ -763,9 +773,10 @@ def get_orbit(orbit_file: Union[list, str],
                                  requested time (should be about 600 seconds)
 
     '''
-    # First load the state vectors into an isce orbit
-    import isce3.ext.isce3 as isce
+    if isce is None:
+        raise ImportError(f'isce3 is required for this function. Use conda to install isce3`')
 
+    # First load the state vectors into an isce orbit
     svs = np.stack(get_sv(orbit_file, ref_time, pad), axis=-1)
     sv_objs = []
     # format for ISCE

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -80,7 +80,7 @@ def get_slc_id_from_point_and_time(lon: float,
 def get_azimuth_time_grid(lon_mesh: np.ndarray,
                           lat_mesh: np.ndarray,
                           hgt_mesh:  np.ndarray,
-                          orb: isce.core.Orbit) -> np.ndarray:
+                          orb) -> np.ndarray:
     '''
     Source: https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/losreader.py#L601C1-L674C22
 

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -3,10 +3,14 @@ import warnings
 
 import asf_search as asf
 import hyp3lib.get_orb
-import isce3.ext.isce3 as isce
 import numpy as np
 import pandas as pd
 from shapely.geometry import Point
+
+try:
+    import isce3.ext.isce3 as isce
+except ImportError:
+    isce = None
 
 from .losreader import get_orbit as get_isce_orbit
 
@@ -84,6 +88,8 @@ def get_azimuth_time_grid(lon_mesh: np.ndarray,
 
     Technically, this is "sensor neutral" since it uses an orb object.
     '''
+    if isce is None:
+        raise ImportError(f'isce3 is required for {__name__}. Use conda to install isce3`')
 
     num_iteration = 100
     residual_threshold = 1.0e-7

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -80,7 +80,7 @@ def get_slc_id_from_point_and_time(lon: float,
 def get_azimuth_time_grid(lon_mesh: np.ndarray,
                           lat_mesh: np.ndarray,
                           hgt_mesh:  np.ndarray,
-                          orb) -> np.ndarray:
+                          orb: 'isce.core.Orbit') -> np.ndarray:
     '''
     Source: https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/losreader.py#L601C1-L674C22
 

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -89,7 +89,7 @@ def get_azimuth_time_grid(lon_mesh: np.ndarray,
     Technically, this is "sensor neutral" since it uses an orb object.
     '''
     if isce is None:
-        raise ImportError(f'isce3 is required for {__name__}. Use conda to install isce3`')
+        raise ImportError(f'isce3 is required for this function. Use conda to install isce3`')
 
     num_iteration = 100
     residual_threshold = 1.0e-7


### PR DESCRIPTION
Cleans up the ICSE3 imports across RAiDER and adds some information on handling optional imports in the contributing guide. 

Notably, following this pattern, you can still import at the top of the file and use typehints. Notably, if you forget the `if isce is None` block, you'll just get an `AtributeError` like:
```python
>>> isce = None
>>> isce.any()
AttributeError: 'NoneType' object has no attribute 'any'
```