### PR TITLE
Circumvent errors when downloading GNSS stations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [782](https://github.com/dbekaert/RAiDER/pull/782) - Fixed bug with handling corrupted or non-existent UNR hosted GNSS ZIP files.
 * [775](https://github.com/dbekaert/RAiDER/pull/775) - Fixed bug in managing longitude conventions for GNSS download bounding box input.
 * [774](https://github.com/dbekaert/RAiDER/pull/774) - Fixed inconsistent Lat/Lon mapping in combine workflow which leads to localtime matching problems.
 * [773](https://github.com/dbekaert/RAiDER/pull/773) - Fixed bug with loading metadata in the stats workflow when replotting data.

--- a/tools/RAiDER/getStationDelays.py
+++ b/tools/RAiDER/getStationDelays.py
@@ -65,12 +65,29 @@ def get_delays_UNR(stationFile: Path, filename: str, dateList: List, returnTime:
     """
     # sort through station zip files
     allstationTarfiles = []
+
     # if URL
     if stationFile.startswith('http'):
-        r = requests.get(stationFile)
-        ziprepo = zipfile.ZipFile(io.BytesIO(r.content))
+        try:
+            r = requests.get(stationFile)
+
+            if not stationFile.lower().endswith('.zip'):
+                logging.warning(f"{stationFile} is not a ZIP file")
+                return None
+
+            # Try to open the ZIP in memory
+            ziprepo = zipfile.ZipFile(io.BytesIO(r.content))
+
+        except (
+            requests.exceptions.RequestException,
+            zipfile.BadZipFile,
+        ) as e:
+            logging.warning(f"Skipping {stationFile}: {e}")
+            return None
+
     else:
         ziprepo = zipfile.ZipFile(stationFile)
+
     # iterate through tarfiles
     stationTarlist = sorted(ziprepo.namelist())
 

--- a/tools/RAiDER/getStationDelays.py
+++ b/tools/RAiDER/getStationDelays.py
@@ -5,13 +5,13 @@
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import csv
 import datetime as dt
 import gzip
 import io
 import multiprocessing as mp
 import os
 import zipfile
-
 from pathlib import Path
 from typing import List, Union
 
@@ -72,7 +72,7 @@ def get_delays_UNR(stationFile: Path, filename: str, dateList: List, returnTime:
             r = requests.get(stationFile)
 
             if not stationFile.lower().endswith('.zip'):
-                logging.warning(f"{stationFile} is not a ZIP file")
+                logger.warning(f"{stationFile} is not a ZIP file")
                 return None
 
             # Try to open the ZIP in memory
@@ -82,7 +82,7 @@ def get_delays_UNR(stationFile: Path, filename: str, dateList: List, returnTime:
             requests.exceptions.RequestException,
             zipfile.BadZipFile,
         ) as e:
-            logging.warning(f"Skipping {stationFile}: {e}")
+            logger.warning(f"Skipping {stationFile}: {e}")
             return None
 
     else:
@@ -240,11 +240,37 @@ def get_station_data(inFile, dateList, gps_repo=None, numCPUs=8, outDir=None, re
             for sf in stationFiles:
                 StationID = os.path.basename(sf).split('.')[0]
                 name = Path(pathbase) / f"{StationID}_ztd.csv"
+                # if GNSS CSV exists
+                # check whether all dates have already been downloaded
+                if Path.exists(name):
+                    with open(name, newline='') as f:
+                        reader = csv.DictReader(f)
+                        dates_in_file = {row['Date'] for row in reader}
+
+                    missing = [d for d in dateList if d not in dates_in_file]
+                    if not missing:
+                        logger.warning(
+                            f"Station file {name} already "
+                            "contains expected dates"
+                        )
+                        continue
+
+                # append query to args
                 args.append((sf, name, dateList, returnTime))
                 outputfiles.append(name)
+
             # Parallelize remote querying of zenith delays
             with mp.Pool(numCPUs) as multipool:
                 multipool.starmap(get_delays_UNR, args)
+ 
+            # Dedup entries in CSV files
+            for name in list(set(outputfiles)):
+                # Read + convert date column
+                df = pd.read_csv(name, parse_dates=['Date'])
+                # Drop duplicates and sort ascending by Date
+                df = df.drop_duplicates().sort_values(by='Date', ascending=True)
+                # Overwrite file cleanly
+                df.to_csv(name, index=False)
 
     # confirm file exists (i.e. valid delays exists for specified time/region).
     outputfiles = [i for i in outputfiles if Path.exists(i)]

--- a/tools/RAiDER/getStationDelays.py
+++ b/tools/RAiDER/getStationDelays.py
@@ -265,12 +265,18 @@ def get_station_data(inFile, dateList, gps_repo=None, numCPUs=8, outDir=None, re
  
             # Dedup entries in CSV files
             for name in list(set(outputfiles)):
-                # Read + convert date column
-                df = pd.read_csv(name, parse_dates=['Date'])
-                # Drop duplicates and sort ascending by Date
-                df = df.drop_duplicates().sort_values(by='Date', ascending=True)
-                # Overwrite file cleanly
-                df.to_csv(name, index=False)
+                if Path(name).exists():
+                    # Read + convert date column
+                    df = pd.read_csv(name, parse_dates=['Date'])
+                    # Drop duplicates and sort ascending by Date
+                    df = df.drop_duplicates().sort_values(by='Date', ascending=True)
+                    # Overwrite file cleanly
+                    df.to_csv(name, index=False)
+                else:
+                    logger.warning(
+                        f"Station file {name} not found likely"
+                        "no available data in specified time span"
+                    )
 
     # confirm file exists (i.e. valid delays exists for specified time/region).
     outputfiles = [i for i in outputfiles if Path.exists(i)]

--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -329,9 +329,29 @@ def main(inps=None) -> None:
     download_tropo_delays(stats, years, gps_repo=gps_repo, writeDir=out, download=download)
 
     # Combine station data with URL info
-    pathsdf = pd.read_csv(os.path.join(out, f'{gps_repo}{NEW_STATION_FILENAME}_withpaths.csv'))
-    pathsdf = pd.merge(left=pathsdf, right=statdf, how='left', left_on='ID', right_on='ID')
-    pathsdf.to_csv(os.path.join(out, f'{gps_repo}{NEW_STATION_FILENAME}_withpaths.csv'), index=False)
+    paths_file = os.path.join(
+        out, f"{gps_repo}{NEW_STATION_FILENAME}_withpaths.csv"
+    )
+
+    pathsdf = pd.read_csv(paths_file)
+
+    pathsdf = pd.merge(
+        left=pathsdf,
+        right=statdf,
+        how='left',
+        left_on='ID',
+        right_on='ID',
+    )
+
+    # Drop duplicates based on ID, year, and path only
+    pathsdf = pathsdf.drop_duplicates(subset=['ID', 'year', 'path'])
+
+    # sort for consistent ordering
+    pathsdf = pathsdf.sort_values(by=['ID', 'year', 'path'], ascending=True)
+
+    # Write cleaned DataFrame back to file
+    pathsdf.to_csv(paths_file, index=False)
+
     del statdf, pathsdf
 
     # Extract delays for each station


### PR DESCRIPTION
In the middle of some very long downloading jobs I get the following ambiguous error in a multi-threading block where the program attempts to access data from UNR:
multiprocessing.pool.RemoteTraceback: 
```
"""
Traceback (most recent call last):
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/RAiDER/tools/RAiDER/getStationDelays.py", line 71, in get_delays_UNR
    ziprepo = zipfile.ZipFile(io.BytesIO(r.content))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/zipfile/__init__.py", line 1354, in __init__
    self._RealGetContents()
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/zipfile/__init__.py", line 1421, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/bin/raiderDownloadGNSS.py", line 8, in <module>
    sys.exit(downloadGNSS())
             ^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/RAiDER/tools/RAiDER/cli/raider.py", line 514, in downloadGNSS
    dlGNSS(args)
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/RAiDER/tools/RAiDER/gnss/downloadGNSSDelays.py", line 339, in main
    get_station_data(
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/RAiDER/tools/RAiDER/getStationDelays.py", line 230, in get_station_data
    multipool.starmap(get_delays_UNR, args)
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/multiprocessing/pool.py", line 375, in starmap
    return self._map_async(func, iterable, starmapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/multiprocessing/pool.py", line 774, in get
    raise self._value
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
      ^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/RAiDER/tools/RAiDER/getStationDelays.py", line 71, in get_delays_UNR
    ziprepo = zipfile.ZipFile(io.BytesIO(r.content))
  ^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/zipfile/__init__.py", line 1354, in __init__
    self._RealGetContents()
^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/RAiDER/lib/python3.12/zipfile/__init__.py", line 1421, in _RealGetContents
    raise BadZipFile("File is not a zip file")
^^^^^^^^^^^^^^^
zipfile.BadZipFile: File is not a zip file
```

I verified that all expected input paths are valid, existing ZIP files. Thus, this must be associated with either a corrupted ZIP file or deleted ZIP file on the UNR archive. These proposed changes thus are intended to more clearly log such failed cases and move on to the next station without raising an error.


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
