### PR TITLE
Bugfix/hack: Always use EPSG:4326 with GeocodedFile to fix crash

### DIFF
--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -332,7 +332,7 @@ class GeocodedFile(AOI):
 
         self._filename = path
         self.p = rio_profile(path)
-        self._bounding_box = transform_bbox(rio_extents(self.p), dest_crs=4326, src_crs=32617)
+        self._bounding_box = transform_bbox(rio_extents(self.p), dest_crs=4326, src_crs=self.p['crs'])
         self._is_dem = is_dem
         _, self._proj, self._geotransform = rio_stats(path)
         self._type = 'geocoded_file'

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -14,6 +14,8 @@ import numpy as np
 import pyproj
 import xarray as xr
 
+from RAiDER.utilFcns import transform_bbox
+
 
 try:
     import pandas as pd
@@ -330,14 +332,11 @@ class GeocodedFile(AOI):
 
         self._filename = path
         self.p = rio_profile(path)
-        self._bounding_box = rio_extents(self.p)
+        self._bounding_box = transform_bbox(rio_extents(self.p), dest_crs=4326, src_crs=32617)
         self._is_dem = is_dem
         _, self._proj, self._geotransform = rio_stats(path)
         self._type = 'geocoded_file'
-        try:
-            self.crs = self.p['crs']
-        except KeyError:
-            self.crs = None
+        self.crs = CRS.from_epsg(4326)
 
     def readLL(self) -> tuple[np.ndarray, np.ndarray]:
         # ll_bounds are SNWE

--- a/tools/RAiDER/utilFcns.py
+++ b/tools/RAiDER/utilFcns.py
@@ -4,7 +4,7 @@ import datetime as dt
 import pathlib
 import re
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -20,9 +20,13 @@ from RAiDER.constants import R_EARTH_MIN_WGS84 as Rmin
 from RAiDER.constants import _THRESHOLD_SECONDS
 from RAiDER.constants import _g0 as G0
 from RAiDER.constants import _g1 as G1
-from RAiDER.llreader import AOI
 from RAiDER.logger import logger
 from RAiDER.types import BB, RIO, CRSLike, FloatArray2D, FloatArray3D
+
+
+# Only used for type annotations
+if TYPE_CHECKING:
+    from RAiDER.llreader import AOI
 
 
 # Optional imports
@@ -420,7 +424,7 @@ def round_time(datetime: dt.datetime, roundTo: int=60) -> dt.datetime:
 
 
 def writeDelays(
-    aoi: AOI,  #: AOI,
+    aoi: 'AOI',
     wetDelay: ndarray,
     hydroDelay: ndarray,
     wet_path: Path,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a line that transforms all bounding boxes the GeocodedFile AOI receives to EPSG:4326.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Rest of the code is not properly set up to handle GeocodedFile AOIs that are not in EPSG:4326, which causes problems with EPSG:32617 interferograms like from ASF On Demand. I lack the time to fix this properly, but I did end up doing this much so that RAiDER would work with my code for the gemlab ASF On Demand notebook jlmaurer/gemlab#11. I offer what I have in case you might want to accept it and/or use it as a jumping-off point for a more in-depth solution.

In the case when the user inputs a geocoded file with projection other than EPSG:4326, this change fixes a crash, at the cost of more transformations in this code path, and any precision errors or other drawbacks that may come with it. A more thoughtful solution may be able to avoid doing a conversion here.  
In all other cases (other projections, other input AOI types), nothing is changed/affected.

## How Has This Been Tested?
<!--- Please run the following command on your PR to ensure code formatting consistency: -->
<!--- autopep8 <changed files/folders> --recursive --in-place --ignore=E5 -->

<!--- Please describe how you tested your changes. -->


<!--- For new functionality, describe added unit tests. -->


<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
