### PR TITLE
Metadata in stats plot not properly initiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [773](https://github.com/dbekaert/RAiDER/pull/773) - Fixed bug with loading metadata in the stats workflow when replotting data.
 * [765](https://github.com/dbekaert/RAiDER/pull/765) - Fixed a dead link to "Installing from Source" in the ReadMe.
 * [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse` S3 tag for `.png` files when uploaded to AWS.
 * [751](https://github.com/dbekaert/RAiDER/pull/751) - Fixed ERA-5 interface for a change to its API that requires pressure variables to be requested separately from temperature and humidity.

--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -508,7 +508,6 @@ def load_gridfile(fname, unit):
     grid_array = np.ma.filled(grid_array, np.nan)
 
     # Make plotting command a global variable
-    print('metadata_dict', metadata_dict)
     gridfile_type = metadata_dict['gridfile_type']
     globals()[gridfile_type] = True
 

--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -491,12 +491,12 @@ def load_gridfile(fname, unit):
     """Function to load gridded-arrays saved from previous runs."""
     try:
         with rasterio.open(fname) as src:
+            # Read data array
             grid_array = src.read(1).astype(float)
+            # Read metadata variables needed for plotting
+            metadata_dict = src.tags()
     except TypeError:
         raise ValueError('fname is not a valid file')
-
-    # Read metadata variables needed for plotting
-    metadata_dict = src.tags()
 
     # Initiate no-data array to mask data
     nodat_arr = [0, np.nan, np.inf]
@@ -729,7 +729,7 @@ class VariogramAnalysis:
         d_test_arr = []
         v_test_arr = []
         for j in sorted(list(set(grid_subset['Date']))):
-            # If insufficient sample size, skip slice and record occurrence
+            # If insufficient sample size, skip slice and record occurence
             if len(np.array(grid_subset[grid_subset['Date'] == j][self.col_name])) < self.densitythreshold:
                 # Record skipped [gridnode, timeslice]
                 self.skipped_slices.append([grid_ind, j.strftime('%Y-%m-%d')])
@@ -2590,7 +2590,7 @@ class RaiderStats:
                     cmap=cmap,
                     norm=norm,
                     zorder=1,
-                    s=0.5,
+                    s=10,
                     marker='.',
                     transform=ccrs.PlateCarree(),
                 )

--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -728,7 +728,7 @@ class VariogramAnalysis:
         d_test_arr = []
         v_test_arr = []
         for j in sorted(list(set(grid_subset['Date']))):
-            # If insufficient sample size, skip slice and record occurence
+            # If insufficient sample size, skip slice and record occurrence
             if len(np.array(grid_subset[grid_subset['Date'] == j][self.col_name])) < self.densitythreshold:
                 # Record skipped [gridnode, timeslice]
                 self.skipped_slices.append([grid_ind, j.strftime('%Y-%m-%d')])
@@ -2589,7 +2589,7 @@ class RaiderStats:
                     cmap=cmap,
                     norm=norm,
                     zorder=1,
-                    s=10,
+                    s=0.5,
                     marker='.',
                     transform=ccrs.PlateCarree(),
                 )


### PR DESCRIPTION
Metadata in stats plot is outside of a loop where GRD files are read, such that the variable is not properly initiated and will lead to crashes when the user attempts to replot.

## How Has This Been Tested?
Download data over California, run stats an initial time, and then replot with new data bounds. Before this tweak, the last step failed as the expected metadata field from previously generated GRD files was not initiated.

# download
raiderDownloadGNSS.py --date 20250930 20251002 1 -b '32.0 42.0 -125.0 -114.0' --returntime 00:00:00 --out GNSS_obs_00 --cpus 8

# run stats a first time to generate the GRD files
raiderStats.py --file GNSS_obs_00/UNRcombinedGPS_ztd.csv -w GNSS_RAIDERmaps --cpus all -verbose -grid_to_raster -sp 1 -figdpi 600 -grid_delay_mean -cb '-6 6' -u cm -c ZTD -oe 0.005 -fmt pdf

# run stats a 2nd time to test replotting
raiderStats.py --file GNSS_RAIDERmaps/ZTD_grid_delay_mean.tif -w GNSS_RAIDERmaps -cb '-3 3' -u cm -figdpi 600 -cm PiYG -fmt pdf

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
