### PR TITLE
Bugfix for handling lat/lon input in downloadGNSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [775](https://github.com/dbekaert/RAiDER/pull/775) - Fixed bug in managing longitude conventions for GNSS download bounding box input.
 * [765](https://github.com/dbekaert/RAiDER/pull/765) - Fixed a dead link to "Installing from Source" in the ReadMe.
 * [759](https://github.com/dbekaert/RAiDER/pull/759) - Added a `browse` S3 tag for `.png` files when uploaded to AWS.
 * [751](https://github.com/dbekaert/RAiDER/pull/751) - Fixed ERA-5 interface for a change to its API that requires pressure variables to be requested separately from temperature and humidity.

--- a/test/test_downloadGNSS.py
+++ b/test/test_downloadGNSS.py
@@ -50,7 +50,7 @@ def test_fix_lons_positive_to360():
 
 def test_fix_lons_negative_to360():
     lon = -100.0
-    assert fix_lons(lon, to360=True) == 800.0
+    assert fix_lons(lon, to360=True) == 80.0
 
 
 def test_fix_lons_0_to180():

--- a/test/test_downloadGNSS.py
+++ b/test/test_downloadGNSS.py
@@ -43,24 +43,24 @@ def test_in_box_outside():
     assert not in_box(lat, lon, llbox)
 
 # Test fix_lons with various longitudes
-def test_fix_lons_positive():
-    lon = 200.0
-    assert fix_lons(lon) == -160.0
+def test_fix_lons_positive_to360():
+    lon = 80.0
+    assert fix_lons(lon, to360=True) == 260.0
 
 
-def test_fix_lons_negative():
-    lon = -220.0
-    assert fix_lons(lon) == 140.0
+def test_fix_lons_negative_to360():
+    lon = -100.0
+    assert fix_lons(lon, to360=True) == 800.0
 
 
-def test_fix_lons_positive_180():
-    lon = 180.0
-    assert fix_lons(lon) == 180.0
-
-
-def test_fix_lons_negative_180():
-    lon = -180.0
+def test_fix_lons_0_to180():
+    lon = 0.0
     assert fix_lons(lon) == -180.0
+
+
+def test_fix_lons_360_to180():
+    lon = 360.0
+    assert fix_lons(lon) == 180.0
 
 
 # Test get_ID with a valid line

--- a/test/test_gnss.py
+++ b/test/test_gnss.py
@@ -92,13 +92,13 @@ def test_concatDelayFiles(tmp_path, temp_file):
 
 
 def test_get_stats_by_llh2():
-    stations = get_stats_by_llh(llhBox=[10, 18, 360-93, 360-88])
+    stations = get_stats_by_llh(llhBox=[10, 18, -93, -88])
     assert isinstance(stations, pd.DataFrame)
 
 
 def test_get_stats_by_llh3():
     with pytest.raises(ValueError):
-        get_stats_by_llh(llhBox=[10, 18, -93, -88])
+        get_stats_by_llh(llhBox=[10, 18, 360-93, 360-88])
 
 
 def test_get_station_list():

--- a/test/test_gnss.py
+++ b/test/test_gnss.py
@@ -139,15 +139,14 @@ def test_filterByBBox1():
     _, station_data = get_station_list(stationFile=os.path.join(
         SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
     with pytest.raises(ValueError):
-        filterToBBox(station_data, llhBox=[34, 38, -120, -115])
+        filterToBBox(station_data, llhBox=[34, 38, 240, 245])
 
 
 def test_filterByBBox2():
     _, station_data = get_station_list(stationFile=os.path.join(
         SCENARIO2_DIR, 'stations.csv'), writeStationFile=False)
-    new_data = filterToBBox(station_data, llhBox=[34, 38, 240, 245])
+    new_data = filterToBBox(station_data, llhBox=[34, 38, -120, -115])
     for stat in ['CAPE', 'MHMS', 'NVCO']:
         assert stat not in new_data['ID'].to_list()
     for stat in ['FGNW', 'JPLT', 'NVTP', 'WLHG', 'WORG']:
         assert stat in new_data['ID'].to_list()
-

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -457,7 +457,12 @@ def downloadGNSS() -> None:
         dest='bounding_box',
         type=str,
         default=None,
-        help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'",
+        help=(
+            "Provide either valid shapefile or Lat/Lon Bounding SNWE. "
+            "If passing SNWE, input must be in 0-centered latitude "
+            "convention (i.e. -180/180). "
+            "Example: '19 20 -99.5 -98.5'"
+        ),
     )
     area.add_argument(
         '--gpsrepo',

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -73,17 +73,15 @@ def get_stats_by_llh(llhBox=None, baseURL=_UNR_URL):
     llhBox should be a tuple in SNWE format.
     """
     if llhBox is None:
-        llhBox = [-90, 90, 0, 360]
+        llhBox = [-90, 90, -180, 180]
     S, N, W, E = llhBox
-    if (W < 0) or (E < 0):
-        raise ValueError('get_stats_by_llh: bounding box must be on lon range [0, 360]')
 
     stationHoldings = f'{baseURL}NGLStationPages/llh.out'
     # it's a file like object and works just like a file
 
     stations = pd.read_csv(stationHoldings, sep=r'\s+', names=['ID', 'Lat', 'Lon', 'Hgt_m'])
 
-    # convert lons from [0, 360] to [-180, 180]
+    # convert lons from [-360, 0] to [-180, 180]
     stations['Lon'] = ((stations['Lon'].values + 180) % 360) - 180
 
     stations = filterToBBox(stations, llhBox)
@@ -141,27 +139,58 @@ def download_tropo_delays(
     statDF.to_csv(os.path.join(writeDir, f'{gps_repo}{NEW_STATION_FILENAME}_withpaths.csv'))
 
 
-def download_UNR(statID, year, writeDir='.', download=False, baseURL=_UNR_URL):
+def download_UNR(statID, year, writeDir=".", download=False, baseURL=_UNR_URL):
     """
-    Download a zip file containing tropospheric delays for a given station and year.
-    The URL format is http://geodesy.unr.edu/gps_timeseries/trop/<ssss>/<ssss>.<yyyy>.trop.zip
-    Inputs:
-        statID   - 4-character station identifier
-        year     - 4-numeral year
+    Download a zip file containing tropospheric delays for a given
+    station and year.
+
+    The URL format is:
+        http://geodesy.unr.edu/gps_timeseries/IGS20/trop/<ssss>/
+        <ssss>.<yyyy>.trop.zip
+
+    Parameters
+    ----------
+    statID : str
+        4-character station identifier.
+    year : int or str
+        4-digit year.
+    writeDir : str, optional
+        Directory to write the downloaded file. Defaults to current
+        directory.
+    download : bool, optional
+        If True, download the file. Otherwise, only check if it exists
+        remotely.
+    baseURL : str, optional
+        Base URL for the UNR repository.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys 'ID', 'year', and 'path'.
     """
     if baseURL not in [_UNR_URL]:
-        raise NotImplementedError(f'Data repository {baseURL} has not yet been implemented')
+        raise NotImplementedError(
+            f"Data repository {baseURL} has not yet been implemented"
+        )
 
-    URL = '{0}gps_timeseries/trop/{1}/{1}.{2}.trop.zip'.format(baseURL, statID.upper(), year)
-    logger.debug('Currently checking station %s in %s', statID, year)
+    URL = (
+        f"{baseURL}gps_timeseries/IGS20/trop/"
+        f"{statID.upper()}/{statID.upper()}.{year}.trop.zip"
+    )
+
+    logger.debug("Currently checking station %s in %s", statID, year)
+
     if download:
-        saveLoc = os.path.abspath(os.path.join(writeDir, f'{statID.upper()}.{year}.trop.zip'))
+        saveLoc = os.path.abspath(
+            os.path.join(writeDir, f"{statID.upper()}.{year}.trop.zip")
+        )
         filepath = download_url(URL, saveLoc)
-        if filepath == '':
-            raise ValueError('Year or station ID does not exist')
+        if filepath == "":
+            raise ValueError("Year or station ID does not exist")
     else:
         filepath = check_url(URL)
-    return {'ID': statID, 'year': year, 'path': filepath}
+
+    return {"ID": statID, "year": year, "path": filepath}
 
 
 def download_url(url, save_path, chunk_size=2048):
@@ -287,14 +316,13 @@ def main(inps=None) -> None:
 
     # Setup bounding box
     if bounding_box:
-        bbox, long_cross_zero = parse_bbox(bounding_box)
+        bbox = parse_bbox(bounding_box)
     # If bbox not specified, query stations across the entire globe
     else:
-        bbox = [-90, 90, 0, 360]
-        long_cross_zero = 1
+        bbox = [-90, 90, -180, 180]
 
     # Handle station query
-    stats, statdf = get_stats(bbox, long_cross_zero, out, station_file)
+    stats, statdf = get_stats(bbox, out, station_file)
 
     # iterate over years
     years = list(set([i.year for i in dateList]))
@@ -333,37 +361,19 @@ def parse_bbox(bounding_box):
     else:
         raise Exception('Passing a file with a bounding box not yet supported.')
 
-    long_cross_zero = 1 if bbox[2] * bbox[3] < 0 else 0
-
-    # convert to 0 to 360 longitude convention
-    bbox[2] = fix_lons(bbox[2], to360=True)
-    bbox[3] = fix_lons(bbox[3], to360=True)
-
-    return bbox, long_cross_zero
+    return bbox
 
 
-def get_stats(bbox, long_cross_zero, out, station_file):
+def get_stats(bbox, out, station_file):
     """Pull the stations needed."""
-    if long_cross_zero == 1:
-        bbox1 = bbox.copy()
-        bbox2 = bbox.copy()
-        bbox1[3] -= 180.0
-        bbox2[2] += 180.0
-        stats1, statdata1 = get_station_list(
-            bbox=bbox1, stationFile=station_file, name_appendix='_a', writeStationFile=False
+    if bbox[3] < bbox[2]:
+        raise ValueError(
+            f"Check input -b {bbox}: longitudes appear to be flipped."
         )
-        stats2, statdata2 = get_station_list(
-            bbox=bbox2, stationFile=station_file, name_appendix='_b', writeStationFile=False
-        )
-        stats = stats1 + stats2
-        stats = list(set(stats))
-        frames = [statdata1, statdata2]
-        statdata = pd.concat(frames, ignore_index=True)
-        statdata = statdata.drop_duplicates(subset=['ID'])
-    else:
-        if bbox[3] < bbox[2]:
-            bbox[3] = 360.0
-        stats, statdata = get_station_list(bbox=bbox, stationFile=station_file, writeStationFile=False)
+
+    stats, statdata = get_station_list(bbox=bbox,
+        stationFile=station_file,
+        writeStationFile=False)
 
     statdata.to_csv(NEW_STATION_FILENAME + '.csv', index=False)
     return stats, statdata
@@ -371,38 +381,57 @@ def get_stats(bbox, long_cross_zero, out, station_file):
 
 def filterToBBox(stations, llhBox):
     """
-    Filter a dataframe by lat/lon.
-    *NOTE: llhBox longitude format should be [0, 360].
+    Filter a DataFrame of stations by latitude and longitude.
 
-    Args:
-        stations: DataFrame     - a pandas dataframe with "Lat" and "Lon" columns
-        llhBox: list of float   - 4-element list: [S, N, W, E]
+    Notes
+    -----
+    The `llhBox` and `stations` longitude format should be in [-180, 180].
 
-    Returns:
-        a Pandas Dataframe with stations removed that are not inside llhBox
+    Parameters
+    ----------
+    stations : pandas.DataFrame
+        DataFrame containing "Lat" and "Lon" (or similar) columns.
+    llhBox : list[float]
+        Four-element list defining [S, N, W, E] bounding box.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Subset of stations within the specified bounding box.
     """
     S, N, W, E = llhBox
-    if (W < 0) or (E < 0):
-        raise ValueError('llhBox longitude format should 0-360')
 
-    # For a user-provided file, need to check the column names
+    if (W > 180.) or (E > 180.):
+        raise ValueError(
+            f"Check input -b:{llhBox} longitudes appear to be in the "
+            "-360/360 convention. Expected -180/180 convention."
+        )
+
+    # For a user-provided file, check possible column names
     keys = stations.columns
-    lat_keys = ['lat', 'latitude', 'Lat', 'Latitude']
-    lon_keys = ['lon', 'longitude', 'Lon', 'Longitude']
+    lat_keys = ["lat", "latitude", "Lat", "Latitude"]
+    lon_keys = ["lon", "longitude", "Lon", "Longitude"]
+
     index = None
     for k, key in enumerate(lat_keys):
         if key in list(keys):
             index = k
             break
+
     if index is None:
-        raise KeyError('filterToBBox: No valid column names found for latitude and longitude')
-    lon_key = lon_keys[k]
-    lat_key = lat_keys[k]
+        raise KeyError(
+            "filterToBBox: No valid column names found for latitude "
+            "and longitude."
+        )
 
-    if stations[lon_key].min() < 0:
-        # convert lon format to -180 to 180
-        W = fix_lons(W)
-        E = fix_lons(E)
+    lon_key = lon_keys[index]
+    lat_key = lat_keys[index]
 
-    mask = (stations[lat_key] > S) & (stations[lat_key] < N) & (stations[lon_key] < E) & (stations[lon_key] > W)
+    mask = (
+        (stations[lat_key] > S)
+        & (stations[lat_key] < N)
+        & (stations[lon_key] < E)
+        & (stations[lon_key] > W)
+    )
+
     return stations[mask]

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -404,7 +404,7 @@ def filterToBBox(stations, llhBox):
     if (W > 180.) or (E > 180.):
         raise ValueError(
             f"Check input -b:{llhBox} longitudes appear to be in the "
-            "-360/360 convention. Expected -180/180 convention."
+            "[0, 360] convention. Expected [-180, 180] convention."
         )
 
     # For a user-provided file, check possible column names

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -54,7 +54,7 @@ def get_station_list(
                     if k == 0:
                         names = line.strip().split()
                     else:
-                        stations.append(line.strip().split())
+                        stations.append([line.strip().split()])
             station_data = pd.DataFrame(stations, columns=names)         
     else:
         station_data = get_stats_by_llh(llhBox=bbox)
@@ -200,13 +200,56 @@ def in_box(lat, lon, llhbox):
     return lat < llhbox[1] and lat > llhbox[0] and lon < llhbox[3] and lon > llhbox[2]
 
 
-def fix_lons(lon):
-    """Fix the given longitudes into the range `[-180, 180]`."""
-    fixed_lon = ((lon + 180) % 360) - 180
-    # Make the positive 180s positive again.
-    if fixed_lon == -180 and lon > 0:
-        fixed_lon *= -1
-    return fixed_lon
+def fix_lons(lon, to360: bool = False):
+    """
+    Convert longitude values between [-180, 180] and [0, 360] conventions.
+
+    Parameters
+    ----------
+    lon : float or array-like
+        Input longitude(s) in degrees.
+    to360 : bool, optional
+        If True, convert from [-180, 180] to [0, 360].
+        If False (default), convert from [0, 360] to [-180, 180].
+
+    Returns
+    -------
+    float or array-like
+        Normalized longitude(s) in the specified range.
+    """
+    if to360:
+        # Input sanity check
+        if lon < -180 or lon > 180:
+            raise ValueError(
+                f"Longitude {lon} outside valid [-180, 180] bounds. "
+                "Check input."
+            )
+
+        # Convert from [-180, 180] → [0, 360]
+        fixed = ((lon + 180) % 360)
+        # Handle the special wrap case: -180 → 0, 180 → 360
+        if lon == -180:
+            fixed = 0
+        elif lon == 180:
+            fixed = 360
+        return fixed
+
+    # Convert from [0, 360] → [-180, 180]
+    # Input sanity check
+    if lon < 0 or lon > 360:
+        raise ValueError(
+            f"Longitude {lon} outside valid [0, 360] bounds. "
+            "Check input."
+        )
+
+    fixed = (lon % 360) - 180
+    # Handle edge cases explicitly: 0 → -180, 360 → 180
+    if lon == 0:
+        fixed = -180
+    elif lon == 360:
+        fixed = 180
+
+    return fixed
 
 
 def get_ID(line):
@@ -227,6 +270,7 @@ def main(inps=None) -> None:
     station_file = inps.station_file
     if (station_file is not None) and not os.path.isfile(station_file):
         raise FileNotFoundError(f'File {station_file} does not exist.')
+
     bounding_box = inps.bounding_box
     gps_repo = inps.gps_repo
     out = inps.out
@@ -291,12 +335,9 @@ def parse_bbox(bounding_box):
 
     long_cross_zero = 1 if bbox[2] * bbox[3] < 0 else 0
 
-    # if necessary, convert negative longitudes to positive
-    if bbox[2] < 0:
-        bbox[2] += 360
-
-    if bbox[3] < 0:
-        bbox[3] += 360
+    # convert to 0 to 360 longitude convention
+    bbox[2] = fix_lons(bbox[2], to360=True)
+    bbox[3] = fix_lons(bbox[3], to360=True)
 
     return bbox, long_cross_zero
 
@@ -306,8 +347,8 @@ def get_stats(bbox, long_cross_zero, out, station_file):
     if long_cross_zero == 1:
         bbox1 = bbox.copy()
         bbox2 = bbox.copy()
-        bbox1[3] = 360.0
-        bbox2[2] = 0.0
+        bbox1[3] -= 180.0
+        bbox2[2] += 180.0
         stats1, statdata1 = get_station_list(
             bbox=bbox1, stationFile=station_file, name_appendix='_a', writeStationFile=False
         )
@@ -360,7 +401,9 @@ def filterToBBox(stations, llhBox):
 
     if stations[lon_key].min() < 0:
         # convert lon format to -180 to 180
-        W, E = (((D + 180) % 360) - 180 for D in [W, E])
+        W = fix_lons(W)
+        E = fix_lons(E)
 
+    print('updated S, N, W, E', S, N, W, E)
     mask = (stations[lat_key] > S) & (stations[lat_key] < N) & (stations[lon_key] < E) & (stations[lon_key] > W)
     return stations[mask]

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -404,6 +404,5 @@ def filterToBBox(stations, llhBox):
         W = fix_lons(W)
         E = fix_lons(E)
 
-    print('updated S, N, W, E', S, N, W, E)
     mask = (stations[lat_key] > S) & (stations[lat_key] < N) & (stations[lon_key] < E) & (stations[lon_key] > W)
     return stations[mask]


### PR DESCRIPTION
When a user specifies a bounding box for the `raiderDownloadGNSS.py`, there was a bug with the necessary internal -180/180 to 0/360 conversion to match with the UNR source convention.

I've pushed a patch and an explicit modification to the parser such that there is no ambiguity in that a 0 longitude centered convention is enforced for the bounding box input

## How Has This Been Tested?

You can run this test, where download data globally over a week

raiderDownloadGNSS.py --date 20250930 20251006 1 -b '-90 90 -180 180' --returntime 00:00:00 --out GNSS_obs_00 --cpus 8

Before this patch, only the western hemisphere got downloaded since the -180/180 to 0/360 conversion wasn't handled properly internally (see the screenshots of the station distribution before vs after the patch).
<img width="1143" height="1108" alt="Screenshot 2025-11-05 at 7 06 09 PM" src="https://github.com/user-attachments/assets/2531522d-d222-47f2-a4fb-9136daa052d2" />

<img width="963" height="989" alt="Screenshot 2025-11-06 at 1 56 31 PM" src="https://github.com/user-attachments/assets/932fff54-7bd4-411c-9c03-4b3972907d6a" />

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
