### PR TITLE
In combine workflow, consistently map GNSS coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [774](https://github.com/dbekaert/RAiDER/pull/774) - Fixed inconsistent Lat/Lon mapping in combine workflow which leads to localtime matching problems.
 * [765](https://github.com/dbekaert/RAiDER/pull/765) - Fixed a dead link to "Installing from Source" in the ReadMe.
 * [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse` S3 tag for `.png` files when uploaded to AWS.
 * [751](https://github.com/dbekaert/RAiDER/pull/751) - Fixed ERA-5 interface for a change to its API that requires pressure variables to be requested separately from temperature and humidity.

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -172,6 +172,10 @@ def local_time_filter(raiderFile, ztdFile, dfr, dfz, localTime):
     """Convert to local-time reference frame WRT 0 longitude."""
     localTime_hrs = int(localTime.split(' ')[0])
     localTime_hrthreshold = int(localTime.split(' ')[1])
+    # modify dataframes without warnings
+    dfr = dfr.copy()
+    dfz = dfz.copy()
+
     # with rotation rate and distance to 0 lon, get localtime shift WRT 00 UTC at 0 lon
     # *rotation rate at given point = (360deg/23.9333333333hr) = 15.041782729825965 deg/hr
     dfr['Localtime'] = dfr['Lon'] / 15.041782729825965
@@ -363,17 +367,30 @@ def main(
 ):
     """Merge a combined RAiDER delays file with a GPS ZTD delay file."""
     print(f'Merging delay files {raider_file} and {ztd_file}')
+
+    # load files
+    dfz = pd.read_csv(ztd_file, parse_dates=['Date'])
     dfr = pd.read_csv(raider_file, parse_dates=['Datetime'])
-    # drop extra columns
+
+    # drop extra columns from tropo delay file
     expected_data_columns = ['ID', 'Lat', 'Lon', 'Hgt_m', 'Datetime', 'wetDelay', 'hydroDelay', raider_delay]
     dfr = dfr.drop(columns=[col for col in dfr if col not in expected_data_columns])
+
+    # Create dictionaries mapping ID → Lat and ID → Lon from GNSS file
+    lat_map = dict(zip(dfz["ID"], dfz["Lat"]))
+    lon_map = dict(zip(dfz["ID"], dfz["Lon"]))
+
+    # Apply to tropo delay file to avoid discrepancies in lat/lon
+    # since this will lead to dropped matches downstream
+    # as localtime estimation would be inconsistent
+    dfr = dfr.copy()
+    dfr["Lat"] = dfr["ID"].map(lat_map)
+    dfr["Lon"] = dfr["ID"].map(lon_map)
 
     # Round raider datetime to the nearest 5 min to match GNSS data
     dfr['Datetime'] = dfr['Datetime'].apply(
         lambda x: x - dt.timedelta(minutes=x.minute % 5, seconds=x.second, microseconds=x.microsecond)
     )
-
-    dfz = pd.read_csv(ztd_file, parse_dates=['Date'])
 
     # Handle datetime conversion for the GNSS files that use time in seconds
     if 'Datetime' not in dfz.keys():


### PR DESCRIPTION
In the raider combine workflow, if there are any inconsistencies in the Lat/Lon values between the two input files, then this will lead to dropped matches downstream as localtime estimation would be inconsistent. Thus here changes are introduced to consistently map Lat/Lon coordinates for each GNSS ID between both CSVs.

Also, I had encountered this warning when applying changes to a given dataframe:
```
SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame. 
```

This arises because `pandas` can’t be sure whether the change is applied to the original DataFrame or just a temporary view. To circumvent this, before applying changes an independent dataframe is made (e.g. `dfr = dfr.copy()`) to essentially "refresh" the dataframe

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
