### PR TITLE
Fixes a north–south flip of the geopotential cube in the ECMWF/ERA-5 model-level reader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
-* [TBD](https://github.com/dbekaert/RAiDER/pull/TBD) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
+* [811](https://github.com/dbekaert/RAiDER/pull/811) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
 
 ## [0.6.0]
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+* [TBD](https://github.com/dbekaert/RAiDER/pull/TBD) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
+
 ## [0.6.0]
 ### Removed
 * [764](https://github.com/dbekaert/RAiDER/pull/764) - Removed Python 3.8 support. Python 3.9 is now the minimum version officially required to run RAiDER.

--- a/test/test_ecmwf_levels.py
+++ b/test/test_ecmwf_levels.py
@@ -1,0 +1,125 @@
+"""Regression tests for the ECMWF/ERA-5 model-level reader.
+
+These cover the orientation of the geopotential cube relative to the other
+fields. ECMWF delivers model-level data with latitude descending, and the
+reader reverses it to ascending; the height cube has to be reversed on the
+same axis as t/q/lnsp, or heights end up mirrored north-south against the
+meteorology.
+
+That failure mode is antisymmetric in latitude, so it very nearly cancels in
+a domain average -- a mean-based check will not catch it. The assertions here
+are deliberately per-column.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+
+from RAiDER.constants import _g0
+from RAiDER.models.era5 import ERA5
+from RAiDER.utilFcns import calcgeoh
+
+
+# Terrain rising steeply from south to north, so that a latitude reflection is
+# unambiguous: the southern rows are at sea level, the northern rows are high.
+_LATS_DESC = np.array([36.0, 35.0, 34.0, 33.0])   # ECMWF order: descending
+_LONS = np.array([240.0, 241.0, 242.0])           # 0-360, as ECMWF delivers
+_TERRAIN = {36.0: 3000.0, 35.0: 2000.0, 34.0: 1000.0, 33.0: 0.0}
+
+
+def _write_synthetic_ml_file(path):
+    """Write a minimal ERA-5 model-level file in ECMWF's native ordering.
+
+    Mirrors what RAiDER's own _fetch writes: z is the *full* geopotential cube
+    (computed with calcgeoh), not the surface-only field CDS returns.
+    """
+    model = ERA5()
+    nlev = model._levels
+    nlat, nlon = len(_LATS_DESC), len(_LONS)
+
+    terrain = np.array([_TERRAIN[la] for la in _LATS_DESC])[:, None] * np.ones((nlat, nlon))
+    z_surface = terrain * _g0
+
+    t = np.full((nlev, nlat, nlon), 280.0)
+    q = np.full((nlev, nlat, nlon), 1e-3)
+
+    # surface pressure consistent with the terrain (barometric)
+    psurf = 101325.0 * np.exp(-terrain / 8400.0)
+    lnsp = np.log(psurf)
+
+    z_full, _, _ = calcgeoh(
+        lnsp=lnsp, t=t, q=q, z_surface=z_surface,
+        a=model._a, b=model._b, R_d=model._R_d, num_levels=nlev,
+    )
+
+    dims = ('valid_time', 'model_level', 'latitude', 'longitude')
+    ds = xr.Dataset(
+        data_vars={
+            't': (dims, t[np.newaxis]),
+            'q': (dims, q[np.newaxis]),
+            'z': (dims, np.asarray(z_full)[np.newaxis]),
+            # the reader takes lnsp as [0, 0], so it must carry both leading dims
+            'lnsp': (dims, np.broadcast_to(lnsp, (1, nlev, nlat, nlon)).copy()),
+        },
+        coords={
+            'valid_time': [0],
+            'model_level': np.arange(1, nlev + 1),
+            'latitude': _LATS_DESC,
+            'longitude': _LONS,
+        },
+    )
+    ds.to_netcdf(path)
+    return model
+
+
+@pytest.fixture
+def loaded_model(tmp_path):
+    f = tmp_path / 'ERA-5_synthetic_ml.nc'
+    model = _write_synthetic_ml_file(f)
+    model._ll_bounds = (32.5, 36.5, -120.5, -117.5)
+    model._load_model_level(f)
+    return model
+
+
+def test_model_level_latitudes_are_ascending(loaded_model):
+    """The reader is expected to flip ECMWF's descending latitudes."""
+    lats = loaded_model._lats[:, 0]
+    assert lats[0] < lats[-1]
+    assert np.allclose(np.sort(lats), lats)
+
+
+def test_surface_height_matches_terrain_per_latitude(loaded_model):
+    """Heights must land on the latitude they came from, not its mirror.
+
+    Reversing only the level axis of z (the bug this guards) leaves the height
+    cube mirrored in latitude, so the 3000 m row shows up at 33 N.
+    """
+    m = loaded_model
+    lats = m._lats[:, 0]
+    surface_height = m._zs[..., 0]   # _zs runs bottom -> top after loading
+
+    expected = np.array([_TERRAIN[round(float(la))] for la in lats])
+    # geo_to_ht applies a small geometric correction, so allow a loose tolerance;
+    # the failure mode being guarded against is off by ~1000-3000 m.
+    assert np.allclose(surface_height.mean(axis=1), expected, atol=50.0)
+
+
+def test_surface_height_and_pressure_are_consistent(loaded_model):
+    """High terrain must carry low surface pressure.
+
+    This is the single most diagnostic invariant: with z reversed on the wrong
+    axis the correlation goes negative, because heights come from the mirrored
+    latitude while pressure does not.
+    """
+    m = loaded_model
+    surface_height = m._zs[..., 0].ravel()
+    surface_pressure = m._p[..., 0].ravel()
+
+    corr = np.corrcoef(surface_height, -surface_pressure)[0, 1]
+    assert corr > 0.99, f'height/pressure correlation {corr:.4f}; z is likely mirrored in latitude'
+
+
+def test_heights_increase_upward(loaded_model):
+    """_zs is ordered surface -> top of atmosphere after loading."""
+    m = loaded_model
+    assert (np.diff(m._zs, axis=2) > 0).all()
+    assert (np.diff(m._p, axis=2) < 0).all()

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -244,7 +244,13 @@ class ECMWF(WeatherModel):
 
         # ECMWF appears to give me this backwards
         if lats[0] > lats[1]:
-            z: FloatArray3D = z[::-1]
+            # z is (level, lat, lon). It needs BOTH axes reversed: the latitude
+            # axis to match t/q/lnsp, and the level axis because the surface
+            # geopotential is taken as z[0] below (the stored cube runs
+            # top-of-atmosphere -> surface). Reversing only axis 0, as this
+            # previously did, left the height field mirrored north-south
+            # relative to the meteorology.
+            z: FloatArray3D = z[::-1, ::-1]
             lnsp: FloatArray2D = lnsp[::-1]
             t: FloatArray3D = t[:, ::-1]
             q: FloatArray3D = q[:, ::-1]


### PR DESCRIPTION
## Description

Thanks to @s-sasaki-earthsea-wizard for catching this bug! 

Fixes a north–south flip of the geopotential cube in the ECMWF/ERA-5 model-level reader.

In `ECMWF._load_model_level`, the branch that corrects ECMWF's descending-latitude ordering reversed the wrong axis of `z`:

```python
if lats[0] > lats[1]:
    z    = z[::-1]        # z is (level, lat, lon) -> reverses LEVEL
    lnsp = lnsp[::-1]     # (lat, lon)             -> reverses lat
    t    = t[:, ::-1]     # (level, lat, lon)      -> reverses lat
    q    = q[:, ::-1]     # -> reverses lat
```

`z` needs **both** axes reversed: the latitude axis to stay aligned with `t`/`q`/`lnsp`, and the level axis because `z[0]` is subsequently passed to `_calculategeoh` as the surface geopotential. Reversing only axis 0 satisfied the second requirement while silently violating the first, leaving the height field mirrored in latitude against the meteorology.

The visible symptom is columns whose pressure profile is displaced vertically by however much terrain differs between a latitude and its mirror — e.g. a sea-level node reporting constant pressure from −500 m up to 1900 m, which is ~1900 m of fictitious sea-level-density air worth roughly +490 mm of spurious delay.

**Affects ERA-5, ERA-5T and HRES on model levels**, which is the default level type for those models. The pressure-level path is untouched.

### When this was introduced

Introduced in `f81225b` ("Update for ERA-5 API changes", #751, merged 2025-09-05, released in 0.6.0) — so the regression window is 0.6.0 onward, not the whole history.

The statement `z = z[::-1]` is older than the bug and was **correct** when written. What changed is the dimensionality of `z` underneath it:

| | before `f81225b` | after |
|---|---|---|
| `_makeDataCubes` | `np.squeeze(block['z'].values)[0, ...]` → **2D** (lat, lon) | `block['z'].values.squeeze()` → **3D** (level, lat, lon) |
| `z[::-1]` | reverses **latitude** ✓ | reverses **level** ✗ |
| call site | `_calculategeoh(z, lnsp)` | `_calculategeoh(z[0, :], lnsp, t, q)` |

The ERA-5 API change meant CDS would only return `z` at the surface, so RAiDER had to compute the full geopotential cube itself. That moved the `[0, ...]` surface-extraction out of `_makeDataCubes` and into the call site as `z[0, :]`, which made the level reversal newly load-bearing — it is what puts the surface at index 0 — at exactly the moment the latitude reversal silently stopped happening. One statement went from serving one purpose to serving a different one, and reads as deliberate either way.

Fixes #806 

### Why this was not caught earlier

The error is antisymmetric in latitude, so it very nearly cancels in a domain average while being severe at individual points. Over a 3-degree box in southern California the mean ZTD moves only 2360 → 2340 mm, but the spread across the domain collapses from physically impossible to correct:

| diagnostic | before | after |
|---|---|---|
| corr(surface height, −surface pressure) | **−0.5415** | **+0.9992** |
| sea-level ZTD range across the domain | 1621 – 3233 mm | 2239 – 2395 mm |
| domain-mean ZTD | 2360 mm | 2340 mm |

Physics requires the correlation to be ~+1 (high terrain carries low surface pressure).

Validated against UNR GNSS ZTD at four stations (FGNW, MHMS, WLHG, WORG) on four dates in 2020 and 2025, spanning both dry and high-water-vapour conditions. Per-station residuals go from **±400–500 mm to −13 to −66 mm**.

### Tests

`test/test_ecmwf_levels.py` builds a synthetic ERA-5 model-level file in ECMWF's native descending-latitude ordering, with terrain rising from 0 m in the south to 3000 m in the north so a reflection is unambiguous, and loads it through the real `_load_model_level`. `z` is generated with `calcgeoh` exactly as RAiDER's own `_fetch` writes it.

Two assertions are load-bearing and **both fail on the pre-fix code** (the correlation comes out at −0.9986):

- surface height per latitude row matches the terrain it was built from
- `corr(surface height, −surface pressure) > 0.99`

The domain mean is deliberately not asserted on, for the reason above; every assertion is per-column.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
