### PR TITLE
Update GNSS dwld to access IGS20 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [772](https://github.com/dbekaert/RAiDER/pull/772) - For GNSS download, pull in new IGS20 processed data which is being supported in forward processing mode.
 * [765](https://github.com/dbekaert/RAiDER/pull/765) - Fixed a dead link to "Installing from Source" in the ReadMe.
 * [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse` S3 tag for `.png` files when uploaded to AWS.
 * [751](https://github.com/dbekaert/RAiDER/pull/751) - Fixed ERA-5 interface for a change to its API that requires pressure variables to be requested separately from temperature and humidity.

--- a/test/test_downloadGNSS.py
+++ b/test/test_downloadGNSS.py
@@ -81,7 +81,10 @@ def test_get_ID_invalid():
 
 
 def test_download_UNR(tmp_path):
-    expected_path = "https://geodesy.unr.edu/gps_timeseries/trop/MORZ/MORZ.2020.trop.zip"
+    expected_path = (
+        "https://geodesy.unr.edu/gps_timeseries/IGS20/trop/MORZ/"
+        "MORZ.2020.trop.zip"
+    )
     statID = "MORZ"
     year = 2020
     with pushd(tmp_path):

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -141,27 +141,58 @@ def download_tropo_delays(
     statDF.to_csv(os.path.join(writeDir, f'{gps_repo}{NEW_STATION_FILENAME}_withpaths.csv'))
 
 
-def download_UNR(statID, year, writeDir='.', download=False, baseURL=_UNR_URL):
+def download_UNR(statID, year, writeDir=".", download=False, baseURL=_UNR_URL):
     """
-    Download a zip file containing tropospheric delays for a given station and year.
-    The URL format is http://geodesy.unr.edu/gps_timeseries/trop/<ssss>/<ssss>.<yyyy>.trop.zip
-    Inputs:
-        statID   - 4-character station identifier
-        year     - 4-numeral year
+    Download a zip file containing tropospheric delays for a given
+    station and year.
+
+    The URL format is:
+        http://geodesy.unr.edu/gps_timeseries/IGS20/trop/<ssss>/
+        <ssss>.<yyyy>.trop.zip
+
+    Parameters
+    ----------
+    statID : str
+        4-character station identifier.
+    year : int or str
+        4-digit year.
+    writeDir : str, optional
+        Directory to write the downloaded file. Defaults to current
+        directory.
+    download : bool, optional
+        If True, download the file. Otherwise, only check if it exists
+        remotely.
+    baseURL : str, optional
+        Base URL for the UNR repository.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys 'ID', 'year', and 'path'.
     """
     if baseURL not in [_UNR_URL]:
-        raise NotImplementedError(f'Data repository {baseURL} has not yet been implemented')
+        raise NotImplementedError(
+            f"Data repository {baseURL} has not yet been implemented"
+        )
 
-    URL = '{0}gps_timeseries/trop/{1}/{1}.{2}.trop.zip'.format(baseURL, statID.upper(), year)
-    logger.debug('Currently checking station %s in %s', statID, year)
+    URL = (
+        f"{baseURL}gps_timeseries/IGS20/trop/"
+        f"{statID.upper()}/{statID.upper()}.{year}.trop.zip"
+    )
+
+    logger.debug("Currently checking station %s in %s", statID, year)
+
     if download:
-        saveLoc = os.path.abspath(os.path.join(writeDir, f'{statID.upper()}.{year}.trop.zip'))
+        saveLoc = os.path.abspath(
+            os.path.join(writeDir, f"{statID.upper()}.{year}.trop.zip")
+        )
         filepath = download_url(URL, saveLoc)
-        if filepath == '':
-            raise ValueError('Year or station ID does not exist')
+        if filepath == "":
+            raise ValueError("Year or station ID does not exist")
     else:
         filepath = check_url(URL)
-    return {'ID': statID, 'year': year, 'path': filepath}
+
+    return {"ID": statID, "year": year, "path": filepath}
 
 
 def download_url(url, save_path, chunk_size=2048):


### PR DESCRIPTION
By default, the script accesses legacy IGS14 GNSS data, which isn't being forward processed before Sept 2024. I've pushed updates which accesses the actively supported IGS20 processed GNSS data (see the new directory structure here for reference: https://geodesy.unr.edu/gps_timeseries/readmes/DirectoryStructureComing.txt)

## How Has This Been Tested?

# download GNSS data over California
raiderDownloadGNSS.py --date 20250930 20251002 1 -b '32.0 42.0 -125.0 -114.0' --returntime 00:00:00 --out GNSS_obs_00 --cpus 8

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
