### PR TITLE
Remove weather model classes from models.__init__

### DIFF
--- a/tools/RAiDER/models/__init__.py
+++ b/tools/RAiDER/models/__init__.py
@@ -1,7 +1,0 @@
-from .era5 import ERA5
-from .era5t import ERA5T
-from .gmao import GMAO
-from .hres import HRES
-from .hrrr import HRRR, HRRRAK
-
-__all__ = ['HRRR', 'HRRRAK', 'GMAO', 'ERA5', 'ERA5T', 'HRES']


### PR DESCRIPTION
Will need to access them via their sub-packages, like:

```python
from RAiDER.models.hres import HRES
```
instead of
```python
from RAiDER.models import HRES
```

fixes #608 