### PR TITLE
Increase CicleCI's No Output Timeout for conda environment creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
 
       - run:
           name: Create RAiDER environment
+          no_output_timeout: 30m
           shell: /bin/bash -xl
           command: |
             source "${HOME}/conda/etc/profile.d/conda.sh"


### PR DESCRIPTION
In previous runs of CircleCI, we've seen tests fail due to hitting the default 10-minute no-output timeout for the RAiDER environment creation step.

Looking at successful runs, they've typically taken between 9 minutes 0 seconds and 9 minutes 55 seconds -- right at the edge of the timeout.

This PR increases the timeout to 30 minutes for the environment creation step, so we shouldn't hit this again.