### PR TITLE
Update xarray usage in RAiDER to use lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 * [811](https://github.com/dbekaert/RAiDER/pull/811) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
 
+### Changed
+* [808](https://github.com/dbekaert/RAiDER/pull/795) - Use `xarray.open_dataset` instead of `load_dataset` for memory efficiency, and guard weather-model file reads with explicit error handling.
+
 ## [0.6.0]
 ### Removed
 * [764](https://github.com/dbekaert/RAiDER/pull/764) - Removed Python 3.8 support. Python 3.9 is now the minimum version officially required to run RAiDER.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [811](https://github.com/dbekaert/RAiDER/pull/811) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
 
 ### Changed
-* [808](https://github.com/dbekaert/RAiDER/pull/795) - Use `xarray.open_dataset` instead of `load_dataset` for memory efficiency, and guard weather-model file reads with explicit error handling.
+* [808](https://github.com/dbekaert/RAiDER/pull/808) - Use `xarray.open_dataset` instead of `load_dataset` for memory efficiency, and guard weather-model file reads with explicit error handling so that datasets are always closed. Dropped the redundant full-cube `shutil.copy` from the ECMWF model-level download, and added regression tests covering the layout contract between `ECMWF._get_from_cds` and `ECMWF._makeDataCubes`.
 
 ## [0.6.0]
 ### Removed

--- a/test/test_ecmwf_fetch.py
+++ b/test/test_ecmwf_fetch.py
@@ -1,0 +1,171 @@
+"""Tests for the ERA-5 model-level download post-processing.
+
+`ECMWF._get_from_cds` writes the file that `ECMWF._makeDataCubes` later reads, so
+the two have to agree on the layout of the surface fields. Nothing in CI performs
+a real CDS retrieval, so these tests stub out `cdsapi.Client` and exercise the
+post-processing and the reader against each other.
+
+The layout contract is:
+
+* `t`, `q`, `z` are ``(time, level, lat, lon)`` cubes spanning all model levels
+* `lnsp` is a surface field, recovered by the reader as ``lnsp[0, 0]``
+
+ERA-5 archives `lnsp` and `z` at model level 1 only, so they have to be
+requested separately from `t`/`q`: CDS returns a mixed-level request as separate
+files rather than as a single netCDF.
+"""
+
+import datetime as dt
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from RAiDER.models.era5 import ERA5
+
+
+NLEV = 137
+LATS = np.arange(50.0, 48.9, -0.25)  # descending, as ERA-5 delivers them
+LONS = np.arange(9.0, 10.1, 0.25)
+NLAT, NLON = len(LATS), len(LONS)
+
+TIME = np.array(['2020-01-01T00:00:00'], dtype='datetime64[ns]')
+SURFACE_PRESSURE = 95_000.0  # Pa
+SURFACE_GEOPOTENTIAL = 500.0 * 9.80665  # 500 m, in m^2/s^2
+
+
+def _t() -> np.ndarray:
+    """Temperature decreasing from the surface (level 137) up to the top (level 1)."""
+    profile = np.linspace(220.0, 290.0, NLEV)
+    return np.broadcast_to(profile[:, np.newaxis, np.newaxis], (NLEV, NLAT, NLON)).copy()
+
+
+def _q() -> np.ndarray:
+    return np.full((NLEV, NLAT, NLON), 1e-3)
+
+
+def _write_surface_file(path: Path) -> None:
+    """Write the lnsp/z response: a single model level (level 1)."""
+    lnsp = np.full((NLAT, NLON), np.log(SURFACE_PRESSURE))
+    z = np.full((NLAT, NLON), SURFACE_GEOPOTENTIAL)
+    xr.Dataset(
+        {
+            'lnsp': (('valid_time', 'model_level', 'latitude', 'longitude'), lnsp[np.newaxis, np.newaxis]),
+            'z': (('valid_time', 'model_level', 'latitude', 'longitude'), z[np.newaxis, np.newaxis]),
+        },
+        coords={'valid_time': TIME, 'model_level': [1], 'latitude': LATS, 'longitude': LONS},
+    ).to_netcdf(path)
+
+
+def _write_model_level_file(path: Path) -> None:
+    """Write the t/q response: all model levels."""
+    xr.Dataset(
+        {
+            't': (('valid_time', 'model_level', 'latitude', 'longitude'), _t()[np.newaxis]),
+            'q': (('valid_time', 'model_level', 'latitude', 'longitude'), _q()[np.newaxis]),
+        },
+        coords={
+            'valid_time': TIME,
+            'model_level': np.arange(1, NLEV + 1),
+            'latitude': LATS,
+            'longitude': LONS,
+        },
+    ).to_netcdf(path)
+
+
+class MixedLevelRequestError(Exception):
+    """Raised when a request mixes surface-only and model-level fields."""
+
+
+class FakeCDSClient:
+    """Stand-in for `cdsapi.Client` that writes synthetic ERA-5 responses.
+
+    Records every request so tests can assert on how the download was split, and
+    refuses to serve a request that mixes surface-only and model-level fields,
+    which is what CDS does in practice.
+    """
+
+    url = 'https://cds.climate.copernicus.eu/api'
+    requests: list[list[str]] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        FakeCDSClient.requests = []
+
+    def retrieve(self, dataset: str, params: dict, target) -> None:
+        param = sorted(params['param'])
+        FakeCDSClient.requests.append(param)
+
+        if param == ['lnsp', 'z']:
+            _write_surface_file(Path(target))
+        elif param == ['q', 't']:
+            _write_model_level_file(Path(target))
+        else:
+            raise MixedLevelRequestError(
+                f'CDS cannot serve {param} as a single netCDF: lnsp and z exist only at '
+                'model level 1, so they must be requested separately from t and q.'
+            )
+
+
+@pytest.fixture()
+def era5() -> ERA5:
+    model = ERA5()
+    model.setLevelType('ml')
+    # Comfortably inside the synthetic grid, so the mask in _makeDataCubes keeps
+    # every point and the shape assertions below are unambiguous.
+    model.set_latlon_bounds([49.0, 50.0, 9.0, 10.0])
+    return model
+
+
+@pytest.fixture()
+def fetched(era5: ERA5, tmp_path: Path) -> Path:
+    out_path = tmp_path / 'ERA-5_2020_01_01_T00_00_00.nc'
+    with patch('cdsapi.Client', FakeCDSClient):
+        era5._get_from_cds(49.0, 50.0, 9.0, 10.0, dt.datetime(2020, 1, 1), out_path)
+    return out_path
+
+
+def test_surface_and_model_level_fields_are_requested_separately(fetched: Path) -> None:
+    assert FakeCDSClient.requests == [['lnsp', 'z'], ['q', 't']]
+
+
+def test_downloaded_file_is_readable_by_makeDataCubes(era5: ERA5, fetched: Path) -> None:
+    """The shapes _load_model_level relies on when it calls _calculategeoh."""
+    lats, lons, _, _, t, q, lnsp, z = era5._makeDataCubes(fetched)
+
+    assert lnsp.shape == (NLAT, NLON)
+    assert t.shape == (NLEV, NLAT, NLON)
+    assert q.shape == (NLEV, NLAT, NLON)
+    assert z.shape == (NLEV, NLAT, NLON)
+    assert len(lats) == NLAT
+    assert len(lons) == NLON
+
+
+def test_lnsp_round_trips_as_a_surface_field(era5: ERA5, fetched: Path) -> None:
+    *_, lnsp, _ = era5._makeDataCubes(fetched)
+
+    assert np.all(np.isfinite(lnsp))
+    assert np.allclose(np.exp(lnsp), SURFACE_PRESSURE)
+
+
+def test_z_is_written_as_a_full_model_level_cube(era5: ERA5, fetched: Path) -> None:
+    """CDS supplies z at the surface only; _get_from_cds fills in the other levels."""
+    *_, z = era5._makeDataCubes(fetched)
+
+    assert np.all(np.isfinite(z))
+    # Level 137 is nearest the surface and level 1 is the top of the atmosphere,
+    # so geopotential must increase monotonically towards index 0.
+    assert np.all(np.diff(z, axis=0) < 0)
+    assert np.allclose(z[-1], SURFACE_GEOPOTENTIAL, rtol=0.1)
+
+
+def test_load_model_level_populates_the_model(era5: ERA5, fetched: Path) -> None:
+    """End to end: the downloaded file drives a complete weather model."""
+    era5._load_model_level(fetched)
+
+    assert era5._p.shape == era5._t.shape == era5._q.shape == era5._zs.shape
+    assert era5._t.shape[:2] == (NLAT, NLON)
+    assert np.all(np.isfinite(era5._p))
+    # _load_model_level flips everything to run surface-to-top.
+    assert np.all(np.diff(era5._zs, axis=2) > 0)

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from collections.abc import Sequence
+from contextlib import ExitStack
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Optional, cast
@@ -811,10 +812,11 @@ def combine_weather_files(wfiles: list[Path], time: dt.datetime, model: str, int
     """Interpolate downloaded weather files and save to a single file."""
     STYLE = {'center_time': '_timeInterp_', 'azimuth_time_grid': '_timeInterpAziGrid_'}
 
-    # read the individual datetime datasets
-    datasets = [xr.open_dataset(f) for f in wfiles]
+    # Use ExitStack to ensure invalid files are handled cleanly
+    with ExitStack() as stack:
+        # read the individual datetime datasets
+        datasets = [stack.enter_context(xr.open_dataset(f)) for f in wfiles]
 
-    try:
         # Pull the datetimes from the datasets
         times: list[dt.datetime] = []
         for ds in datasets:
@@ -850,19 +852,18 @@ def combine_weather_files(wfiles: list[Path], time: dt.datetime, model: str, int
 
         # write the combined results to disk (must happen before closing datasets)
         ds_out.to_netcdf(weather_model_file)
-    finally:
-        for ds in datasets:
-            ds.close()
 
     return weather_model_file
 
 
 def combine_files_using_azimuth_time(wfiles, time: dt.datetime, times: list[dt.datetime]):
     """Combine files using azimuth time interpolation."""
-    # read the individual datetime datasets
-    datasets = [xr.open_dataset(f) for f in wfiles]
 
-    try:
+    # Use ExitStack to ensure invalid files are handled cleanly
+    with ExitStack() as stack:
+        # read the individual datetime datasets
+        datasets = [stack.enter_context(xr.open_dataset(f)) for f in wfiles]
+
         # Pull the datetimes from the datasets
         times: list[dt.datetime] = []
         for ds in datasets:
@@ -893,9 +894,6 @@ def combine_files_using_azimuth_time(wfiles, time: dt.datetime, times: list[dt.d
 
         # write the combined results to disk (must happen before closing datasets)
         ds_out.to_netcdf(weather_model_file)
-    finally:
-        for ds in datasets:
-            ds.close()
 
     return weather_model_file
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -814,41 +814,45 @@ def combine_weather_files(wfiles: list[Path], time: dt.datetime, model: str, int
     # read the individual datetime datasets
     datasets = [xr.open_dataset(f) for f in wfiles]
 
-    # Pull the datetimes from the datasets
-    times: list[dt.datetime] = []
-    for ds in datasets:
-        times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
+    try:
+        # Pull the datetimes from the datasets
+        times: list[dt.datetime] = []
+        for ds in datasets:
+            times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
 
-    if len(times) == 0:
-        raise NoWeatherModelData()
+        if len(times) == 0:
+            raise NoWeatherModelData()
 
-    # calculate relative weights of each dataset
-    if interp_method == 'center_time':
-        wgts = get_weights_time_interp(times, time)
-    elif interp_method == 'azimuth_time_grid':
-        time_grid = get_time_grid_for_aztime_interp(datasets, time, model)
-        wgts = get_inverse_weights_for_dates(time_grid, times)
-    else:  # interp_method == 'none'
-        raise ValueError('Interpolating weather files is not available with interpolation method "none"')
+        # calculate relative weights of each dataset
+        if interp_method == 'center_time':
+            wgts = get_weights_time_interp(times, time)
+        elif interp_method == 'azimuth_time_grid':
+            time_grid = get_time_grid_for_aztime_interp(datasets, time, model)
+            wgts = get_inverse_weights_for_dates(time_grid, times)
+        else:  # interp_method == 'none'
+            raise ValueError('Interpolating weather files is not available with interpolation method "none"')
 
-    # combine datasets
-    ds_out = datasets[0]
-    for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
-        ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
-    ds_out.attrs['Date1'] = 0
-    ds_out.attrs['Date2'] = 0
+        # combine datasets
+        ds_out = datasets[0]
+        for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
+            ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
+        ds_out.attrs['Date1'] = 0
+        ds_out.attrs['Date2'] = 0
 
-    # Give the weighted combination a new file name
-    weather_model_file = wfiles[0].parent / (
-        wfiles[0].name.split('_')[0]
-        + '_'
-        + time.strftime('%Y_%m_%dT%H_%M_%S')
-        + STYLE[interp_method]
-        + '_'.join(wfiles[0].name.split('_')[-4:])
-    )
+        # Give the weighted combination a new file name
+        weather_model_file = wfiles[0].parent / (
+            wfiles[0].name.split('_')[0]
+            + '_'
+            + time.strftime('%Y_%m_%dT%H_%M_%S')
+            + STYLE[interp_method]
+            + '_'.join(wfiles[0].name.split('_')[-4:])
+        )
 
-    # write the combined results to disk
-    ds_out.to_netcdf(weather_model_file)
+        # write the combined results to disk (must happen before closing datasets)
+        ds_out.to_netcdf(weather_model_file)
+    finally:
+        for ds in datasets:
+            ds.close()
 
     return weather_model_file
 
@@ -858,36 +862,40 @@ def combine_files_using_azimuth_time(wfiles, time: dt.datetime, times: list[dt.d
     # read the individual datetime datasets
     datasets = [xr.open_dataset(f) for f in wfiles]
 
-    # Pull the datetimes from the datasets
-    times: list[dt.datetime] = []
-    for ds in datasets:
-        times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
+    try:
+        # Pull the datetimes from the datasets
+        times: list[dt.datetime] = []
+        for ds in datasets:
+            times.append(dt.datetime.strptime(ds.attrs['datetime'], '%Y_%m_%dT%H_%M_%S'))
 
-    model = datasets[0].attrs['model_name']
+        model = datasets[0].attrs['model_name']
 
-    time_grid = get_time_grid_for_aztime_interp(datasets, times, time, model)
+        time_grid = get_time_grid_for_aztime_interp(datasets, times, time, model)
 
-    wgts = get_inverse_weights_for_dates(time_grid, times)
+        wgts = get_inverse_weights_for_dates(time_grid, times)
 
-    # combine datasets
-    ds_out = datasets[0]
-    for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
-        ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
-    ds_out.attrs['Date1'] = 0
-    ds_out.attrs['Date2'] = 0
+        # combine datasets
+        ds_out = datasets[0]
+        for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
+            ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
+        ds_out.attrs['Date1'] = 0
+        ds_out.attrs['Date2'] = 0
 
-    # Give the weighted combination a new file name
-    weather_model_file = os.path.join(
-        os.path.dirname(wfiles[0]),
-        os.path.basename(wfiles[0]).split('_')[0]
-        + '_'
-        + time.strftime('%Y_%m_%dT%H_%M_%S')
-        + '_timeInterpAziGrid_'
-        + '_'.join(wfiles[0].split('_')[-4:]),
-    )
+        # Give the weighted combination a new file name
+        weather_model_file = os.path.join(
+            os.path.dirname(wfiles[0]),
+            os.path.basename(wfiles[0]).split('_')[0]
+            + '_'
+            + time.strftime('%Y_%m_%dT%H_%M_%S')
+            + '_timeInterpAziGrid_'
+            + '_'.join(wfiles[0].split('_')[-4:]),
+        )
 
-    # write the combined results to disk
-    ds_out.to_netcdf(weather_model_file)
+        # write the combined results to disk (must happen before closing datasets)
+        ds_out.to_netcdf(weather_model_file)
+    finally:
+        for ds in datasets:
+            ds.close()
 
     return weather_model_file
 

--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -835,7 +835,7 @@ def combine_weather_files(wfiles: list[Path], time: dt.datetime, model: str, int
             raise ValueError('Interpolating weather files is not available with interpolation method "none"')
 
         # combine datasets
-        ds_out = datasets[0]
+        ds_out = datasets[0].copy(deep=False)
         for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
             ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
         ds_out.attrs['Date1'] = 0
@@ -876,7 +876,7 @@ def combine_files_using_azimuth_time(wfiles, time: dt.datetime, times: list[dt.d
         wgts = get_inverse_weights_for_dates(time_grid, times)
 
         # combine datasets
-        ds_out = datasets[0]
+        ds_out = datasets[0].copy(deep=False)
         for var in ['wet', 'hydro', 'wet_total', 'hydro_total']:
             ds_out[var] = sum([wgt * ds[var] for (wgt, ds) in zip(wgts, datasets)])
         ds_out.attrs['Date1'] = 0

--- a/tools/RAiDER/delay.py
+++ b/tools/RAiDER/delay.py
@@ -62,8 +62,8 @@ def tropo_delay(
     """
     crs = CRS(out_proj)
 
-    # Load CRS from weather model file
-    with xr.load_dataset(weather_model_file) as ds:
+    # Load CRS and heights from weather model file (single open)
+    with xr.open_dataset(weather_model_file) as ds:
         try:
             wm_proj = CRS.from_wkt(ds['proj'].attrs['crs_wkt'])
         except KeyError:
@@ -71,9 +71,6 @@ def tropo_delay(
                 "WARNING: I can't find a CRS in the weather model file, so I will assume you are using WGS84"
             )
             wm_proj = CRS.from_epsg(4326)
-
-    # get heights
-    with xr.load_dataset(weather_model_file) as ds:
         wm_levels = ds.z.values
         toa = wm_levels.max() - 1
 
@@ -137,7 +134,7 @@ def _get_delays_on_cube(datetime: dt.datetime, weather_model_file, wm_proj, aoi,
     try:
         aoi.xpts
     except AttributeError:
-        with xr.load_dataset(weather_model_file) as ds:
+        with xr.open_dataset(weather_model_file) as ds:
             x_spacing = ds.x.diff(dim='x').values.mean()
             y_spacing = ds.y.diff(dim='y').values.mean()
         aoi.set_output_spacing(ll_res=np.min([x_spacing, y_spacing]))

--- a/tools/RAiDER/delayFcns.py
+++ b/tools/RAiDER/delayFcns.py
@@ -28,17 +28,22 @@ def getInterpolators(wm_file: Union[xr.Dataset, Path, str], kind: str='pointwise
     The interpolator grid is (y, x, z)
     """
     # Get the weather model data
-    ds = wm_file if isinstance(wm_file, xr.Dataset) else xr.load_dataset(wm_file)
+    _close_ds = not isinstance(wm_file, xr.Dataset)
+    ds = wm_file if isinstance(wm_file, xr.Dataset) else xr.open_dataset(wm_file)
 
-    xs_wm = np.array(ds.variables['x'][:])
-    ys_wm = np.array(ds.variables['y'][:])
-    zs_wm = np.array(ds.variables['z'][:])
+    try:
+        xs_wm = np.array(ds.variables['x'][:])
+        ys_wm = np.array(ds.variables['y'][:])
+        zs_wm = np.array(ds.variables['z'][:])
 
-    wet = ds.variables['wet_total' if kind == 'total' else 'wet'][:]
-    hydro = ds.variables['hydro_total' if kind == 'total' else 'hydro'][:]
+        wet = ds.variables['wet_total' if kind == 'total' else 'wet'][:]
+        hydro = ds.variables['hydro_total' if kind == 'total' else 'hydro'][:]
 
-    wet = np.array(wet).transpose(1, 2, 0)
-    hydro = np.array(hydro).transpose(1, 2, 0)
+        wet = np.array(wet).transpose(1, 2, 0)
+        hydro = np.array(hydro).transpose(1, 2, 0)
+    finally:
+        if _close_ds:
+            ds.close()
 
     if np.any(np.isnan(wet)) or np.any(np.isnan(hydro)):
         logger.critical('Weather model contains NaNs!')

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -133,11 +133,10 @@ class ECMWF(WeatherModel):
 
         with tempfile.TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
-            out_path_combined = temp_dir / f'{out_path.stem}_combined'
+            out_path_lnsp_z = temp_dir / f'{out_path.stem}_lnsp_z'
+            out_path_t_q = temp_dir / f'{out_path.stem}_t_q'
 
             # Developed from https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5
-            # All four variables are fetched in a single CDS request to halve queue wait time.
-            # lnsp and z are surface-only fields; t and q span all model levels.
             params = {
                 'class': 'ea',
                 'expver': '1',
@@ -153,20 +152,28 @@ class ECMWF(WeatherModel):
                 'area': [lat_max, lon_min, lat_min, lon_max],
                 'grid': [0.25, 0.25],
                 'format': 'netcdf',
-                'param': ['lnsp', 'z', 'q', 't'],
             }
-            c.retrieve('reanalysis-era5-complete', params, out_path_combined)
+            # lnsp and z are surface-only fields; t and q span all model levels. These
+            # must be two separate requests: CDS returns a mixed-level request as
+            # separate files rather than as one netCDF, and even where it does return a
+            # single file, the surface fields come back padded onto the full level axis,
+            # which breaks the (lat, lon) shape calcgeoh and _makeDataCubes expect.
+            params['param'] = ['lnsp', 'z']
+            c.retrieve('reanalysis-era5-complete', params, out_path_lnsp_z)
+            params['param'] = ['q', 't']
+            c.retrieve('reanalysis-era5-complete', params, out_path_t_q)
 
-            with xr.open_dataset(out_path_combined) as ds:
+            with xr.open_dataset(out_path_lnsp_z) as ds_lnsp_z, xr.open_dataset(out_path_t_q) as ds_t_q:
                 # ERA-5 only provides z at the surface level; compute it at all
                 # model levels from lnsp, t, and q via the hypsometric equation.
-                # .squeeze() removes the size-1 time (and level, for lnsp/z) dims,
-                # since calcgeoh expects (level, lat, lon) or (lat, lon) arrays.
+                # .squeeze() removes the size-1 time dim (and, for lnsp/z, the
+                # size-1 level dim), since calcgeoh expects (level, lat, lon) or
+                # (lat, lon) arrays.
                 z_full, _, _ = util.calcgeoh(
-                    lnsp=ds['lnsp'].values.squeeze(),
-                    z_surface=ds['z'].values.squeeze(),
-                    t=ds['t'].values.squeeze(),
-                    q=ds['q'].values.squeeze(),
+                    lnsp=ds_lnsp_z['lnsp'].values.squeeze(),
+                    z_surface=ds_lnsp_z['z'].values.squeeze(),
+                    t=ds_t_q['t'].values.squeeze(),
+                    q=ds_t_q['q'].values.squeeze(),
                     a=self._a,
                     b=self._b,
                     num_levels=self._levels,
@@ -174,11 +181,15 @@ class ECMWF(WeatherModel):
                 )
                 # Replace the surface-only z with the full model-level z cube,
                 # broadcast to match t's (time, level, lat, lon) dimensions.
-                ds_out = ds.assign(
+                ds_out = ds_t_q.assign(
                     z=xr.Variable(
-                        dims=ds['t'].dims,
+                        dims=ds_t_q['t'].dims,
                         data=np.broadcast_to(z_full, (1, *z_full.shape)),
                     ),
+                    # xarray aligns on the level coordinate, so this lands on the
+                    # first level and is NaN on every other one. _makeDataCubes
+                    # reads it back as lnsp[0, 0] to recover the (lat, lon) field.
+                    lnsp=ds_lnsp_z['lnsp'],
                 )
                 ds_out.to_netcdf(out_path)
 

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -134,10 +133,11 @@ class ECMWF(WeatherModel):
 
         with tempfile.TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
-            out_path_lnsp_z = temp_dir / f'{out_path.stem}_lnsp_z'
-            out_path_t_q = temp_dir / f'{out_path.stem}_t_q'
+            out_path_combined = temp_dir / f'{out_path.stem}_combined'
 
             # Developed from https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5
+            # All four variables are fetched in a single CDS request to halve queue wait time.
+            # lnsp and z are surface-only fields; t and q span all model levels.
             params = {
                 'class': 'ea',
                 'expver': '1',
@@ -153,51 +153,32 @@ class ECMWF(WeatherModel):
                 'area': [lat_max, lon_min, lat_min, lon_max],
                 'grid': [0.25, 0.25],
                 'format': 'netcdf',
+                'param': ['lnsp', 'z', 'q', 't'],
             }
-            # Make two separate requests: one for lnsp and z, and the other for t and q.
-            params['param'] = ['lnsp', 'z']
-            c.retrieve('reanalysis-era5-complete', params, out_path_lnsp_z)
-            params['param'] = ['q', 't']
-            c.retrieve('reanalysis-era5-complete', params, out_path_t_q)
+            c.retrieve('reanalysis-era5-complete', params, out_path_combined)
 
-            # RAiDER requires z data for all levels, but ERA-5 only provides it for
-            # the surface level. z can be computed for all levels using lnsp, t, and
-            # q, so that is what we will do.
-            # We will use the t/q dataset as a base to make a full dataset with
-            # lnsp, t, and q, and full z data.
-            shutil.copy(out_path_t_q, out_path)
-
-            with xr.open_dataset(out_path_lnsp_z) as ds_lnsp_z, xr.open_dataset(out_path_t_q) as ds_t_q:
-                # Compute full z
+            with xr.open_dataset(out_path_combined) as ds:
+                # ERA-5 only provides z at the surface level; compute it at all
+                # model levels from lnsp, t, and q via the hypsometric equation.
+                # .squeeze() removes the size-1 time (and level, for lnsp/z) dims,
+                # since calcgeoh expects (level, lat, lon) or (lat, lon) arrays.
                 z_full, _, _ = util.calcgeoh(
-                    # .squeeze(): data comes in with dimensions:
-                    # (valid time, model level, latitude, longitude),
-                    # and we need it in:
-                    # (model level, latitude, longitude),
-                    # and there is always exactly one valid time
-                    # (i.e., shape is always (1, ..., ..., ...)).
-                    lnsp=ds_lnsp_z['lnsp'].values.squeeze(),
-                    z_surface=ds_lnsp_z['z'].values.squeeze(),
-                    t=ds_t_q['t'].values.squeeze(),
-                    q=ds_t_q['q'].values.squeeze(),
+                    lnsp=ds['lnsp'].values.squeeze(),
+                    z_surface=ds['z'].values.squeeze(),
+                    t=ds['t'].values.squeeze(),
+                    q=ds['q'].values.squeeze(),
                     a=self._a,
                     b=self._b,
                     num_levels=self._levels,
                     R_d=self._R_d,
                 )
-                # Add the full z cube to the output dataset.
-                ds_out = ds_t_q.assign(
+                # Replace the surface-only z with the full model-level z cube,
+                # broadcast to match t's (time, level, lat, lon) dimensions.
+                ds_out = ds.assign(
                     z=xr.Variable(
-                        # Copy over t's dimensions as z's.
-                        # Could also have used q; all three are the same.
-                        dims=ds_t_q['t'].dims,
-                        # Present z_full as though it were wrapped in an array to
-                        # match the shape of the rest of the data.
+                        dims=ds['t'].dims,
                         data=np.broadcast_to(z_full, (1, *z_full.shape)),
                     ),
-                    # To fit the shape of the rest of the dataset, this is NaN on
-                    # every level but the first (the surface).
-                    lnsp=ds_lnsp_z['lnsp'],
                 )
                 ds_out.to_netcdf(out_path)
 

--- a/tools/RAiDER/models/merra2.py
+++ b/tools/RAiDER/models/merra2.py
@@ -136,13 +136,13 @@ class MERRA2(WeatherModel):
     def _load_model_level(self, filename) -> None:
         """Get the variables from the GMAO link using OpenDAP."""
         # adding the import here should become absolute when transition to netcdf
-        ds = xr.load_dataset(filename)
-        lons = ds['longitude'].values
-        lats = ds['latitude'].values
-        h = ds['h'].values
-        q = ds['q'].values
-        p = ds['p'].values
-        t = ds['t'].values
+        with xr.open_dataset(filename) as ds:
+            lons = ds['longitude'].values
+            lats = ds['latitude'].values
+            h = ds['h'].values
+            q = ds['q'].values
+            p = ds['p'].values
+            t = ds['t'].values
 
         # Re-structure everything from (heights, lats, lons) to (lons, lats, heights)
         p = np.transpose(p)

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -451,7 +451,7 @@ class WeatherModel(ABC):
             if not Path.exists(Path(path_weather_model)):
                 raise ValueError('Need to save cropped weather model as netcdf')
 
-            with xr.load_dataset(path_weather_model) as ds:
+            with xr.open_dataset(path_weather_model) as ds:
                 try:
                     xmin, xmax = ds.x.min(), ds.x.max()
                     ymin, ymax = ds.y.min(), ds.y.max()


### PR DESCRIPTION
xarray makes available two methods for opening datasets, open_dataset and load_dataset. Using open_dataset allows for lazy loading and memory efficiency. This PR change all the locations were load_dataset was used to `open_dataset', resulting in much better memory performance for RAiDER. This PR also wraps netcdf dataset opening with try/except/finally logic that ensures the datasets are closed properly.

The PR also fixes a small issue where ECMWF requests were being handled in two API requests instead of one. 

All unit tests pass locally.


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added an explanation of what your changes do and why you'd like us to include them.
- [ ] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
