### PR TITLE
Update dem download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 * [811](https://github.com/dbekaert/RAiDER/pull/811) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
+* Update dem to match NISAR DEM as noted here: https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/blob/dev/notebooks/analysis_and_comparison/2_Comparison_with_NISAR_DEM.ipynb
 
 ### Changed
 * [808](https://github.com/dbekaert/RAiDER/pull/808) - Use `xarray.open_dataset` instead of `load_dataset` for memory efficiency, and guard weather-model file reads with explicit error handling so that datasets are always closed. Dropped the redundant full-cube `shutil.copy` from the ECMWF model-level download, and added regression tests covering the layout contract between `ECMWF._get_from_cds` and `ECMWF._makeDataCubes`.

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
  - cdsapi
  - cfgrib
  - dask
- - dem_stitcher>=2.5.8
+ - dem_stitcher>=3.0.0
  - ecmwf-api-client
  - geopandas
  - h5netcdf

--- a/tools/RAiDER/dem.py
+++ b/tools/RAiDER/dem.py
@@ -62,7 +62,7 @@ def download_dem(
             list(bounds),
             dem_name='glo_30',
             dst_ellipsoidal_height=True,
-            dst_area_or_point='Area',
+            dst_area_or_point=None,
         )
         metadata = cast(RIO.Profile, metadata)
         if writeDEM:


### PR DESCRIPTION
@mgovorcin noticed that dem-stitcher introduced a phase bias when used with compass, but NISAR DEM did not.

It was determined that a half pixel shift with the geoid used in dem-stitcher was incorrect.

This has now been fixed: https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/blob/dev/notebooks/analysis_and_comparison/2_Comparison_with_NISAR_DEM.ipynb

I updated the dem-stitcher use appropriately - the lock files still need to be updated though.