### PR TITLE
Fixes orbit downloader Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.4.7]
 ### Fixed
 * [617](https://github.com/dbekaert/RAiDER/issues/617) - RAiDER created `.netrc` is too permissive
+* [622](https://github.com/dbekaert/RAiDER/issues/617) - RAiDER's call to sentineleof needs to have missions and times have same length.
 
 ## [0.4.6]
 

--- a/test/test_s1_orbits.py
+++ b/test/test_s1_orbits.py
@@ -94,7 +94,7 @@ def test_get_orbits_from_slc_ids(mocker):
     assert orbit_files == [Path('foo.txt')]
     assert eof.download.download_eofs.call_count == 1
     eof.download.download_eofs.assert_called_with(
-        [ '20150621T120220', '20150621T120232'], ['S1A'], save_dir=str(Path.cwd())
+        [ '20150621T120220'], ['S1A'], save_dir=str(Path.cwd())
     )
 
     orbit_files = s1_orbits.get_orbits_from_slc_ids(
@@ -104,7 +104,7 @@ def test_get_orbits_from_slc_ids(mocker):
     assert orbit_files == [Path('bar.txt'), Path('fiz.txt')]
     assert eof.download.download_eofs.call_count == 2
     eof.download.download_eofs.assert_called_with(
-        ['20201115T162313', '20201115T162340', '20201203T162353', '20201203T162420'],
-        ['S1A', 'S1B'],
+        ['20201115T162313', '20201203T162353'],
+        ['S1B', 'S1A'],
         save_dir=str(Path.cwd())
     )

--- a/test/test_s1_orbits.py
+++ b/test/test_s1_orbits.py
@@ -94,7 +94,9 @@ def test_get_orbits_from_slc_ids(mocker):
     assert orbit_files == [Path('foo.txt')]
     assert eof.download.download_eofs.call_count == 1
     eof.download.download_eofs.assert_called_with(
-        [ '20150621T120220'], ['S1A'], save_dir=str(Path.cwd())
+        [ '20150621T120220', '20150621T120232'],
+        ['S1A'] * 2,
+        save_dir=str(Path.cwd())
     )
 
     orbit_files = s1_orbits.get_orbits_from_slc_ids(
@@ -104,7 +106,7 @@ def test_get_orbits_from_slc_ids(mocker):
     assert orbit_files == [Path('bar.txt'), Path('fiz.txt')]
     assert eof.download.download_eofs.call_count == 2
     eof.download.download_eofs.assert_called_with(
-        ['20201115T162313', '20201203T162353'],
-        ['S1B', 'S1A'],
+        ['20201115T162313', '20201203T162353', '20201115T162340', '20201203T162420'],
+        ['S1B', 'S1A'] * 2,
         save_dir=str(Path.cwd())
     )

--- a/tools/RAiDER/s1_orbits.py
+++ b/tools/RAiDER/s1_orbits.py
@@ -57,6 +57,8 @@ def get_orbits_from_slc_ids(slc_ids: List[str], directory=Path.cwd()) -> List[Pa
 
     missions = [slc_id[0:3] for slc_id in slc_ids]
     start_times = [re.split(r'_+', slc_id)[4] for slc_id in slc_ids]
-    orb_files = eof.download.download_eofs(start_times, missions, save_dir=str(directory))
+    stop_times = [re.split(r'_+', slc_id)[5] for slc_id in slc_ids]
+    
+    orb_files = eof.download.download_eofs(start_times + stop_times, missions * 2, save_dir=str(directory))
 
     return orb_files

--- a/tools/RAiDER/s1_orbits.py
+++ b/tools/RAiDER/s1_orbits.py
@@ -55,14 +55,8 @@ def get_orbits_from_slc_ids(slc_ids: List[str], directory=Path.cwd()) -> List[Pa
     """
     _ = ensure_orbit_credentials()
 
-    missions = {slc_id[0:3] for slc_id in slc_ids}
-    start_times = {re.split(r'_+', slc_id)[4] for slc_id in slc_ids}
-    stop_times = {re.split(r'_+', slc_id)[5] for slc_id in slc_ids}
-
-    orb_files = eof.download.download_eofs(
-        sorted(list(start_times | stop_times)),
-        sorted(list(missions)),
-        save_dir=str(directory)
-    )
+    missions = [slc_id[0:3] for slc_id in slc_ids]
+    start_times = [re.split(r'_+', slc_id)[4] for slc_id in slc_ids]
+    orb_files = eof.download.download_eofs(start_times, missions, save_dir=str(directory))
 
     return orb_files


### PR DESCRIPTION
Resolves #622. 

Changes `set` to `list` in orbit routine that takes SLC IDs and obtains relevant orbit files.