### PR TITLE
Ensure orbit credentials for ASF as well as CDSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 * A `--input-bucket-prefix` argument to `calcDelaysGUNW` which will allow RAiDER to process ARIA GUNW products under one prefix and upload the final products to another prefix provided by the `--bucket-prefix` argument.
 ### Fixed
-* [631](https://github.com/dbekaert/RAiDER/issues/634) - download orbits from ASF before trying ESA
+* [634](https://github.com/dbekaert/RAiDER/issues/634) - ensure NASA Earthdata credentials for downloading orbits from ASF and download orbits from ASF before trying ESA
 * [630](https://github.com/dbekaert/RAiDER/pull/630) - use correct model name so (hrrr-ak) in azimuth_timing_grid
 * [620](https://github.com/dbekaert/RAiDER/issues/620) - Fix MERRA-2 access because API was updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 * A `--input-bucket-prefix` argument to `calcDelaysGUNW` which will allow RAiDER to process ARIA GUNW products under one prefix and upload the final products to another prefix provided by the `--bucket-prefix` argument.
 ### Fixed
-* [634](https://github.com/dbekaert/RAiDER/issues/634) - ensure NASA Earthdata credentials for downloading orbits from ASF and download orbits from ASF before trying ESA
+* [613](https://github.com/dbekaert/RAiDER/issues/613) - ensure NASA Earthdata credentials for downloading orbits from ASF
+* [634](https://github.com/dbekaert/RAiDER/issues/634) - download orbits from ASF before trying ESA
 * [630](https://github.com/dbekaert/RAiDER/pull/630) - use correct model name so (hrrr-ak) in azimuth_timing_grid
 * [620](https://github.com/dbekaert/RAiDER/issues/620) - Fix MERRA-2 access because API was updated
 

--- a/tools/RAiDER/aria/prepFromGUNW.py
+++ b/tools/RAiDER/aria/prepFromGUNW.py
@@ -8,7 +8,6 @@
 import os
 from datetime import datetime
 import numpy as np
-import eof.download
 import xarray as xr
 import rasterio
 import pandas as pd
@@ -23,7 +22,7 @@ from RAiDER.logger import logger
 from RAiDER.models import credentials
 from RAiDER.models.hrrr import HRRR_CONUS_COVERAGE_POLYGON, AK_GEO, check_hrrr_dataset_availability
 from RAiDER.s1_azimuth_timing import get_times_for_azimuth_interpolation
-from RAiDER.s1_orbits import ensure_orbit_credentials, download_eofs
+from RAiDER.s1_orbits import download_eofs
 
 ## cube spacing in degrees for each model
 DCT_POSTING = {'HRRR': 0.05, 'HRES': 0.10, 'GMAO': 0.10, 'ERA5': 0.10, 'ERA5T': 0.10, 'MERRA2': 0.1}
@@ -276,7 +275,6 @@ class GUNW:
         sat = slc.split('_')[0]
         dt  = datetime.strptime(f'{self.dates[0]}T{self.mid_time}', '%Y%m%dT%H:%M:%S')
 
-        ensure_orbit_credentials()
         path_orb = download_eofs([dt], [sat], str(orbit_dir))
 
         return [str(o) for o in path_orb]

--- a/tools/RAiDER/s1_orbits.py
+++ b/tools/RAiDER/s1_orbits.py
@@ -12,6 +12,7 @@ from RAiDER.logger import logger
 ESA_CDSE_HOST = 'dataspace.copernicus.eu'
 NASA_EDL_HOST = 'urs.earthdata.nasa.gov'
 
+
 def _netrc_path() -> Path:
     netrc_name = '_netrc' if system().lower() == 'windows' else '.netrc'
     return Path.home() / netrc_name

--- a/tools/RAiDER/s1_orbits.py
+++ b/tools/RAiDER/s1_orbits.py
@@ -3,13 +3,14 @@ import os
 import re
 from pathlib import Path
 from platform import system
-from typing import List, Optional, Tuple
-from RAiDER.logger import logger, logging
+from typing import List, Optional
 
+import eof.download
+from RAiDER.logger import logger
 
 
 ESA_CDSE_HOST = 'dataspace.copernicus.eu'
-
+NASA_EDL_HOST = 'urs.earthdata.nasa.gov'
 
 def _netrc_path() -> Path:
     netrc_name = '_netrc' if system().lower() == 'windows' else '.netrc'
@@ -17,11 +18,13 @@ def _netrc_path() -> Path:
 
 
 def ensure_orbit_credentials() -> Optional[int]:
-    """Ensure credentials exist for ESA's CDSE to download orbits
+    """Ensure credentials exist for ESA's CDSE and ASF's S1QC to download orbits
 
-    This method will prefer to use CDSE credentials from your `~/.netrc` file if they exist,
-    otherwise will look for ESA_USERNAME and ESA_PASSWORD environment variables and
-     update or create your `~/.netrc` file.
+    This method will prefer to use CDSE and NASA Earthdata credentials from your `~/.netrc` file if they exist,
+    otherwise will look for environment variables and update or create your `~/.netrc` file. The environment variables
+    used are:
+        CDSE: ESA_USERNAME, ESA_PASSWORD
+        S1QC: EARTHDATA_USERNAME, EARTHDATA_PASSWORD
 
      Returns `None` if the `~/.netrc` file did not need to be updated and the number of characters written if it did.
     """
@@ -32,17 +35,29 @@ def ensure_orbit_credentials() -> Optional[int]:
         netrc_file.touch(mode=0o600)
 
     netrc_credentials = netrc.netrc(netrc_file)
-    if ESA_CDSE_HOST in netrc_credentials.hosts:
+    if ESA_CDSE_HOST in netrc_credentials.hosts and NASA_EDL_HOST in netrc_credentials.hosts:
         return
 
-    username = os.environ.get('ESA_USERNAME')
-    password = os.environ.get('ESA_PASSWORD')
-    if username is None and password is None:
-        raise ValueError('Credentials are required for fetching orbit data from dataspace.copernicus.eu!\n'
-                         'Either add your credentials to ~/.netrc or set the ESA_USERNAME and ESA_PASSWORD '
-                         'environment variables.')
+    if ESA_CDSE_HOST not in netrc_credentials.hosts:
+        username = os.environ.get('ESA_USERNAME')
+        password = os.environ.get('ESA_PASSWORD')
+        if username is None or password is None:
+            raise ValueError('Credentials are required for fetching orbit data from dataspace.copernicus.eu!\n'
+                             'Either add your credentials to ~/.netrc or set the ESA_USERNAME and ESA_PASSWORD '
+                             'environment variables.')
 
-    netrc_credentials.hosts[ESA_CDSE_HOST] = (username, None, password)
+        netrc_credentials.hosts[ESA_CDSE_HOST] = (username, None, password)
+
+    if NASA_EDL_HOST not in netrc_credentials.hosts:
+        username = os.environ.get('EARTHDATA_USERNAME')
+        password = os.environ.get('EARTHDATA_PASSWORD')
+        if username is None or password is None:
+            raise ValueError(f'Credentials are required for fetching orbit data from s1qc.asf.alaska.edu!\n'
+                             'Either add your credentials to ~/.netrc or set the EARTHDATA_USERNAME and'
+                             ' EARTHDATA_PASSWORD environment variables.')
+
+        netrc_credentials.hosts[NASA_EDL_HOST] = (username, None, password)
+
     return netrc_file.write_text(str(netrc_credentials))
 
 
@@ -53,32 +68,32 @@ def get_orbits_from_slc_ids(slc_ids: List[str], directory=Path.cwd()) -> List[Pa
 
     Returns a list of orbit file paths
     """
-    _ = ensure_orbit_credentials()
-
     missions = [slc_id[0:3] for slc_id in slc_ids]
     start_times = [re.split(r'_+', slc_id)[4] for slc_id in slc_ids]
     stop_times = [re.split(r'_+', slc_id)[5] for slc_id in slc_ids]
+
     orb_files = download_eofs(start_times + stop_times, missions * 2, str(directory))
 
     return orb_files
 
 
-def download_eofs(dts:list, missions:list, save_dir:str):
-    """ Wrapper to first try downloading from ASF """
-    import eof.download
+def download_eofs(dts: list, missions: list, save_dir: str):
+    """Wrapper around sentineleof to first try downloading from ASF and fall back to CDSE"""
+    _ = ensure_orbit_credentials()
+
     orb_files = []
     for dt, mission in zip(dts, missions):
         dt = dt if isinstance(dt, list) else [dt]
         mission = mission if isinstance(mission, list) else [mission]
+
         try:
             orb_file = eof.download.download_eofs(dt, mission, save_dir=save_dir, force_asf=True)
-            orb_file = orb_file[0] if isinstance(orb_file, list) else orb_file
-            orb_files.append(orb_file)
         except:
             logger.error(f'Could not download orbit from ASF, trying ESA...')
             orb_file = eof.download.download_eofs(dt, mission, save_dir=save_dir, force_asf=False)
-            orb_file = orb_file[0] if isinstance(orb_file, list) else orb_file
-            orb_files.append(orb_file)
+
+        orb_file = orb_file[0] if isinstance(orb_file, list) else orb_file
+        orb_files.append(orb_file)
 
     if not len(orb_files) == len(dts):
         raise Exception(f'Missing {len(dts) - len(orb_files)} orbit files! dts={dts}, orb_files={len(orb_files)}')


### PR DESCRIPTION
This fixes #613 by requiring credentials for _both_  NASA Earthdata and ESA CDSE. 

#613, however, does suggest we should only require one and warn if the other doesn't exist. I can switch to that easily if desired.