### PR TITLE
Update raiderCombine and fix coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             mamba activate RAiDER
 
             COV_OPTIONS=`python -c "import importlib;print(*(' --cov='+p for p in importlib.util.find_spec('RAiDER').submodule_search_locations))"`
-            pytest -m "not long" test/ ${COV_OPTIONS} --cov-report=
+            coverage run -m pytest -m "not long" test/ ${COV_OPTIONS} --cov-report=
 
       - run:
           name: Report coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,13 @@ jobs:
               mamba activate RAiDER
 
               python -m pip install coveralls
+              pwd
+              ls -l tools/RAiDER/
               python .circleci/fix_coverage_paths.py .coverage ${PWD}/tools/RAiDER/
-              coverage report -mi
-              coveralls
+              coverage report -mi --show-missing --data-file=.coverage
+              ls -l .coverage # Add this line
+              cat .coverage # Add this line (to see its contents)
+              coveralls --verbose
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,8 @@ jobs:
               mamba activate RAiDER
 
               python -m pip install coveralls
-              pwd
-              ls -l tools/RAiDER/
               python .circleci/fix_coverage_paths.py .coverage ${PWD}/tools/RAiDER/
               coverage report -mi --show-missing --data-file=.coverage
-              ls -l .coverage # Add this line
-              cat .coverage # Add this line (to see its contents)
               coveralls --verbose
             fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Updates
+* [715](https://github.com/dbekaert/RAiDER/pull/715) - Fixed the coverage test Github action and a timing issue with raiderCombine
+
 ## [0.5.4]
 ### Changed
 * [701](https://github.com/dbekaert/RAiDER/pull/701) - Fixed a few path typos and handle some edge cases, add unit tests, lint project

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -691,6 +691,14 @@ def combineZTDFiles() -> None:
 
     p = create_parser()
     args: RAiDERCombineArgs = p.parse_args(namespace=RAiDERCombineArgs())
+    if args.verbose:
+        print(f"RAiDER file: {args.raider_file}")
+        print(f"GNSS folder: {args.gnss_folder}")
+        print(f"GNSS file: {args.gnss_file}")
+        print(f"Column name: {args.column_name}")
+        print(f"Raider column name: {args.raider_column_name}")
+        print(f"Output name: {args.out_name}")
+        print(f"Local time: {args.local_time}")
 
     if not args.raider_file.exists():
         combineDelayFiles(args.raider_file, loc=args.raider_folder)

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -258,7 +258,7 @@ def create_parser() -> argparse.ArgumentParser:
             delay files.
             """),
         required=True,
-        type=lambda s: file_choices(p, ('csv',), s),
+        type=lambda s: file_choices(p, ('csv','.csv'), s),
     )
     p.add_argument(
         '--raiderDir',
@@ -292,7 +292,7 @@ def create_parser() -> argparse.ArgumentParser:
             Optional .csv file containing GPS Zenith Delays. Should contain columns "ID", "ZTD", and "Datetime"
             """),
         default=None,
-        type=lambda s: file_choices(p, ('csv',), s),
+        type=lambda s: file_choices(p, ('csv','.csv'), s),
     )
 
     p.add_argument(

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -9,6 +9,8 @@ from typing import Optional
 import pandas as pd
 from tqdm import tqdm
 
+from RAiDER.cli.parser import add_verbose
+
 
 pd.options.mode.chained_assignment = None  # default='warn'
 
@@ -338,6 +340,7 @@ def create_parser() -> argparse.ArgumentParser:
             """),
         default=None,
     )
+    add_verbose(p)
 
     return p
 
@@ -356,9 +359,27 @@ def main(
     # drop extra columns
     expected_data_columns = ['ID', 'Lat', 'Lon', 'Hgt_m', 'Datetime', 'wetDelay', 'hydroDelay', raider_delay]
     dfr = dfr.drop(columns=[col for col in dfr if col not in expected_data_columns])
+
+    # Round raider datetime to the nearest 5 min to match GNSS data
+    dfr['Datetime'] = dfr['Datetime'].apply(
+        lambda x: x - dt.timedelta(minutes=x.minute % 5, seconds=x.second, microseconds=x.microsecond)
+    )
+
     dfz = pd.read_csv(ztd_file, parse_dates=['Date'])
+
+    # Handle datetime conversion for the GNSS files that use time in seconds
     if 'Datetime' not in dfz.keys():
-        dfz.rename(columns={'Date': 'Datetime'}, inplace=True)
+        if "Date" in dfz.keys():
+            date = dfz['Date'].apply(lambda x: x.strftime('%Y-%m-%d'))
+            if 'times' in dfz.keys():
+                tm = dfz['times'].apply(lambda x: dt.timedelta(seconds=x))
+                dfz['Datetime'] = pd.to_datetime(date) + tm
+            else:
+                dfz['Datetime'] = pd.to_datetime(date)
+        else:
+            raise ValueError(
+                f'Datetime key not found in {ztd_file};\n please ensure that "Datetime" or "Date" plus "times" is included'
+            )
     # drop extra columns
     expected_data_columns = [
         'ID',
@@ -393,8 +414,8 @@ def main(
     dfr.drop_duplicates(inplace=True)
     dfz.drop_duplicates(inplace=True)
 
+    # merge the two dataframes
     print('Beginning merge')
-
     dfc = dfr.merge(
         dfz[common_keys + ['ZTD', 'sigZTD']], how='left', left_on=common_keys, right_on=common_keys, sort=True
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- `raiderCombine.py` was not working when the raider time was not an integer multiple of 5 minutes (the GNSS sample rate)
- coveralls (evidently???) changed its behavior at https://coveralls.io/builds/69674378. Now `coverage run -m pytest ...` seems to be required. 

## Description
<!--- Describe your changes in detail -->
- Coveralls was reporting zero % coverage (0/0). Changing the pytest line to include "coverage run -m pytest..." seems to have solved the issue and coverage is now back up. 
- raiderCombine was assuming that raider would have the same time as the GNSS delays; however, this is not the case with the new time interpolation that allows for any time to be returned. I added logic to round to the nearest 5 minutes (the GNSS sample rate) as well as fixed up the column naming logic

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Coveralls is back and at record coverage!!!

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
<!--- Please describe how you tested your changes. -->
<!--- For new functionality, describe added unit tests. -->
<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->
Unit tests are passing

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix [TO COVERALLS] (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
