### PR TITLE
Fix bug mixing `station_delay_mean` and `station_delay_median`

### DIFF
--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -2904,7 +2904,7 @@ def stats_analyses(
     # Plot mean delay per station
     if station_delay_mean:
         logger.info('- Plot mean delay for each station.')
-        unique_points = df_stats.df.groupby(['Lon', 'Lat'])[col_name].median()
+        unique_points = df_stats.df.groupby(['Lon', 'Lat'])[col_name].mean()
         unique_points.dropna(how='any', inplace=True)
         df_stats(
             [
@@ -2920,7 +2920,7 @@ def stats_analyses(
     # Plot median delay per station
     if station_delay_median:
         logger.info('- Plot median delay for each station.')
-        unique_points = df_stats.df.groupby(['Lon', 'Lat'])[col_name].mean()
+        unique_points = df_stats.df.groupby(['Lon', 'Lat'])[col_name].median()
         unique_points.dropna(how='any', inplace=True)
         df_stats(
             [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `station_delay_mean` and `station_delay_median` functionality is flipped in `raiderStats.py`. This PR fixes it.

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
