### PR TITLE
Update concat script to handle multiple subdirs + add noise-corrected residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [731](https://github.com/dbekaert/RAiDER/pull/731) - Fixed fetch routine for GMAO.
 
 ### Added
+* [771](https://github.com/dbekaert/RAiDER/pull/771) - Support in concatenation script to pass wildcard for `--raiderDir` and `--gnssDir` added back in.
 * [762](https://github.com/dbekaert/RAiDER/pull/762) - Added lockfiles through conda-lock to the repo, documentation, and CircleCI runners.
 * [761](https://github.com/dbekaert/RAiDER/pull/761) - Added Python 3.13 support.
 * [747](https://github.com/dbekaert/RAiDER/pull/747) - Added support for run config time format `%H:%M:%S` (without quotes).

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -695,6 +695,7 @@ def combineZTDFiles() -> None:
     args: RAiDERCombineArgs = p.parse_args(namespace=RAiDERCombineArgs())
     if args.verbose:
         print(f"RAiDER file: {args.raider_file}")
+        print(f"RAiDER folder: {args.raider_folder}")
         print(f"GNSS folder: {args.gnss_folder}")
         print(f"GNSS file: {args.gnss_file}")
         print(f"Column name: {args.column_name}")

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -437,11 +437,6 @@ def main(
     # estimate residual
     dfc['ZTD_minus_RAiDER'] = dfc['ZTD'] - dfc[raider_delay]
 
-    # estimate noise corrected residual using GNSS sigZTD
-    dfc["Residual_minus_sigZTD"] = (
-        (dfc["ZTD_minus_RAiDER"] ** 2) - (dfc["sigZTD"] ** 2)
-    ) ** 0.5
-
     print('Total number of rows in the concatenated file: ' f'{dfc.shape[0]}')
     print(f'Total number of rows containing NaNs: {dfc[dfc.isna().any(axis=1)].shape[0]}')
     print('Merge finished')

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -1,14 +1,18 @@
+# Standard library
 import argparse
 import datetime as dt
+import glob
 import math
 import re
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
+# Third-party
 import pandas as pd
 from tqdm import tqdm
 
+# Local
 from RAiDER.cli.parser import add_verbose
 
 
@@ -23,7 +27,7 @@ def combineDelayFiles(
     ref: Optional[Path]=None,
     col_name: str='ZTD'
 ) -> None:
-    file_paths = list(loc.glob('*' + ext))
+    file_paths = [f for folder in loc for f in folder.glob(f"*{ext}")]
 
     if source == 'model':
         print('Ensuring that "Datetime" column exists in files')
@@ -230,11 +234,15 @@ def file_choices(p: argparse.ArgumentParser, choices: tuple[str], s: str) -> Pat
        p.error(f"File must end with one of {choices}")
     return path
 
-def parse_dir(p: argparse.ArgumentParser, s: str) -> Path:
-    path = Path(s)
-    if not path.is_dir():
-        p.error("Path must be a directory")
-    return path
+def parse_dir(pattern: str) -> list[Path]:
+    """
+    Expand a single directory or wildcard pattern into
+    a list of valid Path objects.
+    """
+    paths = sorted(Path(p) for p in glob.glob(pattern))
+    if not paths:
+        raise ValueError(f"No directories found matching pattern: {pattern}")
+    return paths
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -271,8 +279,8 @@ def create_parser() -> argparse.ArgumentParser:
             Files should be named with a Datetime in the name and contain the
             column "ID" as the delay column names.
             """),
-        type=lambda s: parse_dir(p, s),
-        default=Path.cwd(),
+        type=parse_dir,
+        default=[Path.cwd()],
     )
     p.add_argument(
         '--gnssDir',
@@ -283,8 +291,8 @@ def create_parser() -> argparse.ArgumentParser:
             Files should contain the column "ID" as the delay column names
             and times should be denoted by the "Date" key.
             """),
-        type=lambda s: parse_dir(p, s),
-        default=Path.cwd(),
+        type=parse_dir,
+        default=[Path.cwd()],
     )
 
     p.add_argument(
@@ -428,6 +436,11 @@ def main(
 
     # estimate residual
     dfc['ZTD_minus_RAiDER'] = dfc['ZTD'] - dfc[raider_delay]
+
+    # estimate noise corrected residual using GNSS sigZTD
+    dfc["Residual_minus_sigZTD"] = (
+        (dfc["ZTD_minus_RAiDER"] ** 2) - (dfc["sigZTD"] ** 2)
+    ) ** 0.5
 
     print('Total number of rows in the concatenated file: ' f'{dfc.shape[0]}')
     print(f'Total number of rows containing NaNs: {dfc[dfc.isna().any(axis=1)].shape[0]}')


### PR DESCRIPTION
## Description
Support in concatenation script to pass wildcard for `--raiderDir` and `--gnssDir` added back in. Before proposed changes, only single path arguments were supported. Now both single path arguments and wildcards are supported.

I figured this was a change that needed to be reintroduced after legacy bash scripts collating data for global analyses I had between multiple directories were failing.

In addition, now the noise correction residual column is directly passed and added to the final output files. Before I had separate wrapper scripts to add this in

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [X] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
