### PR TITLE
Add autopep8 GitHub Action

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,0 +1,34 @@
+name: Auto-format with autopep8
+
+on: 
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install autopep8
+      run: pip install autopep8
+
+    - name: Run autopep8
+      run: autopep8 --in-place --recursive .
+
+    - name: Check for uncommitted changes
+      run: |
+        if [[ $(git status --porcelain) ]]; then
+          echo "Uncommitted changes found. Please format your code with autopep8."
+          git --no-pager diff
+          exit 1
+        fi

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -23,7 +23,7 @@ jobs:
       run: pip install autopep8
 
     - name: Run autopep8
-      run: autopep8 --in-place --recursive .
+      run: autopep8 --in-place --recursive --ignore=E5 .
 
     - name: Check for uncommitted changes
       run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a GitHub Action workflow to automatically run `autopep8` on pull requests. The workflow is configured to format the codebase using `autopep8` and ensure that all new code adheres to our coding standards before merging. 

The workflow file `.github/workflows/autopep8.yml` has been created, which:
- Checks out the repository
- Sets up Python
- Installs `autopep8`
- Runs `autopep8` on the entire codebase
- Checks for any uncommitted changes after running `autopep8` and fails the workflow if changes are detected

## Motivation and Context
I saw that the project already encourages the manual use of `autopep8` before submitting pull requests. This change enforces code formatting consistency automatically by running the formatter for you. Automating this process reduces the likelihood of formatting issues slipping through code reviews and simplifies the development workflow.

---

By integrating this automated workflow, we can maintain a clean and consistent codebase more efficiently, allowing developers to focus more on functionality and less on formatting.


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] ~~I have written new tests for your core changes, as applicable.~~
- [ ] ~~I have successfully ran tests with your changes locally.~~
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
