### PR TITLE
Use sep instead of delim_whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+* [651](https://github.com/dbekaert/RAiDER/pull/651) Removed use of deprecated argument to `pandas.read_csv`.
+
 ## [0.5.1]
 ### Changed
 * Use hyp3-lib v3* to download orbits to be able to distribute load across ESA and ASF. Can be easily swapped out for `sentineleof` in future release.

--- a/test/test_gnss.py
+++ b/test/test_gnss.py
@@ -1,3 +1,13 @@
+from RAiDER.models.customExceptions import NoStationDataFoundError
+from RAiDER.gnss.downloadGNSSDelays import (
+    get_stats_by_llh, get_station_list, download_tropo_delays,
+    filterToBBox,
+)
+from RAiDER.gnss.processDelayFiles import (
+    addDateTimeToFiles,
+    getDateTime,
+    concatDelayFiles
+)
 import datetime
 import os
 import pytest
@@ -6,18 +16,6 @@ import pandas as pd
 
 from test import pushd, TEST_DIR
 SCENARIO2_DIR = os.path.join(TEST_DIR, "scenario_2")
-
-
-from RAiDER.gnss.processDelayFiles import (
-    addDateTimeToFiles,
-    getDateTime,
-    concatDelayFiles
-)
-from RAiDER.gnss.downloadGNSSDelays import (
-    get_stats_by_llh, get_station_list, download_tropo_delays, 
-    filterToBBox, 
-)
-from RAiDER.models.customExceptions import NoStationDataFoundError
 
 
 def file_len(fname):
@@ -107,26 +105,28 @@ def test_concatDelayFiles(tmp_path, temp_file):
         )
     assert file_len(out_name) == file_length
 
+
 def test_get_stats_by_llh2():
-    stations = get_stats_by_llh(llhBox=[10,18,360-93,360-88])
+    stations = get_stats_by_llh(llhBox=[10, 18, 360-93, 360-88])
     assert isinstance(stations, pd.DataFrame)
 
 
 def test_get_stats_by_llh3():
     with pytest.raises(ValueError):
-        get_stats_by_llh(llhBox=[10,18,-93,-88])
-
+        get_stats_by_llh(llhBox=[10, 18, -93, -88])
 
 
 def test_get_station_list():
-    stations, output_file = get_station_list(stationFile=os.path.join(SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
-    assert isinstance(stations,list)
-    assert isinstance(output_file,pd.DataFrame)
+    stations, output_file = get_station_list(stationFile=os.path.join(
+        SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
+    assert isinstance(stations, list)
+    assert isinstance(output_file, pd.DataFrame)
 
 
 def test_download_tropo_delays1():
     with pytest.raises(NotImplementedError):
-        download_tropo_delays(stats=['GUAT', 'SLAC', 'CRSE'], years=[2022], gps_repo='dummy_repo')
+        download_tropo_delays(stats=['GUAT', 'SLAC', 'CRSE'], years=[
+                              2022], gps_repo='dummy_repo')
 
 
 def test_download_tropo_delays2():
@@ -135,7 +135,8 @@ def test_download_tropo_delays2():
 
 
 def test_download_tropo_delays2(tmp_path):
-    stations, output_file = get_station_list(stationFile=os.path.join(SCENARIO2_DIR, 'stations.csv'))
+    stations, output_file = get_station_list(
+        stationFile=os.path.join(SCENARIO2_DIR, 'stations.csv'))
 
     # spot check a couple of stations
     assert 'CAPE' in stations
@@ -148,15 +149,17 @@ def test_download_tropo_delays2(tmp_path):
 
 
 def test_filterByBBox1():
-    _, station_data = get_station_list(stationFile=os.path.join(SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
+    _, station_data = get_station_list(stationFile=os.path.join(
+        SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
     with pytest.raises(ValueError):
-        filterToBBox(station_data, llhBox=[34,38,-120,-115])
+        filterToBBox(station_data, llhBox=[34, 38, -120, -115])
 
 
 def test_filterByBBox2():
-    _, station_data = get_station_list(stationFile=os.path.join(SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
-    new_data = filterToBBox(station_data, llhBox=[34,38,240,245])
-    for stat in ['CAPE','MHMS','NVCO']:
+    _, station_data = get_station_list(stationFile=os.path.join(
+        SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
+    new_data = filterToBBox(station_data, llhBox=[34, 38, 240, 245])
+    for stat in ['CAPE', 'MHMS', 'NVCO']:
         assert stat not in new_data['ID'].to_list()
     for stat in ['FGNW', 'JPLT', 'NVTP', 'WLHG', 'WORG']:
         assert stat in new_data['ID'].to_list()

--- a/tools/RAiDER/cli/__main__.py
+++ b/tools/RAiDER/cli/__main__.py
@@ -5,37 +5,42 @@ from importlib.metadata import entry_points
 
 import RAiDER.cli.conf as conf
 
+
 def main():
     parser = argparse.ArgumentParser(
         prefix_chars='+',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
-        '++process', choices=['calcDelays', 'downloadGNSS', 'calcDelaysGUNW'],
-                     default='calcDelays',
-                     help='Select the entrypoint to use'
+        '++process',
+        choices=['calcDelays', 'downloadGNSS', 'calcDelaysGUNW'],
+        default='calcDelays',
+        help='Select the entrypoint to use'
     )
     parser.add_argument(
-        '++logger_path', 
-        required = False,
-        default = None,
+        '++logger_path',
+        required=False,
+        default=None,
         help='Set the path to write the log files',
     )
 
     args, unknowns = parser.parse_known_args()
-    
+
     # Needed for a global logging path
     conf.setLoggerPath(args.logger_path)
-    
-    sys.argv = [args.process, *unknowns]    
+
+    sys.argv = [args.process, *unknowns]
 
     try:
         # python >=3.10 interface
-        (process_entry_point,) = entry_points(group='console_scripts', name=f'{args.process}.py')
+        (process_entry_point,) = entry_points(
+            group='console_scripts', name=f'{args.process}.py')
     except TypeError:
         # python 3.8 and 3.9 interface
         scripts = entry_points()['console_scripts']
-        process_entry_point = [ep for ep in scripts if ep.name == f'{args.process}.py'][0]
+        process_entry_point = [
+            ep for ep in scripts if ep.name == f'{args.process}.py'
+        ][0]
 
     process_entry_point.load()()
 

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -74,7 +74,7 @@ def get_stats_by_llh(llhBox=None, baseURL=_UNR_URL):
 
     stations = pd.read_csv(
         stationHoldings,
-        delim_whitespace=True,
+        sep='\s+',
         names=['ID', 'Lat', 'Lon', 'Hgt_m']
     )
     stations = filterToBBox(stations, llhBox)

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -74,7 +74,7 @@ def get_stats_by_llh(llhBox=None, baseURL=_UNR_URL):
 
     stations = pd.read_csv(
         stationHoldings,
-        sep='\s+',
+        sep=r'\s+',
         names=['ID', 'Lat', 'Lon', 'Hgt_m']
     )
     stations = filterToBBox(stations, llhBox)

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -19,25 +19,24 @@ from RAiDER.models.customExceptions import NoStationDataFoundError
 _UNR_URL = "http://geodesy.unr.edu/"
 
 
-
 def get_station_list(
-        bbox=None, 
-        stationFile=None, 
-        userstatList=None, 
-        writeStationFile=True,
-        writeLoc=None, 
-        name_appendix=''
-    ):
+    bbox=None,
+    stationFile=None,
+    userstatList=None,
+    writeStationFile=True,
+    writeLoc=None,
+    name_appendix=''
+):
     '''
     Creates a list of stations inside a lat/lon bounding box from a source
-    
+
     Args:
         bbox: list of float - length-4 list of floats that describes a bounding box. 
                                 Format is S N W E
         writeLoc: string    - Directory to write data
         userstatList: list  - list of specific IDs to access
         name_appendix: str  - name to append to output file
-    
+
     Returns:
         stations: list of strings   - station IDs to access
         output_file: string         - file to write delays
@@ -51,7 +50,8 @@ def get_station_list(
 
     # write to file and pass final stations list
     if writeStationFile:
-        output_file = os.path.join(writeLoc or os.getcwd(), 'gnssStationList_overbbox' + name_appendix + '.csv')
+        output_file = os.path.join(writeLoc or os.getcwd(
+        ), 'gnssStationList_overbbox' + name_appendix + '.csv')
         station_data.to_csv(output_file, index=False)
 
     return list(station_data['ID'].values), [output_file if writeStationFile else station_data][0]
@@ -64,20 +64,22 @@ def get_stats_by_llh(llhBox=None, baseURL=_UNR_URL):
     '''
     if llhBox is None:
         llhBox = [-90, 90, 0, 360]
-    S,N,W,E = llhBox
+    S, N, W, E = llhBox
     if (W < 0) or (E < 0):
-        raise ValueError('get_stats_by_llh: bounding box must use 0 < lon < 360')
+        raise ValueError(
+            'get_stats_by_llh: bounding box must be on lon range [0, 360]')
 
     stationHoldings = '{}NGLStationPages/llh.out'.format(baseURL)
     # it's a file like object and works just like a file
 
     stations = pd.read_csv(
-        stationHoldings, 
-        delim_whitespace=True, 
+        stationHoldings,
+        delim_whitespace=True,
         names=['ID', 'Lat', 'Lon', 'Hgt_m']
     )
     stations = filterToBBox(stations, llhBox)
-    stations['Lon'] = ((stations['Lon'].values + 180) % 360) - 180 # convert lons to -180 - 180
+    # convert lons from [0, 360] to [-180, 180]
+    stations['Lon'] = ((stations['Lon'].values + 180) % 360) - 180
 
     stations = filterToBBox(stations, llhBox)
 
@@ -85,12 +87,12 @@ def get_stats_by_llh(llhBox=None, baseURL=_UNR_URL):
 
 
 def download_tropo_delays(
-        stats, years, 
-        gps_repo='UNR', 
-        writeDir='.', 
-        numCPUs=8, 
-        download=False,
-    ):
+    stats, years,
+    gps_repo='UNR',
+    writeDir='.',
+    numCPUs=8,
+    download=False,
+):
     '''
     Check for and download GNSS tropospheric delays from an archive. If 
     download is True then files will be physically downloaded, but this  
@@ -128,13 +130,16 @@ def download_tropo_delays(
                 if fileurl['path']
             ]
         else:
-            raise NotImplementedError('download_tropo_delays: gps_repo "{}" not yet implemented'.format(gps_repo))
+            raise NotImplementedError(
+                'download_tropo_delays: gps_repo "{}" not yet implemented'.format(gps_repo))
 
     # Write results to file
-    if len(results)==0:
-        raise NoStationDataFoundError(station_list=stats['ID'].to_list(), years=years)
+    if len(results) == 0:
+        raise NoStationDataFoundError(
+            station_list=stats['ID'].to_list(), years=years)
     statDF = pd.DataFrame(results).set_index('ID')
-    statDF.to_csv(os.path.join(writeDir, '{}gnssStationList_overbbox_withpaths.csv'.format(gps_repo)))
+    statDF.to_csv(os.path.join(
+        writeDir, '{}gnssStationList_overbbox_withpaths.csv'.format(gps_repo)))
 
 
 def download_UNR(statID, year, writeDir='.', download=False, baseURL=_UNR_URL):
@@ -205,7 +210,7 @@ def in_box(lat, lon, llhbox):
 
 def fix_lons(lon):
     """
-    Fix the given longitudes into the range ``[-180, 180]``.
+    Fix the given longitudes into the range `[-180, 180]`.
     """
     fixed_lon = ((lon + 180) % 360) - 180
     # Make the positive 180s positive again.
@@ -227,19 +232,19 @@ def main(inps=None):
     Main workflow for querying supported GPS repositories for zenith delay information.
     """
     try:
-        dateList     = inps.date_list
-        returnTime   = inps.time
+        dateList = inps.date_list
+        returnTime = inps.time
     except:
-        dateList     = inps.dateList
-        returnTime   = inps.returnTime
+        dateList = inps.dateList
+        returnTime = inps.returnTime
 
     station_file = inps.station_file
     bounding_box = inps.bounding_box
-    gps_repo     = inps.gps_repo
-    out          = inps.out
-    download     = inps.download
-    cpus         = inps.cpus
-    verbose      = inps.verbose
+    gps_repo = inps.gps_repo
+    out = inps.out
+    download = inps.download
+    cpus = inps.cpus
+    verbose = inps.verbose
 
     if verbose:
         logger.setLevel(logging.DEBUG)
@@ -278,7 +283,8 @@ def main(inps=None):
     # Extract delays for each station
     dateList = [k.strftime('%Y-%m-%d') for k in dateList]
     get_station_data(
-        os.path.join(out, '{}gnssStationList_overbbox_withpaths.csv'.format(gps_repo)),
+        os.path.join(
+            out, '{}gnssStationList_overbbox_withpaths.csv'.format(gps_repo)),
         dateList,
         gps_repo=gps_repo,
         numCPUs=cpus,
@@ -303,7 +309,8 @@ def parse_bbox(bounding_box):
         bbox = bounding_box
 
     else:
-        raise Exception('Passing a file with a bounding box not yet supported.')
+        raise Exception(
+            'Passing a file with a bounding box not yet supported.')
 
     long_cross_zero = 1 if bbox[2] * bbox[3] < 0 else 0
 
@@ -313,7 +320,7 @@ def parse_bbox(bounding_box):
 
     if bbox[3] < 0:
         bbox[3] += 360
-    
+
     return bbox, long_cross_zero
 
 
@@ -326,8 +333,10 @@ def get_stats(bbox, long_cross_zero, out, station_file):
         bbox2 = bbox.copy()
         bbox1[3] = 360.0
         bbox2[2] = 0.0
-        stats1, origstatsFile1 = get_station_list(bbox=bbox1, writeLoc=out, stationFile=station_file, name_appendix='_a')
-        stats2, origstatsFile2 = get_station_list(bbox=bbox2, writeLoc=out, stationFile=station_file, name_appendix='_b')
+        stats1, origstatsFile1 = get_station_list(
+            bbox=bbox1, writeLoc=out, stationFile=station_file, name_appendix='_a')
+        stats2, origstatsFile2 = get_station_list(
+            bbox=bbox2, writeLoc=out, stationFile=station_file, name_appendix='_b')
         stats = stats1 + stats2
         origstatsFile = origstatsFile1[:-6] + '.csv'
         file_a = pd.read_csv(origstatsFile1)
@@ -339,28 +348,28 @@ def get_stats(bbox, long_cross_zero, out, station_file):
         if bbox[3] < bbox[2]:
             bbox[3] = 360.0
         stats, origstatsFile = get_station_list(
-            bbox=bbox, 
-            writeLoc=out, 
+            bbox=bbox,
+            writeLoc=out,
             stationFile=station_file
         )
-    
+
     return stats
 
 
 def filterToBBox(stations, llhBox):
     '''
     Filter a dataframe by lat/lon.
-    *NOTE: llhBox longitude format should be 0-360
-    
+    *NOTE: llhBox longitude format should be [0, 360]
+
     Args:
         stations: DataFrame     - a pandas dataframe with "Lat" and "Lon" columns
         llhBox: list of float   - 4-element list: [S, N, W, E]
-    
+
     Returns:
         a Pandas Dataframe with stations removed that are not inside llhBox
     '''
-    S,N,W,E = llhBox
-    if (W<0) or (E<0):
+    S, N, W, E = llhBox
+    if (W < 0) or (E < 0):
         raise ValueError('llhBox longitude format should 0-360')
 
     # For a user-provided file, need to check the column names
@@ -368,19 +377,20 @@ def filterToBBox(stations, llhBox):
     lat_keys = ['lat', 'latitude', 'Lat', 'Latitude']
     lon_keys = ['lon', 'longitude', 'Lon', 'Longitude']
     index = None
-    for k,key in enumerate(lat_keys):
+    for k, key in enumerate(lat_keys):
         if key in list(keys):
             index = k
             break
     if index is None:
-        raise KeyError('filterToBBox: No valid column names found for latitude and longitude')
+        raise KeyError(
+            'filterToBBox: No valid column names found for latitude and longitude')
     lon_key = lon_keys[k]
     lat_key = lat_keys[k]
 
     if stations[lon_key].min() < 0:
         # convert lon format to -180 to 180
-        W,E = [((D+ 180) % 360) - 180 for D in [W,E]]
-        
-    mask = (stations[lat_key] > S) & (stations[lat_key] < N) & (stations[lon_key] < E) & (stations[lon_key] > W)
-    return stations[mask]
+        W, E = [((D + 180) % 360) - 180 for D in [W, E]]
 
+    mask = (stations[lat_key] > S) & (stations[lat_key] < N) & (
+        stations[lon_key] < E) & (stations[lon_key] > W)
+    return stations[mask]

--- a/tools/RAiDER/processWM.py
+++ b/tools/RAiDER/processWM.py
@@ -30,7 +30,7 @@ def prepareWeatherModel(
     Args:
         weather_model: WeatherModel   - instantiated weather model object
         time: datetime                - Python datetime to request. Will be rounded to nearest available time
-        ll_bounds: list/array        - SNWE bounds target area to ensure weather model contains them
+        ll_bounds: list/array         - SNWE bounds target area to ensure weather model contains them
         download_only: bool           - False if preprocessing weather model data
         makePlots: bool               - whether to write debug plots
         force_download: bool          - True if you want to download even when the weather model exists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`delim_whitespace` is to be deprecated in `pandas.read_csv`. Fortunately they provide a drop-in replacement for its functionality: providing a RegEx for whitespace to the `sep` argument. This change does that in the one place in the repo where `delim_whitespace` is used.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #643.

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
This change modifies `RAiDER.gnss.downloadGNSSDelays.get_stats_by_llh`. Tests `test_gnss.test_get_stats_by_llh2`and `test_gnss.test_get_stats_by_llh3` already test this function and they pass under this change.

<!--- Please describe how you tested your changes. -->


<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] ~~I have written new tests for your core changes, as applicable.~~
- [x] I have successfully ran tests with your changes locally.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
