### PR TITLE
Allow calcDelaysGUNW to process HyP3 jobs independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Latest Changes
+### Added
+* A `--input-bucket-prefix` argument to `calcDelaysGUNW` which will allow RAiDER to process ARIA GUNW products under one prefix and upload the final products to another prefix provided by the `--bucket-prefix` argument.
 ### Fixed
 * [630](https://github.com/dbekaert/RAiDER/pull/630) - use correct model name so (hrrr-ak) in azimuth_timing_grid
 * [620](https://github.com/dbekaert/RAiDER/issues/620) - Fix MERRA-2 access because API was updated

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -510,7 +510,7 @@ def calcDelaysGUNW(iargs: list[str] = None) -> xr.Dataset:
     iargs = p.parse_args(iargs)
 
     if not iargs.input_bucket_prefix:
-        iargs.input_bucket_prefix = iargs.input_bucket_prefix
+        iargs.input_bucket_prefix = iargs.bucket_prefix
 
     if iargs.interpolate_time not in ['none', 'center_time', 'azimuth_time_grid']:
         raise ValueError('interpolate_time arg must be in [\'none\', \'center_time\', \'azimuth_time_grid\']')
@@ -547,7 +547,7 @@ def calcDelaysGUNW(iargs: list[str] = None) -> xr.Dataset:
             #       we include this within this portion of the control flow.
             print('Nothing to do because outside of weather model range')
             return
-        json_file_path = aws.get_s3_file(iargs.bucket, iargs.bucket_prefix, '.json')
+        json_file_path = aws.get_s3_file(iargs.bucket, iargs.input_bucket_prefix, '.json')
         json_data = json.load(open(json_file_path))
         json_data['metadata'].setdefault('weather_model', []).append(iargs.weather_model)
         json.dump(json_data, open(json_file_path, 'w'))

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -461,7 +461,15 @@ def calcDelaysGUNW(iargs: list[str] = None) -> xr.Dataset:
 
     p.add_argument(
         '--bucket-prefix', default='',
-        help='S3 bucket prefix containing ARIA GUNW NetCDF file. Will be ignored if the --file argument is provided.'
+        help='S3 bucket prefix which may contain an ARIA GUNW NetCDF file to calculate delays for and which the final '
+             'ARIA GUNW NetCDF file will be upload to. Will be ignored if the --file argument is provided.'
+    )
+
+    p.add_argument(
+        '--input-bucket-prefix',
+        help='S3 bucket prefix that contains an ARIA GUNW NetCDF file to calculate delays for. '
+             'If not provided, will look in --bucket-prefix for an ARIA GUNW NetCDF file. '
+             'Will be ignored if the --file argument is provided.'
     )
 
     p.add_argument(
@@ -501,6 +509,9 @@ def calcDelaysGUNW(iargs: list[str] = None) -> xr.Dataset:
 
     iargs = p.parse_args(iargs)
 
+    if not iargs.input_bucket_prefix:
+        iargs.input_bucket_prefix = iargs.input_bucket_prefix
+
     if iargs.interpolate_time not in ['none', 'center_time', 'azimuth_time_grid']:
         raise ValueError('interpolate_time arg must be in [\'none\', \'center_time\', \'azimuth_time_grid\']')
 
@@ -520,7 +531,7 @@ def calcDelaysGUNW(iargs: list[str] = None) -> xr.Dataset:
 
     if not iargs.file and iargs.bucket:
         # only use GUNW ID for checking if HRRR available
-        iargs.file = aws.get_s3_file(iargs.bucket, iargs.bucket_prefix, '.nc')
+        iargs.file = aws.get_s3_file(iargs.bucket, iargs.input_bucket_prefix, '.nc')
         if iargs.weather_model == 'HRRR' and (iargs.interpolate_time == 'azimuth_time_grid'):
             file_name_str = str(iargs.file)
             gunw_nc_name = file_name_str.split('/')[-1]


### PR DESCRIPTION
Right now, the calcDelaysGUNW workflow assumes that it's the second step in a multi-step INSAR_ISCE HyP3 job, so it only looks for GUNW files under the same prefix it will upload final products to.

However, if we want a RAiDER-only job that processes previous INSAR_ISCE jobs (that either failed on the RAiDER step or skipped the RAiDER step), we'll need to download products from the previous job's prefix and upload the final products to the current RAIDER's job prefix. 

This adds the option to take a different input prefix than the final output prefix. 

Supports ASFHyP3/hyp3#2192

--- 

Note: HyP3 jobs are all assigned a unique UUID as the Job ID, and we organize the HyP3 content bucket under a prefix, which *is* the job ID, so Job ID and prefix can be used interchangeably.
