### PR TITLE
statsplot call does not capture `user_title` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 * [715](https://github.com/dbekaert/RAiDER/pull/715) - Fixed the coverage test Github action and a timing issue with raiderCombine
+* [720](https://github.com/dbekaert/RAiDER/pull/720) - Bug-fix to properly pass expected `user_title` argument through raiderStats function.
 
 ## [0.5.4]
 ### Changed

--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -3422,6 +3422,7 @@ def stats_analyses(
 
 def main() -> None:
     inps = cmd_line_parse()
+    print('inps', inps)
 
     stats_analyses(
         inps.fname,
@@ -3436,6 +3437,7 @@ def main() -> None:
         inps.seasonalinterval,
         inps.obs_errlimit,
         inps.figdpi,
+        inps.user_title,
         inps.plot_fmt,
         inps.cbounds,
         inps.colorpercentile,
@@ -3466,5 +3468,5 @@ def main() -> None:
         inps.variogramplot,
         inps.binnedvariogram,
         inps.variogram_per_timeslice,
-        inps.variogram_errlimit,
+        inps.variogram_errlimit
     )

--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -3422,7 +3422,6 @@ def stats_analyses(
 
 def main() -> None:
     inps = cmd_line_parse()
-    print('inps', inps)
 
     stats_analyses(
         inps.fname,
@@ -3468,5 +3467,5 @@ def main() -> None:
         inps.variogramplot,
         inps.binnedvariogram,
         inps.variogram_per_timeslice,
-        inps.variogram_errlimit
+        inps.variogram_errlimit,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Expected argument `user_title` is not reflected in the `main` call of the `stats_analyses` function, but is expected when the function is defined. Thus, the program will crash without updating the `main` call accordingly

## How Has This Been Tested?
Could verify with this minimum working example:
raiderDownloadGNSS.py --date 20240201 20240228 1 -b '39.69881 41.81386 -75.28276 -72.18299' --returntime 00:00:00

raiderStats.py --file UNRcombinedGPS_ztd.csv --workdir maps --bounding_box '39.69881 41.81386 -75.28276 -72.18299' --timeinterval '2024-02-01 2024-02-28' --grid_heatmap --grid_delay_mean --grid_delay_stdev --grid_to_raster --cpus 6


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [X] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
