### PR TITLE
Upgrade to numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [732](https://github.com/dbekaert/RAiDER/pull/732) - Updated `hrrr.py` to resolve a deprecation warning about `unary_union`.
 * [731](https://github.com/dbekaert/RAiDER/pull/731) - Fixed fetch routine for GMAO.
 
+### Changed
+* [746](https://github.com/dbekaert/RAiDER/pull/746) - Upgraded numpy version to >2.
+
 ### Added
 * [725](https://github.com/dbekaert/RAiDER/pull/725) - Added rules to ignore all test artifacts in git
 * [728](https://github.com/dbekaert/RAiDER/pull/728) - Added downloader tests for HRES, GMAO, and MERRA2.

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
  - lxml
  - matplotlib
  - netcdf4
- - numpy>=2
+ - numpy
  - pandas
  - progressbar
  - pydap>3.2.2

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
  - lxml
  - matplotlib
  - netcdf4
- - numpy<2
+ - numpy>=2
  - pandas
  - progressbar
  - pydap>3.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,12 @@ quote-style = "single"
 
 [tool.ruff.lint]
 extend-select = [
-    "I",   # isort: https://docs.astral.sh/ruff/rules/#isort-i
-    "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
-    "D",   # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
-    "ANN", # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
-    "PTH", # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "I",      # isort: https://docs.astral.sh/ruff/rules/#isort-i
+    "UP",     # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "D",      # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "ANN",    # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "PTH",    # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "NPY201"  # https://docs.astral.sh/ruff/rules/numpy2-deprecation/#numpy2-deprecation-npy201
 ]
 ignore = ["ANN101", "D200", "D205", "D212"]
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from RAiDER.utilFcns import np_trapezoid
+
+
 # The purpose of these tests is to verify that the axis parameter for trapz is
 # equivalent to calling apply_along_axis(trapz, axis).
 
@@ -13,8 +16,8 @@ def test_integrate_along_axis():
 
     for level in range(y.shape[2]):
         assert np.allclose(
-            np.apply_along_axis(np.trapezoid, 2, y[..., level:], x=x[level:]),
-            np.trapezoid(y[..., level:], x[level:], axis=2)
+            np.apply_along_axis(np_trapezoid, 2, y[..., level:], x=x[level:]),
+            np_trapezoid(y[..., level:], x[level:], axis=2)
         )
 
 
@@ -27,8 +30,8 @@ def test_integrate_along_axis_2():
 
     for level in range(y.shape[2]):
         assert np.allclose(
-            np.apply_along_axis(np.trapezoid, 2, y[..., level:], x=x[level:]),
-            np.trapezoid(y[..., level:], x[level:], axis=2)
+            np.apply_along_axis(np_trapezoid, 2, y[..., level:], x=x[level:]),
+            np_trapezoid(y[..., level:], x[level:], axis=2)
         )
 
 
@@ -38,6 +41,6 @@ def test_integrate_along_axis_large():
 
     for level in range(y.shape[2]):
         assert np.allclose(
-            np.apply_along_axis(np.trapezoid, 2, y[..., level:], x=x[level:]),
-            np.trapezoid(y[..., level:], x[level:], axis=2)
+            np.apply_along_axis(np_trapezoid, 2, y[..., level:], x=x[level:]),
+            np_trapezoid(y[..., level:], x[level:], axis=2)
         )

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -13,8 +13,8 @@ def test_integrate_along_axis():
 
     for level in range(y.shape[2]):
         assert np.allclose(
-            np.apply_along_axis(np.trapz, 2, y[..., level:], x=x[level:]),
-            np.trapz(y[..., level:], x[level:], axis=2)
+            np.apply_along_axis(np.trapezoid, 2, y[..., level:], x=x[level:]),
+            np.trapezoid(y[..., level:], x[level:], axis=2)
         )
 
 
@@ -27,8 +27,8 @@ def test_integrate_along_axis_2():
 
     for level in range(y.shape[2]):
         assert np.allclose(
-            np.apply_along_axis(np.trapz, 2, y[..., level:], x=x[level:]),
-            np.trapz(y[..., level:], x[level:], axis=2)
+            np.apply_along_axis(np.trapezoid, 2, y[..., level:], x=x[level:]),
+            np.trapezoid(y[..., level:], x[level:], axis=2)
         )
 
 
@@ -38,6 +38,6 @@ def test_integrate_along_axis_large():
 
     for level in range(y.shape[2]):
         assert np.allclose(
-            np.apply_along_axis(np.trapz, 2, y[..., level:], x=x[level:]),
-            np.trapz(y[..., level:], x[level:], axis=2)
+            np.apply_along_axis(np.trapezoid, 2, y[..., level:], x=x[level:]),
+            np.trapezoid(y[..., level:], x[level:], axis=2)
         )

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -2,7 +2,7 @@ import datetime as dt
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Literal, Optional, Union, List, Tuple
+from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -18,7 +18,7 @@ from RAiDER.interpolator import fillna3D
 from RAiDER.logger import logger
 from RAiDER.models import plotWeather as plots
 from RAiDER.models.customExceptions import DatetimeOutsideRange
-from RAiDER.utilFcns import calcgeoh, clip_bbox, transform_coords
+from RAiDER.utilFcns import calcgeoh, clip_bbox, np_trapezoid, transform_coords
 
 
 TIME_RES = {
@@ -397,8 +397,8 @@ class WeatherModel(ABC):
         # Get the integrated ZTD
         wet_total, hydro_total = np.zeros(wet.shape), np.zeros(hydro.shape)
         for level in range(wet.shape[2]):
-            wet_total[..., level] = 1e-6 * np.trapezoid(wet[..., level:], x=self._zs[level:], axis=2)
-            hydro_total[..., level] = 1e-6 * np.trapezoid(hydro[..., level:], x=self._zs[level:], axis=2)
+            wet_total[..., level] = 1e-6 * np_trapezoid(wet[..., level:], x=self._zs[level:], axis=2)
+            hydro_total[..., level] = 1e-6 * np_trapezoid(hydro[..., level:], x=self._zs[level:], axis=2)
         self._hydrostatic_ztd = hydro_total
         self._wet_ztd = wet_total
 

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -397,8 +397,8 @@ class WeatherModel(ABC):
         # Get the integrated ZTD
         wet_total, hydro_total = np.zeros(wet.shape), np.zeros(hydro.shape)
         for level in range(wet.shape[2]):
-            wet_total[..., level] = 1e-6 * np.trapz(wet[..., level:], x=self._zs[level:], axis=2)
-            hydro_total[..., level] = 1e-6 * np.trapz(hydro[..., level:], x=self._zs[level:], axis=2)
+            wet_total[..., level] = 1e-6 * np.trapezoid(wet[..., level:], x=self._zs[level:], axis=2)
+            hydro_total[..., level] = 1e-6 * np.trapezoid(hydro[..., level:], x=self._zs[level:], axis=2)
         self._hydrostatic_ztd = hydro_total
         self._wet_ztd = wet_total
 

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -966,3 +966,9 @@ def parse_crs(proj: CRSLike) -> CRS:
     elif isinstance(proj, int):
         return CRS.from_epsg(proj)
     raise TypeError(f'Data type "{type(proj)}" not supported for CRS')
+
+
+if int(np.__version__.split('.')[0]) >= 2:
+    np_trapezoid = np.trapezoid
+else:
+    np_trapezoid = np.trapz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Sets RAiDER's minimum version requirement for numpy to 2.0.
- Migrates away from functions deprecated in numpy 2.0.
- Adds the numpy 2.0 linting ruleset to ruff.

Resolves https://github.com/dbekaert/RAiDER/issues/691.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue was prompted by RAiDER's conda feedstock: https://github.com/conda-forge/raider-feedstock/pull/19

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->
- Tests continue to pass
- No tests added
- No new warnings


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
