### PR TITLE
Restrict permissions on created netrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.7]
+### Fixed
+* [617](https://github.com/dbekaert/RAiDER/issues/617) - RAiDER created `.netrc` is too permissive
+
 ## [0.4.6]
 
 ### Added

--- a/tools/RAiDER/s1_orbits.py
+++ b/tools/RAiDER/s1_orbits.py
@@ -29,7 +29,7 @@ def ensure_orbit_credentials() -> Optional[int]:
 
     # netrc needs a netrc file; if missing create an empty one.
     if not netrc_file.exists():
-        netrc_file.touch()
+        netrc_file.touch(mode=0o600)
 
     netrc_credentials = netrc.netrc(netrc_file)
     if ESA_CDSE_HOST in netrc_credentials.hosts:


### PR DESCRIPTION
fixes #617 

In the ARIA-HyP3 pipeline, RAiDER is run via the [`calcDelaysGUNW`](https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/cli/raider.py#L451) entry point and credentials are injected into the RAiDER container via Environment variables.

Because orbit fetching is done when checking HRRR availability:
https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/cli/raider.py#L518

before the `prepFromGUNW.main` function is run:
https://github.com/dbekaert/RAiDER/blob/dev/tools/RAiDER/cli/raider.py#L548

The `ensure_orbit_credentials` function in `tools.RAiDER.s1_orbits` will initially create the `.netrc` file as it's not provided in the container but will have too broad of permissions.

This appropriately restricts the permissions of the `.netrc` file when it's initially created.