### PR TITLE
Update processDelayFiles.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
+* [787](https://github.com/dbekaert/RAiDER/pull/787) - Updated weather model uncertainty estimation and included error thresholds to discard unreliable observations.
 * [782](https://github.com/dbekaert/RAiDER/pull/782) - Fixed bug with handling corrupted or non-existent UNR hosted GNSS ZIP files.
 * [781](https://github.com/dbekaert/RAiDER/pull/781) - In the combine workflow, accurately pass and write out matching midnight datetimes.
 * [775](https://github.com/dbekaert/RAiDER/pull/775) - Fixed bug in managing longitude conventions for GNSS download bounding box input.

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -610,6 +610,7 @@ def calcDelaysGUNW(iargs: Optional[list[str]] = None) -> Optional[xr.Dataset]:
         args.interpolate_time == 'azimuth_time_grid'
     ):
         gunw_id = args.file.name.replace('.nc', '')
+        weather_model_name = identify_which_hrrr(args.file)
         if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id, weather_model_name):
             raise NoWeatherModelData('The required HRRR data for time-grid interpolation is not available')
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -30,6 +30,7 @@ from RAiDER.cli.types import (
     RuntimeGroup,
     TimeGroup,
 )
+from RAiDER.aria.prepFromGUNW import identify_which_hrrr
 from RAiDER.cli.validators import DateListAction, date_type
 from RAiDER.gnss.types import RAiDERCombineArgs
 from RAiDER.logger import logger, logging
@@ -334,7 +335,7 @@ def calcDelays(iargs: Optional[Sequence[str]]=None) -> list[Path]:
 
         if len(wfiles) == 0:
             logger.error('No weather model data was successfully processed.')
-            raise NoWeatherModelData()
+            raise NoWeatherModelData('Weather model processing failed for all times')
         
         # Get the weather model file
         weather_model_file = getWeatherFile(wfiles, times, t, model._Name, interp_method)

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -30,7 +30,6 @@ from RAiDER.cli.types import (
     RuntimeGroup,
     TimeGroup,
 )
-from RAiDER.aria.prepFromGUNW import identify_which_hrrr
 from RAiDER.cli.validators import DateListAction, date_type
 from RAiDER.gnss.types import RAiDERCombineArgs
 from RAiDER.logger import logger, logging
@@ -335,7 +334,7 @@ def calcDelays(iargs: Optional[Sequence[str]]=None) -> list[Path]:
 
         if len(wfiles) == 0:
             logger.error('No weather model data was successfully processed.')
-            raise NoWeatherModelData('Weather model processing failed for all times')
+            raise NoWeatherModelData()
         
         # Get the weather model file
         weather_model_file = getWeatherFile(wfiles, times, t, model._Name, interp_method)
@@ -610,8 +609,7 @@ def calcDelaysGUNW(iargs: Optional[list[str]] = None) -> Optional[xr.Dataset]:
         args.interpolate_time == 'azimuth_time_grid'
     ):
         gunw_id = args.file.name.replace('.nc', '')
-        weather_model_name = identify_which_hrrr(args.file)
-        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id, weather_model_name):
+        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id):
             raise NoWeatherModelData('The required HRRR data for time-grid interpolation is not available')
 
     if args.file is None:
@@ -707,6 +705,8 @@ def combineZTDFiles() -> None:
         print(f"Raider column name: {args.raider_column_name}")
         print(f"Output name: {args.out_name}")
         print(f"Local time: {args.local_time}")
+        print(f"Observation error threshold: {args.obs_errlimit}")
+        print(f"Nan for negative σ_wm values: {args.allow_nan_for_negative}")
 
     if not args.raider_file.exists():
         combineDelayFiles(args.raider_file, loc=args.raider_folder)
@@ -716,7 +716,8 @@ def combineZTDFiles() -> None:
 
     if not args.gnss_file.exists():
         combineDelayFiles(
-            args.gnss_file, loc=args.gnss_folder, source='GNSS', ref=args.raider_file, col_name=args.column_name
+            args.gnss_file, loc=args.gnss_folder, source='GNSS',
+            ref=args.raider_file, col_name=args.column_name
         )
 
     main(
@@ -726,6 +727,8 @@ def combineZTDFiles() -> None:
         raider_delay=args.raider_column_name,
         out_path=args.out_name,
         local_time=args.local_time,
+        obs_errlimit=args.obs_errlimit,
+        allow_nan_for_negative=args.allow_nan_for_negative,
     )
 
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -609,7 +609,8 @@ def calcDelaysGUNW(iargs: Optional[list[str]] = None) -> Optional[xr.Dataset]:
         args.interpolate_time == 'azimuth_time_grid'
     ):
         gunw_id = args.file.name.replace('.nc', '')
-        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id):
+        weather_model_name = identify_which_hrrr(args.file)
+        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id, weather_model_name):
             raise NoWeatherModelData('The required HRRR data for time-grid interpolation is not available')
 
     if args.file is None:

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -30,7 +30,6 @@ from RAiDER.cli.types import (
     RuntimeGroup,
     TimeGroup,
 )
-from RAiDER.aria.prepFromGUNW import identify_which_hrrr
 from RAiDER.cli.validators import DateListAction, date_type
 from RAiDER.gnss.types import RAiDERCombineArgs
 from RAiDER.logger import logger, logging
@@ -335,7 +334,7 @@ def calcDelays(iargs: Optional[Sequence[str]]=None) -> list[Path]:
 
         if len(wfiles) == 0:
             logger.error('No weather model data was successfully processed.')
-            raise NoWeatherModelData('Weather model processing failed for all times')
+            raise NoWeatherModelData()
         
         # Get the weather model file
         weather_model_file = getWeatherFile(wfiles, times, t, model._Name, interp_method)
@@ -610,8 +609,7 @@ def calcDelaysGUNW(iargs: Optional[list[str]] = None) -> Optional[xr.Dataset]:
         args.interpolate_time == 'azimuth_time_grid'
     ):
         gunw_id = args.file.name.replace('.nc', '')
-        weather_model_name = identify_which_hrrr(args.file)
-        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id, weather_model_name):
+        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id):
             raise NoWeatherModelData('The required HRRR data for time-grid interpolation is not available')
 
     if args.file is None:
@@ -708,7 +706,7 @@ def combineZTDFiles() -> None:
         print(f"Output name: {args.out_name}")
         print(f"Local time: {args.local_time}")
         print(f"Observation error threshold: {args.obs_errlimit}")
-        print(f"Nan for negative σ_wm values: {args.allow_nan_for_negative}")
+        print(f"Nan for negative σ_wm² values: {args.allow_nan_for_negative}")
 
     if not args.raider_file.exists():
         combineDelayFiles(args.raider_file, loc=args.raider_folder)

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -30,6 +30,7 @@ from RAiDER.cli.types import (
     RuntimeGroup,
     TimeGroup,
 )
+from RAiDER.aria.prepFromGUNW import identify_which_hrrr
 from RAiDER.cli.validators import DateListAction, date_type
 from RAiDER.gnss.types import RAiDERCombineArgs
 from RAiDER.logger import logger, logging
@@ -334,7 +335,7 @@ def calcDelays(iargs: Optional[Sequence[str]]=None) -> list[Path]:
 
         if len(wfiles) == 0:
             logger.error('No weather model data was successfully processed.')
-            raise NoWeatherModelData()
+            raise NoWeatherModelData('Weather model processing failed for all times')
         
         # Get the weather model file
         weather_model_file = getWeatherFile(wfiles, times, t, model._Name, interp_method)
@@ -609,7 +610,7 @@ def calcDelaysGUNW(iargs: Optional[list[str]] = None) -> Optional[xr.Dataset]:
         args.interpolate_time == 'azimuth_time_grid'
     ):
         gunw_id = args.file.name.replace('.nc', '')
-        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id):
+        if not RAiDER.aria.prepFromGUNW.check_hrrr_dataset_availablity_for_s1_azimuth_time_interpolation(gunw_id, weather_model_name):
             raise NoWeatherModelData('The required HRRR data for time-grid interpolation is not available')
 
     if args.file is None:

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -497,7 +497,7 @@ def create_parser() -> argparse.ArgumentParser:
         help=dedent(
             """\
             If set, return NaN when σ_model² < 0; otherwise clamp to 0.
-            Default is False.
+            Default is True.
             """
         ),
         action='store_true',

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -254,7 +254,7 @@ def readZTDFile(filename, col_name='ZTD'):
 
 
 def variance_analysis(group: pd.DataFrame,
-                      allow_nan_for_negative: bool = False,
+                      allow_nan_for_negative: bool = True,
                       has_localtime: bool = False) -> pd.Series:
     """
     Compute variance terms and time span for one GNSS station.
@@ -262,7 +262,7 @@ def variance_analysis(group: pd.DataFrame,
     Args:
         group (pd.DataFrame): Subset of rows for a single station ID.
         allow_nan_for_negative (bool): If True, return NaN when
-            sigma_model^2 < 0; otherwise clamp to 0. Default is False.
+            σ_wm² < 0; otherwise clamp to 0. Default is True.
         has_localtime (bool): If True, parse and output Localtime fields.
 
     Returns:
@@ -270,12 +270,12 @@ def variance_analysis(group: pd.DataFrame,
     """
 
     # Capture wm-gnss residual and sig_ztd
-    resid = group["ZTD_minus_RAiDER"]
+    resid = group["ZTD_minus_RAiDER"] # also mean(R)
     sig = group["sigZTD"]
     n_epochs = len(resid)
 
     # Mean-squared terms
-    # σ_res² = E[r²]
+    # σ_res² = D[r] = E((r - E(r))²)
     sigma_res_sq = (
         np.var(resid, ddof=1)
         if n_epochs > 1
@@ -290,7 +290,7 @@ def variance_analysis(group: pd.DataFrame,
 
     # Model variance computation
     if np.isfinite(sigma_res_sq) and np.isfinite(sigma_gnss_sq):
-        # σ_wm^2 = σ_res^2 - σ_gnss^2
+        # σ_wm² = σ_res² - σ_gnss²
         diff = sigma_res_sq - sigma_gnss_sq
         if diff < 0 and allow_nan_for_negative:
             sigma_model_sq = np.nan
@@ -501,7 +501,7 @@ def create_parser() -> argparse.ArgumentParser:
             """
         ),
         action='store_true',
-        default=False,
+        default=True,
     )
     add_verbose(p)
 
@@ -516,7 +516,7 @@ def main(
     out_path: Optional[Path]=None,
     local_time: str=None,
     obs_errlimit: float=float('inf'),
-    allow_nan_for_negative: bool=False
+    allow_nan_for_negative: bool=True
 ):
     """Merge a combined RAiDER delays file with a GPS ZTD delay file."""
     print(f'Merging delay files {raider_file} and {ztd_file}')

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -254,7 +254,7 @@ def readZTDFile(filename, col_name='ZTD'):
 
 
 def variance_analysis(group: pd.DataFrame,
-                      allow_nan_for_negative: bool = True,
+                      allow_nan_for_negative: bool = False,
                       has_localtime: bool = False) -> pd.Series:
     """
     Compute variance terms and time span for one GNSS station.
@@ -262,24 +262,35 @@ def variance_analysis(group: pd.DataFrame,
     Args:
         group (pd.DataFrame): Subset of rows for a single station ID.
         allow_nan_for_negative (bool): If True, return NaN when
-            sigma_model^2 < 0; otherwise clamp to 0. Default is True.
+            sigma_model^2 < 0; otherwise clamp to 0. Default is False.
         has_localtime (bool): If True, parse and output Localtime fields.
 
     Returns:
         pd.Series: Summary statistics for this station.
     """
-    # Residuals and valid mask (pairwise)
-    resid = group["ZTD"] - group["totalDelay"]
-    valid = resid.notna()
-    resid = resid[valid]
-    sig = group.loc[valid, "sigZTD"].dropna()
+
+    # Capture wm-gnss residual and sig_ztd
+    resid = group["ZTD_minus_RAiDER"]
+    sig = group["sigZTD"]
+    n_epochs = len(resid)
 
     # Mean-squared terms
-    sigma_res_sq = np.mean(np.square(resid)) if len(resid) else np.nan
-    sigma_gnss_sq = np.mean(np.square(sig)) if len(sig) else np.nan
+    # σ_res² = E[r²]
+    sigma_res_sq = (
+        np.var(resid, ddof=1)
+        if n_epochs > 1
+        else np.var(resid, ddof=0)
+    )
+    # σ_GNSS² = E[sigZTD²]
+    sigma_gnss_sq = (
+        (sig**2).mean()
+        if n_epochs > 1
+        else np.nan
+    )
 
     # Model variance computation
     if np.isfinite(sigma_res_sq) and np.isfinite(sigma_gnss_sq):
+        # σ_wm^2 = σ_res^2 - σ_gnss^2
         diff = sigma_res_sq - sigma_gnss_sq
         if diff < 0 and allow_nan_for_negative:
             sigma_model_sq = np.nan
@@ -288,52 +299,60 @@ def variance_analysis(group: pd.DataFrame,
     else:
         sigma_model_sq = np.nan
 
+    # Mean bias calculation
+    mean_bias = resid.mean()
+
+    # Uncertainty in mean bias (error propagation)
+    if np.isfinite(sigma_model_sq) and len(sig) > 0:
+        sig_squared = sig**2
+        # Each measurement has uncertainty: σ_i² = σ_GNSS_i² + σ_model²
+        # For mean: σ_mean² = Σ(σ_i²) / n²
+        variance_sum = sig_squared.sum() + len(sig) * sigma_model_sq
+        sigma_mean_bias = np.sqrt(variance_sum) / len(sig)
+    else:
+        sigma_mean_bias = np.nan
+
     # Parse datetime ranges
     dt = pd.to_datetime(group["Datetime"], errors="coerce")
-
-    # Only parse Localtime if present
-    if has_localtime:
-        lt = pd.to_datetime(group["Localtime"], errors="coerce")
-        lt_min = lt.min()
-        lt_max = lt.max()
-    else:
-        lt_min = pd.NaT
-        lt_max = pd.NaT
 
     def first_non_null(series: pd.Series):
         vals = series.dropna()
         return vals.iloc[0] if not vals.empty else np.nan
 
-    def series_aggregate(series: pd.Series, agg_method: str = "median"):
-        """Aggregate a numeric series with NaN handling."""
-        if series is None or len(series.dropna()) == 0:
-            return np.nan
-        if agg_method == "median":
-            return series.median(skipna=True)
-        if agg_method == "mean":
-            return series.mean(skipna=True)
-        raise ValueError(f"Unknown agg_method: {agg_method!r}")
+    data_series = {
+        "ID": group.name,
+        "Lat": first_non_null(group["Lat"]),
+        "Lon": first_non_null(group["Lon"]),
+        "Hgt_m": first_non_null(group["Hgt_m"]),
+        "Datetime": dt.min(),
+        "Enddate_Datetime": dt.max(),
+        "sigZTD": group["sigZTD"].median(),
+        "mean_bias": mean_bias,
+        "sigma_mean_bias": sigma_mean_bias,
+        "sigma_res": np.sqrt(sigma_res_sq)
+        if np.isfinite(sigma_res_sq) else np.nan,
+        "sigma_gnss": np.sqrt(sigma_gnss_sq)
+        if np.isfinite(sigma_gnss_sq) else np.nan,
+        "sigma_model": np.sqrt(sigma_model_sq)
+        if np.isfinite(sigma_model_sq) else np.nan,
+        "n_epochs": n_epochs,
+    }
 
-    return pd.Series(
-        {
-            "ID": group.name,
-            "Lat": first_non_null(group["Lat"]),
-            "Lon": first_non_null(group["Lon"]),
-            "Hgt_m": first_non_null(group["Hgt_m"]),
-            "Datetime": dt.min(),
-            "Enddate_Datetime": dt.max(),
-            "Localtime": lt_min,            # NaT if not present
-            "Enddate_Localtime": lt_max,    # NaT if not present
-            "sigZTD": series_aggregate(group["sigZTD"], "median"),
-            "sigma_res": np.sqrt(sigma_res_sq)
-            if np.isfinite(sigma_res_sq) else np.nan,
-            "sigma_gnss": np.sqrt(sigma_gnss_sq)
-            if np.isfinite(sigma_gnss_sq) else np.nan,
-            "sigma_model": np.sqrt(sigma_model_sq)
-            if np.isfinite(sigma_model_sq) else np.nan,
-            "n_epochs_used": int(valid.sum()),
-        }
-    )
+    # Only parse Localtime if present
+    if has_localtime:
+        lt = pd.to_datetime(
+            group["Localtime"],
+            format="%Y-%m-%d %H:%M:%S",
+            errors="coerce"
+        )
+        data_series.update(
+            {
+                "Localtime": lt.min(),
+                "Enddate_Localtime": lt.max(),
+            }
+        )
+
+    return pd.Series(data_series)
 
 
 def file_choices(p: argparse.ArgumentParser, choices: tuple[str], s: str) -> Path:
@@ -456,6 +475,34 @@ def create_parser() -> argparse.ArgumentParser:
             """),
         default=None,
     )
+
+    p.add_argument(
+        '-oe',
+        '--obs_errlimit',
+        dest='obs_errlimit',
+        help=dedent(
+            """\
+            Observation error threshold for discarding observations
+            with large uncertainties.
+            """
+        ),
+        type=float,
+        default=float('inf'),
+    )
+
+    p.add_argument(
+        '-allownan',
+        '--allow_nan',
+        dest='allow_nan_for_negative',
+        help=dedent(
+            """\
+            If set, return NaN when σ_model² < 0; otherwise clamp to 0.
+            Default is False.
+            """
+        ),
+        action='store_true',
+        default=False,
+    )
     add_verbose(p)
 
     return p
@@ -467,7 +514,9 @@ def main(
     col_name: str='ZTD',
     raider_delay: str='totalDelay',
     out_path: Optional[Path]=None,
-    local_time=None
+    local_time: str=None,
+    obs_errlimit: float=float('inf'),
+    allow_nan_for_negative: bool=False
 ):
     """Merge a combined RAiDER delays file with a GPS ZTD delay file."""
     print(f'Merging delay files {raider_file} and {ztd_file}')
@@ -565,29 +614,44 @@ def main(
     out_path = out_path.with_name(
         f"{out_path.stem}_WM_variance{out_path.suffix}"
     )
+    # filter out obs by error
+    if obs_errlimit != float('inf'):
+        prefilt_len = len(dfc)
+        dfc = dfc[dfc["sigZTD"] <= obs_errlimit]
+        filt_len = len(dfc)
+        errlimit_dropped = prefilt_len - filt_len
+        logger.warning(
+            f"Dropped {errlimit_dropped} observations with sigZTD > input "
+            f"{obs_errlimit} ({filt_len} remaining)."
+        )
 
     dfc_qm = (
         dfc.groupby("ID", dropna=False, sort=True)
         .apply(
             variance_analysis,
-            allow_nan_for_negative=True,
-            has_localtime=has_localtime,
+            allow_nan_for_negative=allow_nan_for_negative,
+            has_localtime=local_time,
             include_groups=False,
         )
         .reset_index(drop=True)
     )
-    del dfc
 
     # Drop all lines with NaNs and duplicates
     n_before = len(dfc_qm)
     dfc_qm.dropna(how="any", inplace=True)
     dfc_qm.drop_duplicates(inplace=True)
-    n_dropped = n_before - len(dfc_qm)
 
-    logger.warning(
-        f"Dropped {n_dropped} stations containing NaN values "
-        f"({len(dfc_qm)} remaining)."
-    )
+    if allow_nan_for_negative:
+        n_flagged = n_before - len(dfc_qm)
+        logger.warning(
+            f"Dropped {n_flagged} stations containing NaN sigma values "
+            f"({len(dfc_qm)} remaining)."
+        )
+    else:
+        n_flagged = (dfc_qm["sigma_model"] == 0).sum()
+        logger.warning(
+            f"{n_flagged}/{len(dfc_qm)} stations contain 0 sigma values."
+        )
 
     dfc_qm.to_csv(
         out_path,


### PR DESCRIPTION
Update building off of [PR 784](https://github.com/dbekaert/RAiDER/pull/784).

Added support in the `raiderCombine.py` workflow to automatically compute and capture within a separate CSV file "*_WM_variance.csv" the uncertainty of the input weather model, defined as `sigma_model = sqrt(sigma_res^2 - sigma_gnss^2)`, where `sigma_res^2=E{(ZTDgnss - ZTDwm)^2}`.  Additional columns for `sigma_res`, `sigma_gnss`, `mean bias`, and `sigma_meanbiass` also passed.

This analysis is done across all time-observations for a given station, so I made some minor adjustments to the statistical analysis call to handle this file appropriately (i.e. avoid averaging in time when the time dimension collapses).

I also include support to remove GNSS stations with sigZTD values above a specified threshold with the `--obs_errlimit` option. This option was originally only supported through `raiderStats.py` on the final CSV file, but not including this option in the `raiderCombine.py` stage would've led to a misleading time-averages as bad stations would get included in the uncertainty calculations.

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
