### PR TITLE
Add `browse` s3 tag to  uploaded `.png` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse_images` S3 tag for `.png` files when uploaded to AWS. 
 * [741](https://github.com/dbekaert/RAiDER/pull/741) - Updated mamba setup commands in CircleCI for mamba 2.0.0.
 * [738](https://github.com/dbekaert/RAiDER/pull/738) - Resolved an InsecureRequestWarning when fetching data through CDS, such as for ERA5.
 * [734](https://github.com/dbekaert/RAiDER/pull/734) - Resolved a deprecation warning from Rasterio about the use of `statistics()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
-* [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse_images` S3 tag for `.png` files when uploaded to AWS. 
+* [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse` S3 tag for `.png` files when uploaded to AWS.
 * [741](https://github.com/dbekaert/RAiDER/pull/741) - Updated mamba setup commands in CircleCI for mamba 2.0.0.
 * [738](https://github.com/dbekaert/RAiDER/pull/738) - Resolved an InsecureRequestWarning when fetching data through CDS, such as for ERA5.
 * [734](https://github.com/dbekaert/RAiDER/pull/734) - Resolved a deprecation warning from Rasterio about the use of `statistics()`.

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -100,7 +100,7 @@ def test_GUNW_hyp3_metadata_update(test_gunw_json_path, test_gunw_json_schema_pa
 
     # We only need to make sure the json file is passed, the netcdf file name will not have
     # any impact on subsequent testing
-    mocker.patch("RAiDER.aws.get_s3_file", side_effect=['foo.nc', temp_json_path, 'foo.png'])
+    mocker.patch("RAiDER.aws.get_s3_file", side_effect=[Path('foo.nc'), temp_json_path, Path('foo.png')])
     mocker.patch("RAiDER.aws.upload_file_to_s3")
     mocker.patch("RAiDER.aria.prepFromGUNW.main", return_value=['my_path_cfg', 'my_wavelength'])
     mocker.patch('RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation',

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -132,7 +132,7 @@ def test_GUNW_hyp3_metadata_update(test_gunw_json_path, test_gunw_json_schema_pa
 
     RAiDER.aria.calcGUNW.tropo_gunw_slc.assert_called_once_with(
         ['file1', 'file2'],
-        'foo.nc',
+        Path('foo.nc'),
         'my_wavelength',
     )
 

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -137,9 +137,9 @@ def test_GUNW_hyp3_metadata_update(test_gunw_json_path, test_gunw_json_schema_pa
     )
 
     assert aws.upload_file_to_s3.mock_calls == [
-        unittest.mock.call('foo.nc', 'myBucket', 'myPrefix'),
+        unittest.mock.call(tmp_path / 'foo.nc', 'myBucket', 'myPrefix'),
         unittest.mock.call(temp_json_path, 'myBucket', 'myPrefix'),
-        unittest.mock.call('foo.png', 'myBucket', 'myPrefix'),
+        unittest.mock.call(tmp_path / 'foo.png', 'myBucket', 'myPrefix'),
     ]
 
 

--- a/test/test_GUNW.py
+++ b/test/test_GUNW.py
@@ -137,9 +137,9 @@ def test_GUNW_hyp3_metadata_update(test_gunw_json_path, test_gunw_json_schema_pa
     )
 
     assert aws.upload_file_to_s3.mock_calls == [
-        unittest.mock.call(tmp_path / 'foo.nc', 'myBucket', 'myPrefix'),
+        unittest.mock.call(Path('foo.nc'), 'myBucket', 'myPrefix'),
         unittest.mock.call(temp_json_path, 'myBucket', 'myPrefix'),
-        unittest.mock.call(tmp_path / 'foo.png', 'myBucket', 'myPrefix'),
+        unittest.mock.call(Path('foo.png'), 'myBucket', 'myPrefix'),
     ]
 
 

--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -10,6 +10,23 @@ from RAiDER.logger import logger
 S3_CLIENT = boto3.client('s3')
 
 
+def get_tag_set(file_name: str) -> dict:
+    if file_name.endswith('.png'):
+        file_type = 'browse'
+    else:
+        file_type = 'product'
+
+    tag_set = {
+        'TagSet': [
+            {
+                'Key': 'file_type',
+                'Value': file_type
+            }
+        ]
+    }
+    return tag_set
+
+
 def get_content_type(file_location: Union[Path, str]) -> str:
     content_type = guess_type(file_location)[0]
     if content_type is None:
@@ -25,14 +42,7 @@ def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str =
     logger.info(f'Uploading s3://{bucket}/{key}')
     S3_CLIENT.upload_file(str(path_to_file), bucket, key, extra_args)
 
-    tag_set = {
-        'TagSet': [
-            {
-                'Key': 'file_type',
-                'Value': 'product'
-            }
-        ]
-    }
+    tag_set = get_tag_set(path_to_file.name)
 
     S3_CLIENT.put_object_tagging(Bucket=bucket, Key=key, Tagging=tag_set)
 

--- a/tools/RAiDER/aws.py
+++ b/tools/RAiDER/aws.py
@@ -34,9 +34,8 @@ def get_content_type(file_location: Union[Path, str]) -> str:
     return content_type
 
 
-def upload_file_to_s3(path_to_file: Union[str, Path], bucket: str, prefix: str = '') -> None:
-    path_to_file = Path(path_to_file)
-    key = str(Path(prefix) / path_to_file)
+def upload_file_to_s3(path_to_file: Path, bucket: str, prefix: str = '') -> None:
+    key = str(Path(prefix) / path_to_file.name)
     extra_args = {'ContentType': get_content_type(key)}
 
     logger.info(f'Uploading s3://{bucket}/{key}')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the ability to tag `.png` files as `browse` when uploaded to S3. This addresses [Issue 754](https://github.com/dbekaert/RAiDER/issues/754).

## Motivation and Context
This addresses [Issue 754](https://github.com/dbekaert/RAiDER/issues/754).


## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->
Will be validated in hyp3-test deployment

<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [ ] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
