### PR TITLE
Secrets no longer needed for changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,5 +14,3 @@ on:
 jobs:
   call-changelog-check-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.2
-    secrets:
-      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With the upgrade to ASFHyP3/action v0.11.1+ (#654), the changelog check action no longer needs to be provided secrets and doesn't depend on `Zomzog/changelog-checker`. 

With this change, it should be working again and fork safe.

Fixes #653 