### PR TITLE
Add weather model uncertainty workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [731](https://github.com/dbekaert/RAiDER/pull/731) - Fixed fetch routine for GMAO.
 
 ### Added
+* [784](https://github.com/dbekaert/RAiDER/pull/784) - Added support to compute and pass weather model uncertainty in `raiderCombine.py` and `raiderStats.py` workflow.
 * [771](https://github.com/dbekaert/RAiDER/pull/771) - Support in concatenation script to pass wildcard for `--raiderDir` and `--gnssDir` added back in.
 * [762](https://github.com/dbekaert/RAiDER/pull/762) - Added lockfiles through conda-lock to the repo, documentation, and CircleCI runners.
 * [761](https://github.com/dbekaert/RAiDER/pull/761) - Added Python 3.13 support.

--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -15,6 +15,7 @@ import warnings
 
 import matplotlib as mpl
 import numpy as np
+from pathlib import Path
 import pandas as pd
 import rasterio
 from matplotlib import pyplot as plt
@@ -1599,8 +1600,24 @@ class RaiderStats:
 
         if self.grid_delay_mean:
             # Take mean of station-wise means per gridcell
-            unique_points = self.df.groupby(['ID', 'Lon', 'Lat', 'gridnode'], as_index=False)[self.col_name].mean()
-            unique_points = unique_points.groupby(['gridnode'])[self.col_name].mean()
+            if not Path(self.fname).name.endswith('WM_variance.csv'):
+                unique_points = (
+                    self.df.groupby(
+                        ['ID', 'Lon', 'Lat', 'gridnode'], as_index=False
+                    )[self.col_name]
+                    .mean()
+                )
+                unique_points = (
+                    unique_points.groupby(['gridnode'])[self.col_name]
+                    .mean()
+                )
+            else:
+                unique_points = (
+                    self.df.groupby(['gridnode'])[
+                        self.col_name
+                    ].mean()
+                )
+                unique_points.index.name = 'gridnode'
             unique_points.dropna(how='any', inplace=True)
             self.grid_delay_mean = (
                 np.array(
@@ -1632,8 +1649,24 @@ class RaiderStats:
 
         if self.grid_delay_median:
             # Take mean of station-wise medians per gridcell
-            unique_points = self.df.groupby(['ID', 'Lon', 'Lat', 'gridnode'], as_index=False)[self.col_name].median()
-            unique_points = unique_points.groupby(['gridnode'])[self.col_name].mean()
+            if not Path(self.fname).name.endswith('WM_variance.csv'):
+                unique_points = (
+                    self.df.groupby(
+                        ['ID', 'Lon', 'Lat', 'gridnode'], as_index=False
+                    )[self.col_name]
+                    .median()
+                )
+                unique_points = (
+                    unique_points.groupby(['gridnode'])[self.col_name]
+                    .mean()
+                )
+            else:
+                unique_points = (
+                    self.df.groupby(['gridnode'])[
+                        self.col_name
+                    ].median()
+                )
+                unique_points.index.name = 'gridnode'
             unique_points.dropna(how='any', inplace=True)
             self.grid_delay_median = (
                 np.array(
@@ -1665,8 +1698,24 @@ class RaiderStats:
 
         if self.grid_delay_stdev:
             # Take mean of station-wise stdev per gridcell
-            unique_points = self.df.groupby(['ID', 'Lon', 'Lat', 'gridnode'], as_index=False)[self.col_name].std()
-            unique_points = unique_points.groupby(['gridnode'])[self.col_name].mean()
+            if not Path(self.fname).name.endswith('WM_variance.csv'):
+                unique_points = (
+                    self.df.groupby(
+                        ['ID', 'Lon', 'Lat', 'gridnode'], as_index=False
+                    )[self.col_name]
+                    .std()
+                )
+                unique_points = (
+                    unique_points.groupby(['gridnode'])[self.col_name]
+                    .mean()
+                )
+            else:
+                unique_points = (
+                    self.df.groupby(['gridnode'])[
+                        self.col_name
+                    ].std()
+                )
+                unique_points.index.name = 'gridnode'
             unique_points.dropna(how='any', inplace=True)
             self.grid_delay_stdev = (
                 np.array(

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 from typing import Optional
 
 # Third-party
+import numpy as np
 import pandas as pd
 from tqdm import tqdm
 

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -585,7 +585,7 @@ def main(
     n_dropped = n_before - len(dfc_qm)
 
     logger.warning(
-        f"Dropped {n_dropped} rows containing NaN values "
+        f"Dropped {n_dropped} stations containing NaN values "
         f"({len(dfc_qm)} remaining)."
     )
 

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 
 # Local
 from RAiDER.cli.parser import add_verbose
+from RAiDER.logger import logger
 
 
 pd.options.mode.chained_assignment = None  # default='warn'
@@ -251,6 +252,89 @@ def readZTDFile(filename, col_name='ZTD'):
     return data
 
 
+def variance_analysis(group: pd.DataFrame,
+                      allow_nan_for_negative: bool = True,
+                      has_localtime: bool = False) -> pd.Series:
+    """
+    Compute variance terms and time span for one GNSS station.
+
+    Args:
+        group (pd.DataFrame): Subset of rows for a single station ID.
+        allow_nan_for_negative (bool): If True, return NaN when
+            sigma_model^2 < 0; otherwise clamp to 0. Default is True.
+        has_localtime (bool): If True, parse and output Localtime fields.
+
+    Returns:
+        pd.Series: Summary statistics for this station.
+    """
+    # Residuals and valid mask (pairwise)
+    resid = group["ZTD"] - group["totalDelay"]
+    valid = resid.notna()
+    resid = resid[valid]
+    sig = group.loc[valid, "sigZTD"].dropna()
+
+    # Mean-squared terms
+    sigma_res_sq = np.mean(np.square(resid)) if len(resid) else np.nan
+    sigma_gnss_sq = np.mean(np.square(sig)) if len(sig) else np.nan
+
+    # Model variance computation
+    if np.isfinite(sigma_res_sq) and np.isfinite(sigma_gnss_sq):
+        diff = sigma_res_sq - sigma_gnss_sq
+        if diff < 0 and allow_nan_for_negative:
+            sigma_model_sq = np.nan
+        else:
+            sigma_model_sq = max(diff, 0.0)
+    else:
+        sigma_model_sq = np.nan
+
+    # Parse datetime ranges
+    dt = pd.to_datetime(group["Datetime"], errors="coerce")
+
+    # Only parse Localtime if present
+    if has_localtime:
+        lt = pd.to_datetime(group["Localtime"], errors="coerce")
+        lt_min = lt.min()
+        lt_max = lt.max()
+    else:
+        lt_min = pd.NaT
+        lt_max = pd.NaT
+
+    def first_non_null(series: pd.Series):
+        vals = series.dropna()
+        return vals.iloc[0] if not vals.empty else np.nan
+
+    def series_aggregate(series: pd.Series, agg_method: str = "median"):
+        """Aggregate a numeric series with NaN handling."""
+        if series is None or len(series.dropna()) == 0:
+            return np.nan
+        if agg_method == "median":
+            return series.median(skipna=True)
+        if agg_method == "mean":
+            return series.mean(skipna=True)
+        raise ValueError(f"Unknown agg_method: {agg_method!r}")
+
+    return pd.Series(
+        {
+            "ID": group.name,
+            "Lat": first_non_null(group["Lat"]),
+            "Lon": first_non_null(group["Lon"]),
+            "Hgt_m": first_non_null(group["Hgt_m"]),
+            "Datetime": dt.min(),
+            "Enddate_Datetime": dt.max(),
+            "Localtime": lt_min,            # NaT if not present
+            "Enddate_Localtime": lt_max,    # NaT if not present
+            "sigZTD": series_aggregate(group["sigZTD"], "median"),
+            "sigma_res": np.sqrt(sigma_res_sq)
+            if np.isfinite(sigma_res_sq) else np.nan,
+            "sigma_gnss": np.sqrt(sigma_gnss_sq)
+            if np.isfinite(sigma_gnss_sq) else np.nan,
+            "sigma_model": np.sqrt(sigma_model_sq)
+            if np.isfinite(sigma_model_sq) else np.nan,
+            "n_epochs_used": int(valid.sum()),
+        }
+    )
+
+
 def file_choices(p: argparse.ArgumentParser, choices: tuple[str], s: str) -> Path:
     path = Path(s)
     if path.suffix not in choices:
@@ -452,7 +536,8 @@ def main(
     )
 
     # only keep observation closest to Localtime
-    if 'Localtime' in dfc.keys():
+    has_localtime = "Localtime" in dfc.columns
+    if has_localtime:
         dfc['Localtimediff'] = abs((dfc['Datetime'] - dfc['Localtime']).dt.total_seconds() / 3600)
         dfc = dfc.loc[dfc.groupby(['ID', 'Localtime']).Localtimediff.idxmin()].reset_index(drop=True)
         dfc.drop(columns=['Localtimediff'], inplace=True)
@@ -474,3 +559,37 @@ def main(
         # force consistent datetime format
         dfc['Datetime'] = pd.to_datetime(dfc['Datetime'], errors='raise')
         dfc.to_csv(out_path, index=False, date_format='%Y-%m-%d %H:%M:%S')
+
+    # compute and pass separate CSV with weather model variance
+    out_path = out_path.with_name(
+        f"{out_path.stem}_WM_variance{out_path.suffix}"
+    )
+
+    dfc_qm = (
+        dfc.groupby("ID", dropna=False, sort=True)
+        .apply(
+            variance_analysis,
+            allow_nan_for_negative=True,
+            has_localtime=has_localtime,
+            include_groups=False,
+        )
+        .reset_index(drop=True)
+    )
+
+    # Drop all lines with NaNs and duplicates
+    n_before = len(dfc_qm)
+    dfc_qm.dropna(how="any", inplace=True)
+    dfc_qm.drop_duplicates(inplace=True)
+    n_dropped = n_before - len(dfc_qm)
+
+    logger.warning(
+        f"Dropped {n_dropped} rows containing NaN values "
+        f"({len(dfc_qm)} remaining)."
+    )
+
+    dfc_qm.to_csv(
+        out_path,
+        index=False,
+        date_format="%Y-%m-%d %H:%M:%S",
+        float_format="%.6f",
+    )

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -575,6 +575,7 @@ def main(
         )
         .reset_index(drop=True)
     )
+    del dfc
 
     # Drop all lines with NaNs and duplicates
     n_before = len(dfc_qm)
@@ -593,3 +594,4 @@ def main(
         date_format="%Y-%m-%d %H:%M:%S",
         float_format="%.6f",
     )
+    del dfc_qm


### PR DESCRIPTION
Added support in the `raiderCombine.py` workflow to automatically compute and capture within a separate CSV file "*_WM_variance.csv" the uncertainty of the input weather model, defined as `sigma_model = sqrt(sigma_res^2 - sigma_gnss^2)`, where `sigma_res^2=E{(ZTDgnss - ZTDwm)^2}`.  Additional columns for `sigma_res` and `sigma_gnss` also passed.

This analysis is done across all time-observations for a given station, so I made some minor adjustments to the statistical analysis call to handle this file appropriately (i.e. avoid averaging in time when the time dimension collapses).

## How Has This Been Tested?
Barebones minimum working example (input files can be provided as ZIP files upon request):
`raiderCombine.py --gnss GNSS_localtime06_combined_delays.csv --gnssDir final_12_day_GNSS --column ZTD --raider TROPO_localtime06_combined_delays.csv --raiderDir final_TROPO --raider_column totalDelay --out GNSS_TROPO_localtime06_Combined_delays.csv --localtime 6 3 -v`

`raiderStats.py --file GNSS_TROPO_localtime06_Combined_delays_WM_variance.csv -w GNSS_RAIDERmaps_2024-01-01_2025-12-31 -ti '2024-01-01 2025-12-31' --cpus all -verbose -grid_to_raster -b '-90 90 -180 180' -sp 1 -figdpi 600 -grid_delay_mean -grid_delay_stdev -cb '0 6' -u cm -c sigma_model -oe 0.005 -fmt pdf -tl`


## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
