### PR TITLE
Use memory efficiently, GNSS geometric heights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ orbits/
 /GUNW*.yaml
 /*.tif
 .coverage*
+TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changedp
+* [795](https://github.com/dbekaert/RAiDER/pull/795) - use xarray.open_dataset instead of load_dataset for memory efficiency. Also convert GNSS heights to geoid instead of native ellipsoid for increased accuracy when intersecting with the weather model cube
+
 ## [0.6.0]
 ### Removed
 * [764](https://github.com/dbekaert/RAiDER/pull/764) - Removed Python 3.8 support. Python 3.9 is now the minimum version officially required to run RAiDER.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     long: mark a test as a long
+    network: mark a test as requiring external network access (e.g. PROJ CDN for EGM96 grids)

--- a/test/test_llreader.py
+++ b/test/test_llreader.py
@@ -1,9 +1,12 @@
+import logging
 import os
 from pathlib import Path
 import pytest
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pyproj
 
 from test import GEOM_DIR, TEST_DIR
 from pyproj import CRS
@@ -12,7 +15,8 @@ from RAiDER.cli.raider import calcDelays
 
 from RAiDER.utilFcns import rio_open
 from RAiDER.llreader import (
-    StationFile, RasterRDR, BoundingBox, GeocodedFile, bounds_from_latlon_rasters, bounds_from_csv
+    StationFile, RasterRDR, BoundingBox, GeocodedFile, bounds_from_latlon_rasters,
+    bounds_from_csv, _parse_crs, _ellipsoidal_to_geometric,
 )
 
 SCENARIO0_DIR = TEST_DIR / "scenario_0"
@@ -147,3 +151,285 @@ def test_GeocodedFile():
     x,y = aoi.readLL()
     assert z.shape == (569,558)
     assert x.shape == z.shape
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared by CRS / geoid tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_station_file(tmp_path):
+    """Three-station CSV with known ellipsoidal heights across CONUS latitudes."""
+    csv = tmp_path / 'stations.csv'
+    csv.write_text(
+        'ID,Lat,Lon,Hgt_m\n'
+        'STA1,34.0,-118.0,50.0\n'
+        'STA2,36.0,-115.0,150.0\n'
+        'STA3,49.0,-122.0,195.28\n'
+    )
+    return csv
+
+
+@pytest.fixture
+def conus_lats():
+    return np.array([34.0, 36.0, 49.0])
+
+
+@pytest.fixture
+def conus_lons():
+    return np.array([-118.0, -115.0, -122.0])
+
+
+@pytest.fixture
+def conus_heights():
+    return np.array([50.0, 150.0, 195.28])
+
+
+# ---------------------------------------------------------------------------
+# _parse_crs
+# ---------------------------------------------------------------------------
+
+def test_parse_crs_int():
+    assert _parse_crs(4326).to_epsg() == 4326
+
+
+def test_parse_crs_string_bare():
+    assert _parse_crs('4979').to_epsg() == 4979
+
+
+def test_parse_crs_string_with_prefix():
+    assert _parse_crs('EPSG:4979').to_epsg() == 4979
+
+
+def test_parse_crs_crs_object_is_identity():
+    """Passing a CRS object should return the same object unchanged."""
+    src = CRS.from_epsg(32631)
+    assert _parse_crs(src) is src
+
+
+def test_parse_crs_invalid_raises():
+    with pytest.raises(Exception):
+        _parse_crs('definitely_not_a_crs')
+
+
+# ---------------------------------------------------------------------------
+# _ellipsoidal_to_geometric – unit tests (no network required)
+# ---------------------------------------------------------------------------
+
+def test_ellipsoidal_to_geometric_2d_crs_is_noop(conus_lats, conus_lons, conus_heights):
+    """A 2D CRS (EPSG:4326) must return heights unchanged without touching PROJ."""
+    result = _ellipsoidal_to_geometric(
+        conus_lats, conus_lons, conus_heights, CRS.from_epsg(4326)
+    )
+    assert np.array_equal(result, conus_heights)
+
+
+def test_ellipsoidal_to_geometric_cdn_fallback_applied(
+    conus_lats, conus_lons, conus_heights, monkeypatch
+):
+    """Noop local grid → CDN enabled → real corrections applied."""
+    correction = np.full_like(conus_heights, 20.0)
+    h_expected = conus_heights + correction
+    call_count = {'n': 0}
+
+    def mock_from_crs(*args, **kwargs):
+        call_count['n'] += 1
+        t = MagicMock()
+        if call_count['n'] == 1:       # first build: local grid missing → noop
+            t.to_proj4.return_value = '+proj=noop'
+            t.transform.return_value = (conus_lons, conus_lats, conus_heights.copy())
+        else:                           # second build: after CDN enabled → real grid
+            t.to_proj4.return_value = None
+            t.transform.return_value = (conus_lons, conus_lats, h_expected.copy())
+        return t
+
+    enabled_states = []
+    monkeypatch.setattr(pyproj.Transformer, 'from_crs', mock_from_crs)
+    monkeypatch.setattr(pyproj.network, 'is_network_enabled', lambda: False)
+    monkeypatch.setattr(pyproj.network, 'set_network_enabled',
+                        lambda v: enabled_states.append(v))
+
+    result = _ellipsoidal_to_geometric(
+        conus_lats, conus_lons, conus_heights, CRS.from_epsg(4979)
+    )
+
+    assert np.allclose(result, h_expected)
+    assert call_count['n'] == 2, 'Transformer should be built twice (local then CDN)'
+    assert True in enabled_states, 'CDN should have been enabled'
+    assert False in enabled_states, 'CDN state should have been restored'
+
+
+def test_ellipsoidal_to_geometric_cdn_also_noop_warns(
+    conus_lats, conus_lons, conus_heights, monkeypatch, caplog
+):
+    """When CDN is also unavailable (still noop), return heights with a warning."""
+    noop_mock = MagicMock()
+    noop_mock.to_proj4.return_value = '+proj=noop'
+    noop_mock.transform.return_value = (conus_lons, conus_lats, conus_heights.copy())
+
+    monkeypatch.setattr(pyproj.Transformer, 'from_crs', lambda *a, **kw: noop_mock)
+    monkeypatch.setattr(pyproj.network, 'is_network_enabled', lambda: False)
+    monkeypatch.setattr(pyproj.network, 'set_network_enabled', lambda v: None)
+
+    with caplog.at_level(logging.WARNING, logger='RAiDER'):
+        result = _ellipsoidal_to_geometric(
+            conus_lats, conus_lons, conus_heights, CRS.from_epsg(4979)
+        )
+
+    assert np.array_equal(result, conus_heights)
+    assert 'EGM96 grid unavailable' in caplog.text
+
+
+def test_ellipsoidal_to_geometric_exception_returns_unchanged(
+    conus_lats, conus_lons, conus_heights, monkeypatch, caplog
+):
+    """An unexpected PROJ exception must return heights unchanged with a warning."""
+    def raising(*args, **kwargs):
+        raise RuntimeError('simulated PROJ error')
+
+    monkeypatch.setattr(pyproj.Transformer, 'from_crs', raising)
+
+    with caplog.at_level(logging.WARNING, logger='RAiDER'):
+        result = _ellipsoidal_to_geometric(
+            conus_lats, conus_lons, conus_heights, CRS.from_epsg(4979)
+        )
+
+    assert np.array_equal(result, conus_heights)
+    assert 'conversion failed' in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# _ellipsoidal_to_geometric – integration test (requires PROJ CDN or local grids)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.network
+def test_ellipsoidal_to_geometric_egm96_conus_values(
+    conus_lats, conus_lons, conus_heights
+):
+    """EGM96 orthometric heights in CONUS are 10–45 m larger than WGS84 ellipsoidal."""
+    result = _ellipsoidal_to_geometric(
+        conus_lats, conus_lons, conus_heights, CRS.from_epsg(4979)
+    )
+    corrections = result - conus_heights
+    # EGM96 geoid is 15–35 m below the WGS84 ellipsoid in CONUS, so
+    # orthometric heights are larger than ellipsoidal heights.
+    assert np.all(corrections > 10), f'Expected >10 m corrections; got {corrections}'
+    assert np.all(corrections < 45), f'Expected <45 m corrections; got {corrections}'
+
+
+# ---------------------------------------------------------------------------
+# StationFile – crs parameter and update_crs method
+# ---------------------------------------------------------------------------
+
+def test_station_file_default_crs_is_4326(tmp_station_file):
+    sf = StationFile(tmp_station_file)
+    assert sf._crs.to_epsg() == 4326
+
+
+def test_station_file_crs_int(tmp_station_file):
+    sf = StationFile(tmp_station_file, crs=4979)
+    assert sf._crs.to_epsg() == 4979
+
+
+def test_station_file_crs_string(tmp_station_file):
+    sf = StationFile(tmp_station_file, crs='4979')
+    assert sf._crs.to_epsg() == 4979
+
+
+def test_station_file_crs_epsg_string(tmp_station_file):
+    sf = StationFile(tmp_station_file, crs='EPSG:4979')
+    assert sf._crs.to_epsg() == 4979
+
+
+def test_station_file_crs_object(tmp_station_file):
+    crs = CRS.from_epsg(4979)
+    sf = StationFile(tmp_station_file, crs=crs)
+    assert sf._crs.to_epsg() == 4979
+
+
+def test_update_crs_changes_datum(tmp_station_file):
+    sf = StationFile(tmp_station_file)
+    assert sf._crs.to_epsg() == 4326
+    sf.update_crs(4979)
+    assert sf._crs.to_epsg() == 4979
+
+
+def test_update_crs_string_input(tmp_station_file):
+    sf = StationFile(tmp_station_file)
+    sf.update_crs('EPSG:4979')
+    assert sf._crs.to_epsg() == 4979
+
+
+def test_update_crs_crs_object(tmp_station_file):
+    sf = StationFile(tmp_station_file)
+    sf.update_crs(CRS.from_epsg(4979))
+    assert sf._crs.to_epsg() == 4979
+
+
+# ---------------------------------------------------------------------------
+# StationFile.readZ – height conversion plumbing
+# ---------------------------------------------------------------------------
+
+def test_readZ_default_crs_heights_unchanged(tmp_station_file):
+    """crs=4326 must return Hgt_m values from the CSV unmodified."""
+    z = StationFile(tmp_station_file).readZ()
+    assert np.allclose(z, [50.0, 150.0, 195.28])
+
+
+def test_readZ_3d_crs_calls_conversion(tmp_station_file, monkeypatch):
+    """crs=4979 must route Hgt_m through _ellipsoidal_to_geometric."""
+    import RAiDER.llreader as lr
+
+    captured = {}
+
+    def mock_convert(lats, lons, heights, crs):
+        captured['heights'] = heights.copy()
+        captured['crs_epsg'] = crs.to_epsg()
+        return heights + 25.0
+
+    monkeypatch.setattr(lr, '_ellipsoidal_to_geometric', mock_convert)
+
+    z = StationFile(tmp_station_file, crs=4979).readZ()
+
+    assert captured['crs_epsg'] == 4979
+    assert np.allclose(captured['heights'], [50.0, 150.0, 195.28])
+    assert np.allclose(z, [75.0, 175.0, 220.28])
+
+
+def test_readZ_update_crs_uses_new_datum(tmp_station_file, monkeypatch):
+    """update_crs before readZ must pass the updated CRS to the conversion."""
+    import RAiDER.llreader as lr
+
+    captured_epsg = []
+
+    def mock_convert(lats, lons, heights, crs):
+        captured_epsg.append(crs.to_epsg())
+        return heights
+
+    monkeypatch.setattr(lr, '_ellipsoidal_to_geometric', mock_convert)
+
+    sf = StationFile(tmp_station_file)   # default 4326
+    sf.update_crs(4979)
+    sf.readZ()
+
+    assert captured_epsg == [4979]
+
+
+def test_readZ_2d_crs_conversion_is_noop(tmp_station_file, monkeypatch):
+    """_ellipsoidal_to_geometric is still called for 2D CRS but returns heights unchanged."""
+    import RAiDER.llreader as lr
+
+    call_count = {'n': 0}
+
+    def mock_convert(lats, lons, heights, crs):
+        call_count['n'] += 1
+        # The function itself handles the 2D noop, but verify it receives crs=4326
+        assert crs.to_epsg() == 4326
+        return heights  # same as real behaviour for 2D
+
+    monkeypatch.setattr(lr, '_ellipsoidal_to_geometric', mock_convert)
+
+    z = StationFile(tmp_station_file).readZ()
+
+    assert call_count['n'] == 1
+    assert np.allclose(z, [50.0, 150.0, 195.28])

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -814,41 +814,45 @@ def combine_weather_files(wfiles: list[Path], time: dt.datetime, model: str, int
     # read the individual datetime datasets
     datasets = [xr.open_dataset(f) for f in wfiles]
 
-    # Pull the datetimes from the datasets
-    times: list[dt.datetime] = []
-    for ds in datasets:
-        times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
+    try:
+        # Pull the datetimes from the datasets
+        times: list[dt.datetime] = []
+        for ds in datasets:
+            times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
 
-    if len(times) == 0:
-        raise NoWeatherModelData()
+        if len(times) == 0:
+            raise NoWeatherModelData()
 
-    # calculate relative weights of each dataset
-    if interp_method == 'center_time':
-        wgts = get_weights_time_interp(times, time)
-    elif interp_method == 'azimuth_time_grid':
-        time_grid = get_time_grid_for_aztime_interp(datasets, time, model)
-        wgts = get_inverse_weights_for_dates(time_grid, times)
-    else:  # interp_method == 'none'
-        raise ValueError('Interpolating weather files is not available with interpolation method "none"')
+        # calculate relative weights of each dataset
+        if interp_method == 'center_time':
+            wgts = get_weights_time_interp(times, time)
+        elif interp_method == 'azimuth_time_grid':
+            time_grid = get_time_grid_for_aztime_interp(datasets, time, model)
+            wgts = get_inverse_weights_for_dates(time_grid, times)
+        else:  # interp_method == 'none'
+            raise ValueError('Interpolating weather files is not available with interpolation method "none"')
 
-    # combine datasets
-    ds_out = datasets[0]
-    for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
-        ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
-    ds_out.attrs['Date1'] = 0
-    ds_out.attrs['Date2'] = 0
+        # combine datasets
+        ds_out = datasets[0]
+        for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
+            ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
+        ds_out.attrs['Date1'] = 0
+        ds_out.attrs['Date2'] = 0
 
-    # Give the weighted combination a new file name
-    weather_model_file = wfiles[0].parent / (
-        wfiles[0].name.split('_')[0]
-        + '_'
-        + time.strftime('%Y_%m_%dT%H_%M_%S')
-        + STYLE[interp_method]
-        + '_'.join(wfiles[0].name.split('_')[-4:])
-    )
+        # Give the weighted combination a new file name
+        weather_model_file = wfiles[0].parent / (
+            wfiles[0].name.split('_')[0]
+            + '_'
+            + time.strftime('%Y_%m_%dT%H_%M_%S')
+            + STYLE[interp_method]
+            + '_'.join(wfiles[0].name.split('_')[-4:])
+        )
 
-    # write the combined results to disk
-    ds_out.to_netcdf(weather_model_file)
+        # write the combined results to disk (must happen before closing datasets)
+        ds_out.to_netcdf(weather_model_file)
+    finally:
+        for ds in datasets:
+            ds.close()
 
     return weather_model_file
 
@@ -858,36 +862,40 @@ def combine_files_using_azimuth_time(wfiles, time: dt.datetime, times: list[dt.d
     # read the individual datetime datasets
     datasets = [xr.open_dataset(f) for f in wfiles]
 
-    # Pull the datetimes from the datasets
-    times: list[dt.datetime] = []
-    for ds in datasets:
-        times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
+    try:
+        # Pull the datetimes from the datasets
+        times: list[dt.datetime] = []
+        for ds in datasets:
+            times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
 
-    model = datasets[0].attrs['model_name']
+        model = datasets[0].attrs['model_name']
 
-    time_grid = get_time_grid_for_aztime_interp(datasets, times, time, model)
+        time_grid = get_time_grid_for_aztime_interp(datasets, times, time, model)
 
-    wgts = get_inverse_weights_for_dates(time_grid, times)
+        wgts = get_inverse_weights_for_dates(time_grid, times)
 
-    # combine datasets
-    ds_out = datasets[0]
-    for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
-        ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
-    ds_out.attrs['Date1'] = 0
-    ds_out.attrs['Date2'] = 0
+        # combine datasets
+        ds_out = datasets[0]
+        for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
+            ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
+        ds_out.attrs['Date1'] = 0
+        ds_out.attrs['Date2'] = 0
 
-    # Give the weighted combination a new file name
-    weather_model_file = os.path.join(
-        os.path.dirname(wfiles[0]),
-        os.path.basename(wfiles[0]).split('_')[0]
-        + '_'
-        + time.strftime('%Y_%m_%dT%H_%M_%S')
-        + '_timeInterpAziGrid_'
-        + '_'.join(wfiles[0].split('_')[-4:]),
-    )
+        # Give the weighted combination a new file name
+        weather_model_file = os.path.join(
+            os.path.dirname(wfiles[0]),
+            os.path.basename(wfiles[0]).split('_')[0]
+            + '_'
+            + time.strftime('%Y_%m_%dT%H_%M_%S')
+            + '_timeInterpAziGrid_'
+            + '_'.join(wfiles[0].split('_')[-4:]),
+        )
 
-    # write the combined results to disk
-    ds_out.to_netcdf(weather_model_file)
+        # write the combined results to disk (must happen before closing datasets)
+        ds_out.to_netcdf(weather_model_file)
+    finally:
+        for ds in datasets:
+            ds.close()
 
     return weather_model_file
 

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -62,8 +62,8 @@ def tropo_delay(
     """
     crs = CRS(out_proj)
 
-    # Load CRS from weather model file
-    with xr.load_dataset(weather_model_file) as ds:
+    # Load CRS and heights from weather model file (single open)
+    with xr.open_dataset(weather_model_file) as ds:
         try:
             wm_proj = CRS.from_wkt(ds['proj'].attrs['crs_wkt'])
         except KeyError:
@@ -71,9 +71,6 @@ def tropo_delay(
                 "WARNING: I can't find a CRS in the weather model file, so I will assume you are using WGS84"
             )
             wm_proj = CRS.from_epsg(4326)
-
-    # get heights
-    with xr.load_dataset(weather_model_file) as ds:
         wm_levels = ds.z.values
         toa = wm_levels.max() - 1
 
@@ -137,7 +134,7 @@ def _get_delays_on_cube(datetime: dt.datetime, weather_model_file, wm_proj, aoi,
     try:
         aoi.xpts
     except AttributeError:
-        with xr.load_dataset(weather_model_file) as ds:
+        with xr.open_dataset(weather_model_file) as ds:
             x_spacing = ds.x.diff(dim='x').values.mean()
             y_spacing = ds.y.diff(dim='y').values.mean()
         aoi.set_output_spacing(ll_res=np.min([x_spacing, y_spacing]))

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -28,17 +28,22 @@ def getInterpolators(wm_file: Union[xr.Dataset, Path, str], kind: str='pointwise
     The interpolator grid is (y, x, z)
     """
     # Get the weather model data
-    ds = wm_file if isinstance(wm_file, xr.Dataset) else xr.load_dataset(wm_file)
+    _close_ds = not isinstance(wm_file, xr.Dataset)
+    ds = wm_file if isinstance(wm_file, xr.Dataset) else xr.open_dataset(wm_file)
 
-    xs_wm = np.array(ds.variables['x'][:])
-    ys_wm = np.array(ds.variables['y'][:])
-    zs_wm = np.array(ds.variables['z'][:])
+    try:
+        xs_wm = np.array(ds.variables['x'][:])
+        ys_wm = np.array(ds.variables['y'][:])
+        zs_wm = np.array(ds.variables['z'][:])
 
-    wet = ds.variables['wet_total' if kind == 'total' else 'wet'][:]
-    hydro = ds.variables['hydro_total' if kind == 'total' else 'hydro'][:]
+        wet = ds.variables['wet_total' if kind == 'total' else 'wet'][:]
+        hydro = ds.variables['hydro_total' if kind == 'total' else 'hydro'][:]
 
-    wet = np.array(wet).transpose(1, 2, 0)
-    hydro = np.array(hydro).transpose(1, 2, 0)
+        wet = np.array(wet).transpose(1, 2, 0)
+        hydro = np.array(hydro).transpose(1, 2, 0)
+    finally:
+        if _close_ds:
+            ds.close()
 
     if np.any(np.isnan(wet)) or np.any(np.isnan(hydro)):
         logger.critical('Weather model contains NaNs!')

--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -191,15 +191,138 @@ class AOI:
         self.ypts = np.arange(out_snwe[1], out_snwe[0] - out_spacing, -out_spacing)
 
 
-class StationFile(AOI):
-    """Use a .csv file containing at least Lat, Lon, and optionally Hgt_m columns."""
+def _parse_crs(crs: Union[int, str, CRS]) -> CRS:
+    """Parse an EPSG code (int or str), CRS string, or CRS object into a pyproj CRS."""
+    if isinstance(crs, CRS):
+        return crs
+    try:
+        return CRS.from_epsg(crs)
+    except pyproj.exceptions.CRSError:
+        return CRS(crs)
 
-    def __init__(self, station_file, demFile=None, cube_spacing_in_m: Optional[float]=None, output_directory=os.getcwd()) -> None:
+
+def _ellipsoidal_to_geometric(
+    lats: np.ndarray,
+    lons: np.ndarray,
+    heights: np.ndarray,
+    crs: CRS,
+) -> np.ndarray:
+    """Convert heights from ellipsoidal to geometric (geoid-referenced) if needed.
+
+    ERA5 geopotential heights are referenced to the geoid (mean sea level).
+    GNSS-derived station heights (e.g. from UNR MAGNET in IGS20) are ellipsoidal
+    heights above the WGS84 ellipsoid.  In CONUS the geoid sits ~15–35 m below
+    the ellipsoid, so sampling the RAiDER cube with uncorrected GNSS heights
+    places the integration surface too low by that amount, causing a ~5–9 mm
+    positive ZTD bias.
+
+    Conversion targets EPSG:9707 (WGS 84 + EGM96 height).  PROJ requires the
+    EGM96 geoid grid, which ships with the ``proj-data`` conda package.  If the
+    grid is absent locally the function transparently enables the PROJ CDN for a
+    one-time download and then restores the previous network state.  If the
+    download also fails, input heights are returned unchanged with a warning.
+
+    Args:
+        lats:    station latitudes in degrees
+        lons:    station longitudes in degrees
+        heights: station heights in the coordinate system described by ``crs``
+        crs:     pyproj CRS describing the input height datum
+
+    Returns:
+        heights above the EGM96 geoid (~MSL / orthometric),
+        or the input heights unchanged if the CRS has no 3D ellipsoidal vertical.
+    """
+    # A 2D CRS (e.g. EPSG:4326) carries no vertical datum — return unchanged.
+    if len(crs.axis_info) < 3:
+        return heights
+
+    _TARGET = CRS.from_epsg(9707)  # WGS 84 + EGM96 height
+
+    def _build_and_apply() -> tuple:
+        """Return (transformer, converted_heights)."""
+        from pyproj import Transformer
+        t = Transformer.from_crs(crs, _TARGET, always_xy=True)
+        _, _, h = t.transform(lons, lats, heights)
+        return t, h
+
+    try:
+        t, h_geoid = _build_and_apply()
+
+        # PROJ silently falls back to a noop when the EGM96 grid is missing.
+        # Detect this by inspecting the WKT pipeline string.
+        # to_proj4() returns '+proj=noop' when PROJ fell back to a no-op
+        # because the EGM96 grid is absent.  A real geoid transform returns
+        # None (it is too complex to express as a PROJ4 string).
+        if t.to_proj4() == '+proj=noop':
+            logger.info(
+                'EGM96 geoid grid not found locally; attempting download from '
+                'the PROJ CDN.  Install the proj-data conda package for fully '
+                'offline use.'
+            )
+            _was_enabled = pyproj.network.is_network_enabled()
+            pyproj.network.set_network_enabled(True)
+            try:
+                t, h_geoid = _build_and_apply()
+                if t.to_proj4() == '+proj=noop':
+                    logger.warning(
+                        'EGM96 grid unavailable (no local data and CDN '
+                        'unreachable); ellipsoidal heights used unchanged.'
+                    )
+                    return heights
+            finally:
+                pyproj.network.set_network_enabled(_was_enabled)
+
+        logger.debug(
+            'Converted ellipsoidal heights to EGM96 geoid heights; '
+            'mean geoid undulation applied: %.2f m',
+            float(np.nanmean(h_geoid - heights)),
+        )
+        return h_geoid
+
+    except Exception as exc:
+        logger.warning(
+            'Ellipsoidal-to-geoid height conversion failed (%s); '
+            'using input heights unchanged.  '
+            'Ensure proj-data grids are installed for accurate results.',
+            exc,
+        )
+        return heights
+
+
+class StationFile(AOI):
+    """Use a .csv file containing at least Lat, Lon, and optionally Hgt_m columns.
+
+    By default heights are assumed to be already geoid-referenced (MSL), matching
+    the ERA5 z-axis convention (``crs=4326``).  Pass ``crs=4979`` when the file
+    contains WGS84 ellipsoidal heights (e.g. from UNR MAGNET / IGS20) so that
+    they are automatically converted to geoid heights before the weather model
+    cube is sampled.
+    """
+
+    def __init__(
+        self,
+        station_file: Union[str, Path],
+        demFile: Optional[Union[str, Path]] = None,
+        cube_spacing_in_m: Optional[float] = None,
+        output_directory: Union[str, Path] = Path.cwd(),
+        crs: Union[int, str, CRS] = 4326,
+    ) -> None:
         super().__init__(cube_spacing_in_m, output_directory)
         self._filename = station_file
         self._demfile = demFile
         self._bounding_box = bounds_from_csv(station_file)
         self._type = 'station_file'
+        self._crs = _parse_crs(crs)
+
+    def update_crs(self, new_crs: Union[int, str, CRS]) -> None:
+        """Update the CRS describing the height datum of the station file.
+
+        Args:
+            new_crs: EPSG code (int or str), CRS string, or pyproj CRS object.
+                     ``4326`` (default) — heights are geoid-referenced (MSL).
+                     ``4979`` — heights are WGS84 ellipsoidal (e.g. from GNSS/UNR).
+        """
+        self._crs = _parse_crs(new_crs)
 
     def readLL(self) -> tuple[np.ndarray, np.ndarray]:
         """Read the station lat/lons from the csv file."""
@@ -207,12 +330,21 @@ class StationFile(AOI):
         return df['Lat'].to_numpy(), df['Lon'].to_numpy()
 
     def readZ(self):
-        """Read the station heights from the file, or download a DEM if not present."""
+        """Read station heights, converting to geoid heights if the CRS is 3D ellipsoidal.
+
+        When constructed with ``crs=4979`` (or any 3D CRS with an ellipsoidal
+        vertical), heights are converted from WGS84 ellipsoidal to EGM96 geoid
+        heights so they are consistent with the ERA5 z-axis reference.
+        DEM-derived heights are already MSL and are never converted.
+        """
         df = pd.read_csv(self._filename).drop_duplicates(subset=['Lat', 'Lon'])
         if 'Hgt_m' in df.columns:
-            return df['Hgt_m'].values
+            heights = df['Hgt_m'].values
+            return _ellipsoidal_to_geometric(
+                df['Lat'].values, df['Lon'].values, heights, self._crs
+            )
         else:
-            # Download the DEM
+            # Download the DEM (DEM heights are MSL; no conversion needed)
             from RAiDER.dem import download_dem
             from RAiDER.interpolator import interpolateDEM
 

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -134,10 +133,11 @@ class ECMWF(WeatherModel):
 
         with tempfile.TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
-            out_path_lnsp_z = temp_dir / f'{out_path.stem}_lnsp_z'
-            out_path_t_q = temp_dir / f'{out_path.stem}_t_q'
+            out_path_combined = temp_dir / f'{out_path.stem}_combined'
 
             # Developed from https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5
+            # All four variables are fetched in a single CDS request to halve queue wait time.
+            # lnsp and z are surface-only fields; t and q span all model levels.
             params = {
                 'class': 'ea',
                 'expver': '1',
@@ -153,51 +153,32 @@ class ECMWF(WeatherModel):
                 'area': [lat_max, lon_min, lat_min, lon_max],
                 'grid': [0.25, 0.25],
                 'format': 'netcdf',
+                'param': ['lnsp', 'z', 'q', 't'],
             }
-            # Make two separate requests: one for lnsp and z, and the other for t and q.
-            params['param'] = ['lnsp', 'z']
-            c.retrieve('reanalysis-era5-complete', params, out_path_lnsp_z)
-            params['param'] = ['q', 't']
-            c.retrieve('reanalysis-era5-complete', params, out_path_t_q)
+            c.retrieve('reanalysis-era5-complete', params, out_path_combined)
 
-            # RAiDER requires z data for all levels, but ERA-5 only provides it for
-            # the surface level. z can be computed for all levels using lnsp, t, and
-            # q, so that is what we will do.
-            # We will use the t/q dataset as a base to make a full dataset with
-            # lnsp, t, and q, and full z data.
-            shutil.copy(out_path_t_q, out_path)
-
-            with xr.open_dataset(out_path_lnsp_z) as ds_lnsp_z, xr.open_dataset(out_path_t_q) as ds_t_q:
-                # Compute full z
+            with xr.open_dataset(out_path_combined) as ds:
+                # ERA-5 only provides z at the surface level; compute it at all
+                # model levels from lnsp, t, and q via the hypsometric equation.
+                # .squeeze() removes the size-1 time (and level, for lnsp/z) dims,
+                # since calcgeoh expects (level, lat, lon) or (lat, lon) arrays.
                 z_full, _, _ = util.calcgeoh(
-                    # .squeeze(): data comes in with dimensions:
-                    # (valid time, model level, latitude, longitude),
-                    # and we need it in:
-                    # (model level, latitude, longitude),
-                    # and there is always exactly one valid time
-                    # (i.e., shape is always (1, ..., ..., ...)).
-                    lnsp=ds_lnsp_z['lnsp'].values.squeeze(),
-                    z_surface=ds_lnsp_z['z'].values.squeeze(),
-                    t=ds_t_q['t'].values.squeeze(),
-                    q=ds_t_q['q'].values.squeeze(),
+                    lnsp=ds['lnsp'].values.squeeze(),
+                    z_surface=ds['z'].values.squeeze(),
+                    t=ds['t'].values.squeeze(),
+                    q=ds['q'].values.squeeze(),
                     a=self._a,
                     b=self._b,
                     num_levels=self._levels,
                     R_d=self._R_d,
                 )
-                # Add the full z cube to the output dataset.
-                ds_out = ds_t_q.assign(
+                # Replace the surface-only z with the full model-level z cube,
+                # broadcast to match t's (time, level, lat, lon) dimensions.
+                ds_out = ds.assign(
                     z=xr.Variable(
-                        # Copy over t's dimensions as z's.
-                        # Could also have used q; all three are the same.
-                        dims=ds_t_q['t'].dims,
-                        # Present z_full as though it were wrapped in an array to
-                        # match the shape of the rest of the data.
+                        dims=ds['t'].dims,
                         data=np.broadcast_to(z_full, (1, *z_full.shape)),
                     ),
-                    # To fit the shape of the rest of the dataset, this is NaN on
-                    # every level but the first (the surface).
-                    lnsp=ds_lnsp_z['lnsp'],
                 )
                 ds_out.to_netcdf(out_path)
 

--- a/tools/RAiDER/models/merra2.py
+++ b/tools/RAiDER/models/merra2.py
@@ -136,13 +136,13 @@ class MERRA2(WeatherModel):
     def _load_model_level(self, filename) -> None:
         """Get the variables from the GMAO link using OpenDAP."""
         # adding the import here should become absolute when transition to netcdf
-        ds = xr.load_dataset(filename)
-        lons = ds['longitude'].values
-        lats = ds['latitude'].values
-        h = ds['h'].values
-        q = ds['q'].values
-        p = ds['p'].values
-        t = ds['t'].values
+        with xr.open_dataset(filename) as ds:
+            lons = ds['longitude'].values
+            lats = ds['latitude'].values
+            h = ds['h'].values
+            q = ds['q'].values
+            p = ds['p'].values
+            t = ds['t'].values
 
         # Re-structure everything from (heights, lats, lons) to (lons, lats, heights)
         p = np.transpose(p)

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -451,7 +451,7 @@ class WeatherModel(ABC):
             if not Path.exists(Path(path_weather_model)):
                 raise ValueError('Need to save cropped weather model as netcdf')
 
-            with xr.load_dataset(path_weather_model) as ds:
+            with xr.open_dataset(path_weather_model) as ds:
                 try:
                     xmin, xmax = ds.x.min(), ds.x.max()
                     ymin, ymax = ds.y.min(), ds.y.max()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
xarray makes available two methods for opening datasets, open_dataset and load_dataset. Using open_dataset allows for lazy loading and memory efficiency. This PR change all the locations were `load_dataset` was used to `open_dataset', resulting in much better memory performance for RAiDER. This PR also wraps netcdf dataset opening with try/except/finally logic that ensures the datasets are closed properly. 

In addition, the CDS API call for ERA-5 model levels was doubling calls to the API because the variables were in two pairs. I think this was a holdover from a previous API version. Now all four variables (lnsp, z, t, and q) are called at once. 

Finally, GNSS heights were not getting converted to orthometric heights prior to interpolation in RAiDER. This PR implements a conversion from ellipsoid heights to the geoid only for GNSS stations. 

<!--- If this PR breaks existing unit tests, please describe in detail -->
<!--- which tests break and why. Describe what functionality is changed. -->
All unit tests pass locally. 


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
