### PR TITLE
exit successfully with no changes when run via hyp3 with weather_model=HRRR and outside HRRR coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [701](https://github.com/dbekaert/RAiDER/pull/701) - Fixed a few path typos and handle some edge cases, add unit tests, lint project
 * [672](https://github.com/dbekaert/RAiDER/pull/672) - Linted the project with `ruff`.
 * [683](https://github.com/dbekaert/RAiDER/pull/683) - Fixed a naive datetime and added default template to template generation argument
+* `prepFromGunw.check_weather_model_availability` now returns `False` for HRRR when outside the CONUS or AK coverage areas, rather than raising `ValueError`.
+  As a result, HRRR jobs run via HyP3 for GUNWs outside HRRR coverage will exit successfully without making any changes to the GUNW. 
 
 ### Fixed
 * [700](https://github.com/dbekaert/RAiDER/pull/700) - Fixed a few path typos and handle some edge cases

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,6 +37,8 @@ def test_gunw_path_factory() -> Callable:
             file_name = 'S1-GUNW-D-R-071-tops-20200130_20200124-135156-34956N_32979N-PP-913f-v2_0_4.nc'
         elif location == 'alaska':
             file_name = 'S1-GUNW-D-R-059-tops-20230320_20220418-180300-00179W_00051N-PP-c92e-v2_0_6.nc'
+        elif location == 'philippines':
+            file_name = 'S1-GUNW-D-R-032-tops-20200220_20200214-214625-00120E_00014N-PP-b785-v3_0_1.nc'
         else:
             raise NotImplementedError
         return TEST_DIR / 'gunw_test_data' / file_name

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -364,6 +364,12 @@ def test_check_weather_model_availability_over_alaska(test_gunw_path_factory, we
     assert cond
 
 
+def test_check_hrrr_availability_outside_united_states(test_gunw_path_factory):
+    # S1-GUNW-D-R-032-tops-20200220_20200214-214625-00120E_00014N-PP-b785-v3_0_1.nc
+    test_gunw_path = test_gunw_path_factory(location='philippines')
+    assert not check_weather_model_availability(test_gunw_path, 'HRRR')
+
+
 @pytest.mark.parametrize('weather_model_name', ['ERA5', 'GMAO', 'MERRA2', 'HRRR'])
 def test_check_weather_model_availability_2(weather_model_name):
     gunw_id = Path("test/gunw_test_data/S1-GUNW-D-R-059-tops-20230320_20220418-180300-00179W_00051N-PP-c92e-v2_0_6.nc")

--- a/tools/RAiDER/aria/prepFromGUNW.py
+++ b/tools/RAiDER/aria/prepFromGUNW.py
@@ -110,14 +110,13 @@ def check_weather_model_availability(gunw_path: Path, weather_model_name: str) -
     Returns:
     -------
     bool:
-        True if both reference and secondary acquisitions are within the valid range. We assume that
-        reference_date > secondary_date (i.e. reference scenes are most recent)
+        True if both reference and secondary acquisitions are within the valid temporal and spatial ranges for the given
+        weather model. We assume that reference_date > secondary_date (i.e. reference scenes are most recent)
 
     Raises:
     ------
     ValueError
         - If weather model is not correctly referencing the Class from RAiDER.models
-        - HRRR was requested and it's not in the HRRR CONUS or HRRR AK coverage area
     """
     ref_slc_ids = get_slc_ids_from_gunw(gunw_path, reference_or_secondary='reference')
     sec_slc_ids = get_slc_ids_from_gunw(gunw_path, reference_or_secondary='secondary')
@@ -134,7 +133,7 @@ def check_weather_model_availability(gunw_path: Path, weather_model_name: str) -
         elif AK_GEO.intersects(gunw_poly):
             weather_model_name = 'HRRRAK'
         else:
-            raise ValueError('HRRR was requested but it is not available in this area')
+            return False
 
     # source: https://stackoverflow.com/a/7668273
     # Allows us to get weather models as strings


### PR DESCRIPTION
Pivoting to a shorter-term change than https://github.com/dbekaert/RAiDER/pull/695 , I believe this is sufficient to let ASF provide standard ARIA_S1_GUNW products on demand via HyP3. Standard Jobs will always be submitted with weather_model=HRRR. Jobs within HRRR coverage will have the data layers added. Jobs outside HRRR temporal or spatial coverage will exit successfully without making any changes to the GUNW file.

Expanding the logic for a weather model for a standard product in the future, say to add the use of additional weather models, would require more in-depth changes such as those in #695.