### PR TITLE
Fix #740: Use mamba shell init instead of sourcing mamba.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,23 +15,20 @@ jobs:
           name: Install MiniForge
           shell: /bin/bash -l
           command: |
-            apt update --yes && apt-get upgrade --yes
-            apt install -y --no-install-recommends wget ca-certificates git
+            apt update --yes && apt upgrade --yes
+            apt install --yes --no-install-recommends wget ca-certificates git
 
             cd ${HOME}
             wget -O  Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
             bash Miniforge3.sh -b -p "${HOME}/conda"
             source "${HOME}/conda/etc/profile.d/conda.sh"
-            source "${HOME}/conda/etc/profile.d/mamba.sh"
+            mamba shell init
 
       - run:
           name: Create RAiDER environment
           no_output_timeout: 30m
           shell: /bin/bash -xl
           command: |
-            source "${HOME}/conda/etc/profile.d/conda.sh"
-            source "${HOME}/conda/etc/profile.d/mamba.sh"
-          
             PYTHON_VERSION="<< parameters.python-version >>"
             sed -i "/python>=/c\ - python=${PYTHON_VERSION}" environment.yml
             mamba env create -f environment.yml
@@ -40,10 +37,6 @@ jobs:
           name: Install raider and check environment
           shell: /bin/bash -xl
           command: |
-            source "${HOME}/conda/etc/profile.d/conda.sh"
-            source "${HOME}/conda/etc/profile.d/mamba.sh"
-            mamba activate RAiDER
-
             python -m pip install --no-deps .
 
             python -c "import RAiDER; from RAiDER.delay import tropo_delay"
@@ -57,21 +50,13 @@ jobs:
           name: Setup data stores
           shell: /bin/bash -xl
           command: |
-            source "${HOME}/conda/etc/profile.d/conda.sh"
-            source "${HOME}/conda/etc/profile.d/mamba.sh"
-            mamba activate RAiDER
-
             python -c 'from RAiDER.models.credentials import setup_from_env; setup_from_env()'
 
       - run:
           name: Run unit tests
           shell: /bin/bash -xl
           command: |
-            source "${HOME}/conda/etc/profile.d/conda.sh"
-            source "${HOME}/conda/etc/profile.d/mamba.sh"
-            mamba activate RAiDER
-
-            COV_OPTIONS=`python -c "import importlib;print(*(' --cov='+p for p in importlib.util.find_spec('RAiDER').submodule_search_locations))"`
+            COV_OPTIONS=`python -c "import importlib; print(*(' --cov='+p for p in importlib.util.find_spec('RAiDER').submodule_search_locations))"`
             coverage run -m pytest -m "not long" test/ ${COV_OPTIONS} --cov-report=
 
       - run:
@@ -80,10 +65,6 @@ jobs:
           command: |
             PYTHON_VERSION="<< parameters.python-version >>"
             if [ "${PYTHON_VERSION}" == "3.12" ]; then
-              source "${HOME}/conda/etc/profile.d/conda.sh"
-              source "${HOME}/conda/etc/profile.d/mamba.sh"
-              mamba activate RAiDER
-
               python -m pip install coveralls
               python .circleci/fix_coverage_paths.py .coverage ${PWD}/tools/RAiDER/
               coverage report -mi --show-missing --data-file=.coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* [741](https://github.com/dbekaert/RAiDER/pull/741) - Updated mamba setup commands in CircleCI for mamba 2.0.0.
+
 ### Added
 * [725](https://github.com/dbekaert/RAiDER/pull/725) - Added rules to ignore all test artifacts in git
 * [728](https://github.com/dbekaert/RAiDER/pull/728) - Added downloader tests for HRES, GMAO, and MERRA2.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the warning in #740 ("/root/conda/etc/profile.d/mamba.sh is deprecated, will be removed after September 30, 2025"), ensuring that RAiDER's CircleCI runners will continue to run after mamba's deprecated way of activating is removed.

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->


<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
