### PR TITLE
In the combine workflow, appropriately pass midnight datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [781](https://github.com/dbekaert/RAiDER/pull/781) - In the combine workflow, accurately pass and write out matching midnight datetimes.
 * [775](https://github.com/dbekaert/RAiDER/pull/775) - Fixed bug in managing longitude conventions for GNSS download bounding box input.
 * [774](https://github.com/dbekaert/RAiDER/pull/774) - Fixed inconsistent Lat/Lon mapping in combine workflow which leads to localtime matching problems.
 * [773](https://github.com/dbekaert/RAiDER/pull/773) - Fixed bug with loading metadata in the stats workflow when replotting data.

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -216,6 +216,10 @@ def local_time_filter(raiderFile, ztdFile, dfr, dfz, localTime):
     dfr.drop(columns=['Localtime_l', 'Localtime_u'], inplace=True)
     dfz.drop(columns=['Localtime_l', 'Localtime_u'], inplace=True)
 
+    # Ensure Datetime is pandas datetime64[ns] before returning
+    for _df in (dfr, dfz):
+        _df['Datetime'] = pd.to_datetime(_df['Datetime'], errors='raise')
+
     return dfr, dfz
 
 
@@ -223,8 +227,23 @@ def readZTDFile(filename, col_name='ZTD'):
     """Read and parse a GPS zenith delay file."""
     try:
         data = pd.read_csv(filename, parse_dates=['Date'])
-        times = data['times'].apply(lambda x: dt.timedelta(seconds=x))
-        data['Datetime'] = data['Date'] + times
+        date0 = pd.to_datetime(data['Date'],
+            errors='raise',
+            format='%Y-%m-%d')
+
+        # If present, convert seconds → pandas Timedelta; otherwise zero
+        if 'times' in data.columns:
+            sec = pd.to_numeric(data['times'], errors='coerce').fillna(0)
+            td = pd.to_timedelta(sec, unit='s')
+        else:
+            td = pd.to_timedelta(0, unit='s')
+
+        # Combine using numpy/pandas arrays
+        # (stays in datetime64[ns], never Python objects)
+        dt_vals = date0.values + td.values 
+
+        # Assign back
+        data['Datetime'] = pd.to_datetime(dt_vals)
     except (KeyError, ValueError):
         data = pd.read_csv(filename, parse_dates=['Datetime'])
 
@@ -369,7 +388,7 @@ def main(
     print(f'Merging delay files {raider_file} and {ztd_file}')
 
     # load files
-    dfz = pd.read_csv(ztd_file, parse_dates=['Date'])
+    dfz = pd.read_csv(ztd_file, parse_dates=['Datetime'])
     dfr = pd.read_csv(raider_file, parse_dates=['Datetime'])
 
     # drop extra columns from tropo delay file
@@ -392,19 +411,6 @@ def main(
         lambda x: x - dt.timedelta(minutes=x.minute % 5, seconds=x.second, microseconds=x.microsecond)
     )
 
-    # Handle datetime conversion for the GNSS files that use time in seconds
-    if 'Datetime' not in dfz.keys():
-        if "Date" in dfz.keys():
-            date = dfz['Date'].apply(lambda x: x.strftime('%Y-%m-%d'))
-            if 'times' in dfz.keys():
-                tm = dfz['times'].apply(lambda x: dt.timedelta(seconds=x))
-                dfz['Datetime'] = pd.to_datetime(date) + tm
-            else:
-                dfz['Datetime'] = pd.to_datetime(date)
-        else:
-            raise ValueError(
-                f'Datetime key not found in {ztd_file};\n please ensure that "Datetime" or "Date" plus "times" is included'
-            )
     # drop extra columns
     expected_data_columns = [
         'ID',
@@ -465,4 +471,6 @@ def main(
         dfc.dropna(how='any', inplace=True)
         # drop all duplicate lines
         dfc.drop_duplicates(inplace=True)
-        dfc.to_csv(out_path, index=False)
+        # force consistent datetime format
+        dfc['Datetime'] = pd.to_datetime(dfc['Datetime'], errors='raise')
+        dfc.to_csv(out_path, index=False, date_format='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
In the GNSS/tropo model combine workflow, midnight UTC crossing were not handled consistently such that the expected YYYY-MM-DD HH:MM:SS `Datetime` convention was written to the output merged file.

While this does not affect accurate matching of GNSS/tropo model observations, the output field for such cases only reflects `YYYY-MM-DD` (HH:MM:SS is stripped). So when `raiderStats.py` is run, then the user would encounter a crash as not all entries for `Datetime` have the expected datetime convention.

In addition to this, I streamlined the logic a bit more to git rid of some confusing overhead with the way the `Date` to `Datetime` conversion was handled for GNSS files.

## How Has This Been Tested?
To test this, you may access some input test files in the attached ZIP file -- for which I passed daily observations for a GNSS station collected at 00 UTC --  and run this command:
[pr_781_test.zip](https://github.com/user-attachments/files/23473618/pr_781_test.zip)
`raiderCombine.py --gnss GNSS_localtime06_combined_delays.csv --gnssDir GNSS_input --column ZTD --raider TROPO_localtime06_combined_delays.csv --raiderDir TROPO_input --raider_column totalDelay --out GNSS_TROPO_localtime06_Combined_delays.csv --localtime '6 3' -v`

In the output `GNSS_TROPO_localtime06_Combined_delays.csv`, you can verify that the `Datetime` column contains entries with the expected YYYY-MM-DD HH:MM:SS convention.


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
