### PR TITLE
Enhance variance_analysis with global date tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [753](https://github.com/dbekaert/RAiDER/pull/753) - Removed support for ERA-Interim.
 
 ### Changed
+* [788](https://github.com/dbekaert/RAiDER/pull/788) - Streamlined the logic for handling stations where σ_model² < 0, specifically by default such cases are set to nan, but a user may clamp σ_model² to 0 instead by specifying the `--no-allow-nan` for `raiderCombine.py`.
 * [743](https://github.com/dbekaert/RAiDER/pull/743) - Switched from HTTPS to DAP4 for retrieving MERRA2 data, and suppressed a warning for using DAP4 for GMAO data where doing so is not possible.
 
 ### Fixed
@@ -33,6 +34,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [731](https://github.com/dbekaert/RAiDER/pull/731) - Fixed fetch routine for GMAO.
 
 ### Added
+* [788](https://github.com/dbekaert/RAiDER/pull/788) - Updated `variance_analysis` function to include global date tracking parameters and modified datetime handling for station start and end dates.
 * [784](https://github.com/dbekaert/RAiDER/pull/784) - Added support to compute and pass weather model uncertainty in `raiderCombine.py` and `raiderStats.py` workflow.
 * [771](https://github.com/dbekaert/RAiDER/pull/771) - Support in concatenation script to pass wildcard for `--raiderDir` and `--gnssDir` added back in.
 * [762](https://github.com/dbekaert/RAiDER/pull/762) - Added lockfiles through conda-lock to the repo, documentation, and CircleCI runners.

--- a/tools/RAiDER/cli/parser.py
+++ b/tools/RAiDER/cli/parser.py
@@ -37,3 +37,21 @@ def add_bbox(parser: argparse.ArgumentParser) -> None:
         action=BBoxAction,
         metavar=('S', 'N', 'W', 'E'),
     )
+
+
+def add_allow_nan_options(parser: argparse.ArgumentParser) -> None:
+    parser.set_defaults(allow_nan_for_negative=True)
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '--allow-nan',
+        dest='allow_nan_for_negative',
+        action='store_true',
+        help="Return NaN when σ_model² < 0 (default).",
+    )
+    group.add_argument(
+        '--no-allow-nan',
+        dest='allow_nan_for_negative',
+        action='store_false',
+        help="Clamp σ_model² < 0 to 0 instead of returning NaN.",
+    )

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -712,7 +712,7 @@ def main(
         )
 
     # get temporal sampling stats
-    mean_delta_days, mode_delta_days = sampling_delta_stats(df)
+    mean_delta_days, mode_delta_days = sampling_delta_stats(dfc)
 
     logger.warning(
         f"Global mean delta (days): {mean_delta_days} "

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -253,6 +253,60 @@ def readZTDFile(filename, col_name='ZTD'):
     return data
 
 
+def sampling_delta_stats(df: pd.DataFrame) -> tuple[float, float]:
+    """
+    Compute global temporal sampling statistics.
+    Needed to inform temporal sampling overlap percentage.
+
+    For each station ID:
+        * Sort by Datetime.
+        * Compute time differences (days) between consecutive observations.
+
+    Then, over all stations combined:
+        * Compute the mean time difference in days.
+        * Compute the most common time difference (mode) in days.
+
+    Args:
+        df: Dataframe with columns "ID" and "Datetime".
+            "Datetime" must be datetime-like or parseable as datetime.
+
+    Returns:
+        A tuple of:
+            mean_delta_days: float
+                Mean time difference in days.
+            mode_delta_days: float
+                Most common time difference in days (global mode).
+    """
+    # Ensure Datetime is datetime64
+    if not np.issubdtype(df["Datetime"].dtype, np.datetime64):
+        df = df.copy()
+        df["Datetime"] = pd.to_datetime(df["Datetime"], errors="raise")
+
+    # Work on a sorted view to get correct diffs per station
+    df_sorted = df.sort_values(["ID", "Datetime"])
+
+    # Time differences between consecutive observations per station (in days)
+    delta_days = (
+        df_sorted.groupby("ID", sort=False)["Datetime"]
+        .diff()
+        .dt.total_seconds()
+        .div(86400.0)
+    )
+
+    # Drop NaNs from the first diff in each group
+    delta_days = delta_days.dropna()
+
+    if delta_days.empty:
+        return np.nan, np.nan
+
+    mean_delta_days = float(delta_days.mean())
+
+    # Global mode of all deltas
+    mode_delta_days = float(delta_days.mode().iloc[0])
+
+    return mean_delta_days, mode_delta_days
+
+
 def variance_analysis(
     group: pd.DataFrame,
     allow_nan_for_negative: bool = True,
@@ -340,7 +394,7 @@ def variance_analysis(
             )
         sigma_model_sq = (
             np.nan
-            if negative and allow_nan_for_negative
+            if negative_diff and allow_nan_for_negative
             else max(diff, 0.0)
         )
     else:
@@ -657,14 +711,25 @@ def main(
             f"{obs_errlimit} ({filt_len} remaining)."
         )
 
-    # Determine coverage window across all retained observations
+    # get temporal sampling stats
+    mean_delta_days, mode_delta_days = sampling_delta_stats(df)
+
+    logger.warning(
+        f"Global mean delta (days): {mean_delta_days} "
+        f"Global mode delta (days): {mode_delta_days}"
+    )
+
+    # determine coverage window across all retained observations
     df_date = dfc["Datetime"].dt.normalize()
     global_start = df_date.min()
     global_end = df_date.max()
     if pd.isna(global_start) or pd.isna(global_end):
         n_global_days = 0
     else:
-        n_global_days = (global_end - global_start).days + 1
+        n_global_days_total_span = (global_end - global_start).days + 1
+        # capture reference, maximum temporal sampling
+        # using mean time delta of all observations
+        n_global_days = n_global_days_total_span  / int(mean_delta_days)
         logger.warning(
             "The earliest/latest dates found are "
             f"{global_start} & {global_end}, which spans {n_global_days} days"

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -729,10 +729,12 @@ def main(
         n_global_days_total_span = (global_end - global_start).days + 1
         # capture reference, maximum temporal sampling
         # using mean time delta of all observations
-        n_global_days = n_global_days_total_span  / int(mean_delta_days)
+        n_global_days = int(n_global_days_total_span  / mean_delta_days)
         logger.warning(
             "The earliest/latest dates found are "
-            f"{global_start} & {global_end}, which spans {n_global_days} days"
+            f"{global_start} & {global_end} "
+            f"which spans {n_global_days_total_span} days, with"
+            f"an average sampling of {n_global_days} days"
         )
 
     dfc_qm = (

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -321,26 +321,27 @@ def variance_analysis(
         else np.nan
     )
 
+    # Mean bias calculation
+    mean_bias = resid.mean()
+
     # Model variance computation
     if np.isfinite(sigma_res_sq) and np.isfinite(sigma_gnss_sq):
         # σ_wm² = σ_res² - σ_gnss²
         diff = sigma_res_sq - sigma_gnss_sq
-        if diff < 0 and allow_nan_for_negative:
-            sigma_model_sq = np.nan
+        if diff < 0:
             logger.warning(
-                f"Dropped station {group.name} with NaN sigma values, "
+                f"Flagged station {group.name} with negative sigma values, "s
                 f"with mean bias {mean_bias}, mean σ_wm² {diff}, "
                 f"with {n_unique_days} unique days sampled which translates "
                 f"to {coverage_pct}% daily overlap with the "
                 f"input dataset timespan."
             )
-        else:
-            sigma_model_sq = max(diff, 0.0)
+            if allow_nan_for_negative:
+                sigma_model_sq = np.nan
+            else:
+                sigma_model_sq = max(diff, 0.0)
     else:
         sigma_model_sq = np.nan
-
-    # Mean bias calculation
-    mean_bias = resid.mean()
 
     # Uncertainty in mean bias (error propagation)
     if np.isfinite(sigma_model_sq) and len(sig) > 0:

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -328,7 +328,9 @@ def variance_analysis(
     if np.isfinite(sigma_res_sq) and np.isfinite(sigma_gnss_sq):
         # σ_wm² = σ_res² - σ_gnss²
         diff = sigma_res_sq - sigma_gnss_sq
-        if diff < 0:
+        negative_diff = diff < 0
+
+        if negative_diff:
             logger.warning(
                 f"Flagged station {group.name} with negative sigma values, "
                 f"with mean bias {mean_bias}, mean σ_wm² {diff}, "
@@ -336,10 +338,11 @@ def variance_analysis(
                 f"to {coverage_pct}% daily overlap with the "
                 f"input dataset timespan."
             )
-            if allow_nan_for_negative:
-                sigma_model_sq = np.nan
-            else:
-                sigma_model_sq = max(diff, 0.0)
+        sigma_model_sq = (
+            np.nan
+            if negative and allow_nan_for_negative
+            else max(diff, 0.0)
+        )
     else:
         sigma_model_sq = np.nan
 

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -733,7 +733,7 @@ def main(
         logger.warning(
             "The earliest/latest dates found are "
             f"{global_start} & {global_end} "
-            f"which spans {n_global_days_total_span} days, with"
+            f"which spans {n_global_days_total_span} days, with "
             f"an average sampling of {n_global_days} days"
         )
 

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -14,7 +14,7 @@ import pandas as pd
 from tqdm import tqdm
 
 # Local
-from RAiDER.cli.parser import add_verbose
+from RAiDER.cli.parser import add_verbose, add_allow_nan_options
 from RAiDER.logger import logger
 
 
@@ -253,9 +253,14 @@ def readZTDFile(filename, col_name='ZTD'):
     return data
 
 
-def variance_analysis(group: pd.DataFrame,
-                      allow_nan_for_negative: bool = True,
-                      has_localtime: bool = False) -> pd.Series:
+def variance_analysis(
+    group: pd.DataFrame,
+    allow_nan_for_negative: bool = True,
+    has_localtime: bool = False,
+    global_start=None,
+    global_end=None,
+    n_global_days=None,
+) -> pd.Series:
     """
     Compute variance terms and time span for one GNSS station.
 
@@ -264,6 +269,10 @@ def variance_analysis(group: pd.DataFrame,
         allow_nan_for_negative (bool): If True, return NaN when
             σ_wm² < 0; otherwise clamp to 0. Default is True.
         has_localtime (bool): If True, parse and output Localtime fields.
+        global_start/global_end: Earliest/latest dates across the
+            merged dataset, used for percent coverage tracking.
+        n_global_days (int): Total number of unique days between
+            global_start/global_end (inclusive).
 
     Returns:
         pd.Series: Summary statistics for this station.
@@ -273,6 +282,30 @@ def variance_analysis(group: pd.DataFrame,
     resid = group["ZTD_minus_RAiDER"] # also mean(R)
     sig = group["sigZTD"]
     n_epochs = len(resid)
+
+    # Parse datetime ranges
+    dt = pd.to_datetime(group["Datetime"], errors="coerce")
+
+    # Capture number of observations and unique dates
+    unique_dates = (
+        dt.dt.normalize()
+        .dropna()
+        .drop_duplicates()
+        .sort_values()
+    )
+
+    n_unique_days = unique_dates.size
+    if n_unique_days > 0:
+        station_start = unique_dates.iloc[0]
+        station_end = unique_dates.iloc[-1]
+    else:
+        station_start = pd.NaT
+        station_end = pd.NaT
+
+    if n_global_days is not None and n_global_days > 0:
+        coverage_pct = (n_unique_days / n_global_days) * 100.0
+    else:
+        coverage_pct = np.nan
 
     # Mean-squared terms
     # σ_res² = D[r] = E((r - E(r))²)
@@ -312,9 +345,6 @@ def variance_analysis(group: pd.DataFrame,
     else:
         sigma_mean_bias = np.nan
 
-    # Parse datetime ranges
-    dt = pd.to_datetime(group["Datetime"], errors="coerce")
-
     def first_non_null(series: pd.Series):
         vals = series.dropna()
         return vals.iloc[0] if not vals.empty else np.nan
@@ -324,8 +354,8 @@ def variance_analysis(group: pd.DataFrame,
         "Lat": first_non_null(group["Lat"]),
         "Lon": first_non_null(group["Lon"]),
         "Hgt_m": first_non_null(group["Hgt_m"]),
-        "Datetime": dt.min(),
-        "Enddate_Datetime": dt.max(),
+        "Datetime": station_start,
+        "Enddate_Datetime": station_end,
         "sigZTD": group["sigZTD"].median(),
         "mean_bias": mean_bias,
         "sigma_mean_bias": sigma_mean_bias,
@@ -336,6 +366,8 @@ def variance_analysis(group: pd.DataFrame,
         "sigma_model": np.sqrt(sigma_model_sq)
         if np.isfinite(sigma_model_sq) else np.nan,
         "n_epochs": n_epochs,
+        "n_unique_days": n_unique_days,
+        "pct_days_global": coverage_pct,
     }
 
     # Only parse Localtime if present
@@ -490,19 +522,8 @@ def create_parser() -> argparse.ArgumentParser:
         default=float('inf'),
     )
 
-    p.add_argument(
-        '-allownan',
-        '--allow_nan',
-        dest='allow_nan_for_negative',
-        help=dedent(
-            """\
-            If set, return NaN when σ_model² < 0; otherwise clamp to 0.
-            Default is True.
-            """
-        ),
-        action='store_true',
-        default=True,
-    )
+    # add other args to parser
+    add_allow_nan_options(p)
     add_verbose(p)
 
     return p
@@ -625,12 +646,28 @@ def main(
             f"{obs_errlimit} ({filt_len} remaining)."
         )
 
+    # Determine coverage window across all retained observations
+    df_date = dfc["Datetime"].dt.normalize()
+    global_start = df_date.min()
+    global_end = df_date.max()
+    if pd.isna(global_start) or pd.isna(global_end):
+        n_global_days = 0
+    else:
+        n_global_days = (global_end - global_start).days + 1
+        logger.warning(
+            "The earliest/latest dates found are "
+            f"{global_start} & {global_end}, which spans {n_global_days} days"
+        )
+
     dfc_qm = (
         dfc.groupby("ID", dropna=False, sort=True)
         .apply(
             variance_analysis,
             allow_nan_for_negative=allow_nan_for_negative,
-            has_localtime=local_time,
+            has_localtime=has_localtime,
+            global_start=global_start,
+            global_end=global_end,
+            n_global_days=n_global_days,
             include_groups=False,
         )
         .reset_index(drop=True)

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -327,6 +327,13 @@ def variance_analysis(
         diff = sigma_res_sq - sigma_gnss_sq
         if diff < 0 and allow_nan_for_negative:
             sigma_model_sq = np.nan
+            logger.warning(
+                f"Dropped station {group.name} with NaN sigma values, "
+                f"with mean bias {mean_bias}, mean σ_wm² {diff}, "
+                f"with {n_unique_days} unique days sampled which translates "
+                f"to {coverage_pct}% daily overlap with the "
+                f"input dataset timespan."
+            )
         else:
             sigma_model_sq = max(diff, 0.0)
     else:

--- a/tools/RAiDER/gnss/processDelayFiles.py
+++ b/tools/RAiDER/gnss/processDelayFiles.py
@@ -330,7 +330,7 @@ def variance_analysis(
         diff = sigma_res_sq - sigma_gnss_sq
         if diff < 0:
             logger.warning(
-                f"Flagged station {group.name} with negative sigma values, "s
+                f"Flagged station {group.name} with negative sigma values, "
                 f"with mean bias {mean_bias}, mean σ_wm² {diff}, "
                 f"with {n_unique_days} unique days sampled which translates "
                 f"to {coverage_pct}% daily overlap with the "


### PR DESCRIPTION
Updated `variance_analysis` function to include global date tracking parameters and modified datetime handling for station start and end dates.

This can be used to better understand the temporal sampling of observations and inform analyses.

I also streamlined the logic for handling stations where σ_model² < 0, specifically by default such cases are set to nan, but a user may clamp σ_model² to 0 instead by specifying the `--no-allow-nan` for `raiderCombine.py`.

## Screenshots (if appropriate):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
