### PR TITLE
Update dem-stitcher for new geoid url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [657](https://github.com/dbekaert/RAiDER/pull/657) - Fixed a few typos in `README.md`.
 * [651](https://github.com/dbekaert/RAiDER/pull/651) - Removed use of deprecated argument to `pandas.read_csv`.
 * [627](https://github.com/dbekaert/RAiDER/pull/627) - Made Python datetimes timezone-aware and add unit tests and bug fixes.
-* Ensures dem-stitcher to be >= v2.5.6, which updates the url for reading the Geoid EGM 2008.
+* [662](https://github.com/dbekaert/RAiDER/pull/662) - Ensures dem-stitcher to be >= v2.5.6, which updates the url for reading the Geoid EGM 2008.
 
 ## [0.5.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [657](https://github.com/dbekaert/RAiDER/pull/657) - Fixed a few typos in `README.md`.
 * [651](https://github.com/dbekaert/RAiDER/pull/651) - Removed use of deprecated argument to `pandas.read_csv`.
 * [627](https://github.com/dbekaert/RAiDER/pull/627) - Made Python datetimes timezone-aware and add unit tests and bug fixes.
+* Ensures dem-stitcher to be >= v2.5.6, which updates the url for reading the Geoid EGM 2008.
 
 ## [0.5.1]
 ### Changed

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
  - cdsapi
  - cfgrib
  - dask
- - dem_stitcher>=2.3.1
+ - dem_stitcher>=2.5.6
  - ecmwf-api-client
  - h5netcdf
  - h5py


### PR DESCRIPTION
* Ensures dem-stitcher to be >= v2.5.6, which updates the url for reading the Geoid EGM 2008.