### PR TITLE
Preserve the ERA-5 surface geopotential and start the model-level integration from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
+* [812](https://github.com/dbekaert/RAiDER/issues/812) - Start the ERA-5 model-level hydrostatic integration at the terrain surface instead of the lowest full model level. The fetch step now keeps the downloaded surface geopotential as its own `z_surface` variable alongside the recomputed full-level `z` cube instead of discarding it, and `_load_model_level` passes it to `_calculategeoh`, whose contract is the true surface geopotential. Previously the loader passed `z[0]` (the lowest full level, ~10 m above ground), shifting every reconstructed column up by a near-uniform +9.4 to +10.2 m. Files fetched before `z_surface` was stored fall back to the previous behavior.
 * [811](https://github.com/dbekaert/RAiDER/pull/811) - Fixed a north-south flip in the ECMWF/ERA-5 model-level reader. `_load_model_level` reversed only the level axis of the geopotential cube (`z[::-1]`) while `t`, `q`, and `lnsp` had their latitude axis reversed, leaving heights mirrored in latitude relative to the meteorology. Surface height and surface pressure were anti-correlated (r = -0.54 where physics requires ~+1); sea-level ZTD over a 3-degree box spanned 1621-3233 mm instead of 2239-2395 mm. The error is antisymmetric in latitude, so it largely cancels in a domain average while being severe at individual points.
 
 ### Changed

--- a/test/test_ecmwf_fetch.py
+++ b/test/test_ecmwf_fetch.py
@@ -180,10 +180,38 @@ def test_load_model_level_populates_the_model(era5: ERA5, fetched: Path) -> None
 
 def test_z_surface_round_trips_as_a_surface_field(era5: ERA5, fetched: Path) -> None:
     """The downloaded surface geopotential survives the post-processing unchanged."""
+    with xr.open_dataset(fetched) as ds:
+        # on-disk layout: aligned on the level coordinate, like lnsp
+        assert ds['z_surface'].dims == ds['t'].dims
+
     *_, z_surface = era5._makeDataCubes(fetched)
 
     assert z_surface is not None
     assert np.array_equal(z_surface, np.full((NLAT, NLON), SURFACE_GEOPOTENTIAL))
+
+
+def test_unexpected_z_surface_layout_falls_back(era5: ERA5, fetched: Path, tmp_path: Path) -> None:
+    """A z_surface stored in a foreign layout is ignored, not misread.
+
+    The reader recovers z_surface as ``[0, 0]`` of the level-aligned layout the
+    fetch writes; a 2D (lat, lon) variable read that way would yield a scalar.
+    The reader must fall back to the lowest full level instead of crashing or
+    broadcasting a wrong value.
+    """
+    foreign_path = tmp_path / 'foreign_z_surface.nc'
+    with xr.open_dataset(fetched) as ds:
+        ds = ds.drop_vars('z_surface')
+        ds['z_surface'] = (
+            ('latitude', 'longitude'),
+            np.full((NLAT, NLON), SURFACE_GEOPOTENTIAL),
+        )
+        ds.to_netcdf(foreign_path)
+
+    *_, z_surface = era5._makeDataCubes(foreign_path)
+    assert z_surface is None
+
+    era5._load_model_level(foreign_path)
+    assert np.all(np.isfinite(era5._zs))
 
 
 def test_column_heights_start_at_the_surface(era5: ERA5, fetched: Path) -> None:
@@ -208,8 +236,8 @@ def test_column_heights_start_at_the_surface(era5: ERA5, fetched: Path) -> None:
     # step writes that mutated array back out, so the loader re-applies the
     # moisture factor and lands slightly above the stored cube — for this
     # fixture (q = 1e-3, T <= 290 K) roughly R_d * 0.609e-3 * 290 * alpha / g0
-    # ~ 6 mm at the lowest level. The bug this test guards is three orders of
-    # magnitude above the 0.02 m tolerance.
+    # ~ 6 mm at the lowest level. The ~10 m bug this test guards exceeds the
+    # 0.02 m tolerance with ample margin.
     assert np.allclose(era5._zs[..., 0], expected_lowest, atol=0.02)
 
 

--- a/test/test_ecmwf_fetch.py
+++ b/test/test_ecmwf_fetch.py
@@ -206,8 +206,10 @@ def test_column_heights_start_at_the_surface(era5: ERA5, fetched: Path) -> None:
     # The tolerance leaves room for a separate, much smaller defect: calcgeoh
     # turns its t argument into virtual temperature in place, and the fetch
     # step writes that mutated array back out, so the loader re-applies the
-    # moisture factor and lands a few mm above the stored cube. The bug this
-    # test guards is three orders of magnitude larger.
+    # moisture factor and lands slightly above the stored cube — for this
+    # fixture (q = 1e-3, T <= 290 K) roughly R_d * 0.609e-3 * 290 * alpha / g0
+    # ~ 6 mm at the lowest level. The bug this test guards is three orders of
+    # magnitude above the 0.02 m tolerance.
     assert np.allclose(era5._zs[..., 0], expected_lowest, atol=0.02)
 
 

--- a/test/test_ecmwf_fetch.py
+++ b/test/test_ecmwf_fetch.py
@@ -9,6 +9,10 @@ The layout contract is:
 
 * `t`, `q`, `z` are ``(time, level, lat, lon)`` cubes spanning all model levels
 * `lnsp` is a surface field, recovered by the reader as ``lnsp[0, 0]``
+* `z_surface` is the downloaded surface geopotential, kept alongside the
+  recomputed full-level `z` cube and recovered the same way as `lnsp`; the
+  reader starts the hydrostatic integration from it, falling back to the
+  lowest full level for files fetched before it was stored
 
 ERA-5 archives `lnsp` and `z` at model level 1 only, so they have to be
 requested separately from `t`/`q`: CDS returns a mixed-level request as separate
@@ -23,7 +27,9 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from RAiDER.constants import _g0
 from RAiDER.models.era5 import ERA5
+from RAiDER.utilFcns import geo_to_ht
 
 
 NLEV = 137
@@ -132,18 +138,19 @@ def test_surface_and_model_level_fields_are_requested_separately(fetched: Path) 
 
 def test_downloaded_file_is_readable_by_makeDataCubes(era5: ERA5, fetched: Path) -> None:
     """The shapes _load_model_level relies on when it calls _calculategeoh."""
-    lats, lons, _, _, t, q, lnsp, z = era5._makeDataCubes(fetched)
+    lats, lons, _, _, t, q, lnsp, z, z_surface = era5._makeDataCubes(fetched)
 
     assert lnsp.shape == (NLAT, NLON)
     assert t.shape == (NLEV, NLAT, NLON)
     assert q.shape == (NLEV, NLAT, NLON)
     assert z.shape == (NLEV, NLAT, NLON)
+    assert z_surface.shape == (NLAT, NLON)
     assert len(lats) == NLAT
     assert len(lons) == NLON
 
 
 def test_lnsp_round_trips_as_a_surface_field(era5: ERA5, fetched: Path) -> None:
-    *_, lnsp, _ = era5._makeDataCubes(fetched)
+    *_, lnsp, _, _ = era5._makeDataCubes(fetched)
 
     assert np.all(np.isfinite(lnsp))
     assert np.allclose(np.exp(lnsp), SURFACE_PRESSURE)
@@ -151,7 +158,7 @@ def test_lnsp_round_trips_as_a_surface_field(era5: ERA5, fetched: Path) -> None:
 
 def test_z_is_written_as_a_full_model_level_cube(era5: ERA5, fetched: Path) -> None:
     """CDS supplies z at the surface only; _get_from_cds fills in the other levels."""
-    *_, z = era5._makeDataCubes(fetched)
+    *_, z, _ = era5._makeDataCubes(fetched)
 
     assert np.all(np.isfinite(z))
     # Level 137 is nearest the surface and level 1 is the top of the atmosphere,
@@ -169,3 +176,56 @@ def test_load_model_level_populates_the_model(era5: ERA5, fetched: Path) -> None
     assert np.all(np.isfinite(era5._p))
     # _load_model_level flips everything to run surface-to-top.
     assert np.all(np.diff(era5._zs, axis=2) > 0)
+
+
+def test_z_surface_round_trips_as_a_surface_field(era5: ERA5, fetched: Path) -> None:
+    """The downloaded surface geopotential survives the post-processing unchanged."""
+    *_, z_surface = era5._makeDataCubes(fetched)
+
+    assert z_surface is not None
+    assert np.array_equal(z_surface, np.full((NLAT, NLON), SURFACE_GEOPOTENTIAL))
+
+
+def test_column_heights_start_at_the_surface(era5: ERA5, fetched: Path) -> None:
+    """The loader reproduces the heights the fetch step computed.
+
+    The loader re-runs the hydrostatic integration from the surface
+    geopotential; the fetch step already did the same integration from the
+    same inputs when it built the stored z cube, so the reconstructed lowest
+    full level must match the stored one to numerical precision. Starting the
+    integration from the lowest full level instead (the pre-fix behavior)
+    shifts every column up by that level's height above the terrain (~10 m
+    here), which this tolerance rejects.
+    """
+    *_, z, _ = era5._makeDataCubes(fetched)
+    era5._load_model_level(fetched)
+
+    # stored cube runs top -> surface with descending latitude; _zs runs
+    # surface -> top with ascending latitude
+    expected_lowest = geo_to_ht(era5._lats, z[-1, ::-1] / _g0)
+    # The tolerance leaves room for a separate, much smaller defect: calcgeoh
+    # turns its t argument into virtual temperature in place, and the fetch
+    # step writes that mutated array back out, so the loader re-applies the
+    # moisture factor and lands a few mm above the stored cube. The bug this
+    # test guards is three orders of magnitude larger.
+    assert np.allclose(era5._zs[..., 0], expected_lowest, atol=0.02)
+
+
+def test_legacy_file_without_z_surface_falls_back(era5: ERA5, fetched: Path, tmp_path: Path) -> None:
+    """Files fetched before z_surface was stored still load, with the old offset."""
+    legacy_path = tmp_path / 'legacy.nc'
+    with xr.open_dataset(fetched) as ds:
+        ds.drop_vars('z_surface').to_netcdf(legacy_path)
+
+    *_, z, z_surface = era5._makeDataCubes(legacy_path)
+    assert z_surface is None
+
+    era5._load_model_level(legacy_path)
+    zs_legacy = era5._zs.copy()
+    era5._load_model_level(fetched)
+
+    # The fallback starts the integration at the lowest full level, so every
+    # column sits higher than the fixed one by exactly that level's height
+    # above the terrain.
+    lowest_level_agl = (z[-1, ::-1] - SURFACE_GEOPOTENTIAL) / _g0
+    assert np.allclose(zs_legacy[..., 0] - era5._zs[..., 0], lowest_level_agl, atol=1e-2)

--- a/test/test_ecmwf_levels.py
+++ b/test/test_ecmwf_levels.py
@@ -10,6 +10,7 @@ That failure mode is antisymmetric in latitude, so it very nearly cancels in
 a domain average -- a mean-based check will not catch it. The assertions here
 are deliberately per-column.
 """
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -21,8 +22,8 @@ from RAiDER.utilFcns import calcgeoh, geo_to_ht
 
 # Terrain rising steeply from south to north, so that a latitude reflection is
 # unambiguous: the southern rows are at sea level, the northern rows are high.
-_LATS_DESC = np.array([36.0, 35.0, 34.0, 33.0])   # ECMWF order: descending
-_LONS = np.array([240.0, 241.0, 242.0])           # 0-360, as ECMWF delivers
+_LATS_DESC = np.array([36.0, 35.0, 34.0, 33.0])  # ECMWF order: descending
+_LONS = np.array([240.0, 241.0, 242.0])  # 0-360, as ECMWF delivers
 _TERRAIN = {36.0: 3000.0, 35.0: 2000.0, 34.0: 1000.0, 33.0: 0.0}
 
 
@@ -55,8 +56,14 @@ def _write_synthetic_ml_file(path, include_z_surface=False):
     # array instead — a separate defect; this fixture writes the intended
     # layout.)
     z_full, _, _ = calcgeoh(
-        lnsp=lnsp, t=t.copy(), q=q, z_surface=z_surface,
-        a=model._a, b=model._b, R_d=model._R_d, num_levels=nlev,
+        lnsp=lnsp,
+        t=t.copy(),
+        q=q,
+        z_surface=z_surface,
+        a=model._a,
+        b=model._b,
+        R_d=model._R_d,
+        num_levels=nlev,
     )
 
     dims = ('valid_time', 'model_level', 'latitude', 'longitude')
@@ -113,7 +120,7 @@ def test_surface_height_matches_terrain_per_latitude(loaded_model):
     """
     m = loaded_model
     lats = m._lats[:, 0]
-    surface_height = m._zs[..., 0]   # _zs runs bottom -> top after loading
+    surface_height = m._zs[..., 0]  # _zs runs bottom -> top after loading
 
     expected = np.array([_TERRAIN[round(float(la))] for la in lats])
     # geo_to_ht applies a small geometric correction, so allow a loose tolerance;

--- a/test/test_ecmwf_levels.py
+++ b/test/test_ecmwf_levels.py
@@ -16,7 +16,7 @@ import xarray as xr
 
 from RAiDER.constants import _g0
 from RAiDER.models.era5 import ERA5
-from RAiDER.utilFcns import calcgeoh
+from RAiDER.utilFcns import calcgeoh, geo_to_ht
 
 
 # Terrain rising steeply from south to north, so that a latitude reflection is
@@ -26,11 +26,14 @@ _LONS = np.array([240.0, 241.0, 242.0])           # 0-360, as ECMWF delivers
 _TERRAIN = {36.0: 3000.0, 35.0: 2000.0, 34.0: 1000.0, 33.0: 0.0}
 
 
-def _write_synthetic_ml_file(path):
+def _write_synthetic_ml_file(path, include_z_surface=False):
     """Write a minimal ERA-5 model-level file in ECMWF's native ordering.
 
     Mirrors what RAiDER's own _fetch writes: z is the *full* geopotential cube
-    (computed with calcgeoh), not the surface-only field CDS returns.
+    (computed with calcgeoh), not the surface-only field CDS returns. With
+    ``include_z_surface`` the downloaded surface geopotential is kept as its
+    own variable, as the fetch step now does; without it the file has the
+    legacy layout, where the reader has to fall back to the lowest full level.
     """
     model = ERA5()
     nlev = model._levels
@@ -46,20 +49,26 @@ def _write_synthetic_ml_file(path):
     psurf = 101325.0 * np.exp(-terrain / 8400.0)
     lnsp = np.log(psurf)
 
+    # calcgeoh turns its t argument into virtual temperature in place, so pass
+    # a copy: the file must carry true temperature, as CDS delivers it.
     z_full, _, _ = calcgeoh(
-        lnsp=lnsp, t=t, q=q, z_surface=z_surface,
+        lnsp=lnsp, t=t.copy(), q=q, z_surface=z_surface,
         a=model._a, b=model._b, R_d=model._R_d, num_levels=nlev,
     )
 
     dims = ('valid_time', 'model_level', 'latitude', 'longitude')
+    data_vars = {
+        't': (dims, t[np.newaxis]),
+        'q': (dims, q[np.newaxis]),
+        'z': (dims, np.asarray(z_full)[np.newaxis]),
+        # the reader takes lnsp as [0, 0], so it must carry both leading dims
+        'lnsp': (dims, np.broadcast_to(lnsp, (1, nlev, nlat, nlon)).copy()),
+    }
+    if include_z_surface:
+        # like lnsp, read back by the reader as [0, 0]
+        data_vars['z_surface'] = (dims, np.broadcast_to(z_surface, (1, nlev, nlat, nlon)).copy())
     ds = xr.Dataset(
-        data_vars={
-            't': (dims, t[np.newaxis]),
-            'q': (dims, q[np.newaxis]),
-            'z': (dims, np.asarray(z_full)[np.newaxis]),
-            # the reader takes lnsp as [0, 0], so it must carry both leading dims
-            'lnsp': (dims, np.broadcast_to(lnsp, (1, nlev, nlat, nlon)).copy()),
-        },
+        data_vars=data_vars,
         coords={
             'valid_time': [0],
             'model_level': np.arange(1, nlev + 1),
@@ -71,10 +80,16 @@ def _write_synthetic_ml_file(path):
     return model
 
 
-@pytest.fixture
-def loaded_model(tmp_path):
+@pytest.fixture(params=[False, True], ids=['legacy_layout', 'with_z_surface'])
+def loaded_model(tmp_path, request):
+    """The loaded synthetic model, in both file layouts.
+
+    The legacy layout exercises the lowest-full-level fallback (and with it
+    the orientation of the z cube); the z_surface layout exercises the
+    orientation of the stored surface field.
+    """
     f = tmp_path / 'ERA-5_synthetic_ml.nc'
-    model = _write_synthetic_ml_file(f)
+    model = _write_synthetic_ml_file(f, include_z_surface=request.param)
     model._ll_bounds = (32.5, 36.5, -120.5, -117.5)
     model._load_model_level(f)
     return model
@@ -123,3 +138,29 @@ def test_heights_increase_upward(loaded_model):
     m = loaded_model
     assert (np.diff(m._zs, axis=2) > 0).all()
     assert (np.diff(m._p, axis=2) < 0).all()
+
+
+def test_z_surface_starts_columns_at_the_terrain(tmp_path):
+    """With z_surface stored, the reader reproduces the fetch-time heights exactly.
+
+    The reader re-runs the hydrostatic integration from the surface
+    geopotential it is given. Started from the true surface, it lands each
+    full level exactly where the fetch-time calcgeoh put it in the stored z
+    cube; started from the lowest full level (the legacy fallback), every
+    column comes out ~10 m too high; started from a mirrored z_surface, the
+    error would be the terrain difference between mirrored latitudes
+    (hundreds to thousands of meters). A tight per-column tolerance catches
+    all of these.
+    """
+    f = tmp_path / 'ERA-5_synthetic_ml_z_surface.nc'
+    model = _write_synthetic_ml_file(f, include_z_surface=True)
+    model._ll_bounds = (32.5, 36.5, -120.5, -117.5)
+    model._load_model_level(f)
+
+    with xr.open_dataset(f) as ds:
+        z_cube = ds['z'].values[0]  # (level, lat, lon), latitude descending
+
+    # stored cube runs top -> surface with descending latitude; _zs runs
+    # surface -> top with ascending latitude
+    expected_lowest = geo_to_ht(model._lats, z_cube[-1, ::-1] / _g0)
+    assert np.allclose(model._zs[..., 0], expected_lowest, atol=1e-3)

--- a/test/test_ecmwf_levels.py
+++ b/test/test_ecmwf_levels.py
@@ -50,7 +50,10 @@ def _write_synthetic_ml_file(path, include_z_surface=False):
     lnsp = np.log(psurf)
 
     # calcgeoh turns its t argument into virtual temperature in place, so pass
-    # a copy: the file must carry true temperature, as CDS delivers it.
+    # a copy so the synthetic file carries the temperature CDS puts in its raw
+    # response. (Files written by the real fetch currently store the mutated
+    # array instead — a separate defect; this fixture writes the intended
+    # layout.)
     z_full, _, _ = calcgeoh(
         lnsp=lnsp, t=t.copy(), q=q, z_surface=z_surface,
         a=model._a, b=model._b, R_d=model._R_d, num_levels=nlev,

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -397,6 +397,11 @@ class ECMWF(WeatherModel):
             # lnsp, it is aligned on the level coordinate and read back from
             # the first level.
             z_surface = block['z_surface'].values[0, 0] if 'z_surface' in block else None
+            if z_surface is not None and not np.all(np.isfinite(z_surface)):
+                # A z_surface that did not land on the first level (or was
+                # written by some other layout) reads back as NaN; treat it
+                # as absent rather than poisoning the integration.
+                z_surface = None
             lats = block['latitude'].values
             lons = block['longitude'].values
 

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -397,10 +397,12 @@ class ECMWF(WeatherModel):
             # lnsp, it is aligned on the level coordinate and read back from
             # the first level.
             z_surface = block['z_surface'].values[0, 0] if 'z_surface' in block else None
-            if z_surface is not None and not np.all(np.isfinite(z_surface)):
-                # A z_surface that did not land on the first level (or was
-                # written by some other layout) reads back as NaN; treat it
-                # as absent rather than poisoning the integration.
+            if z_surface is not None and (z_surface.shape != lnsp.shape or not np.all(np.isfinite(z_surface))):
+                # A z_surface stored in some other layout does not survive the
+                # [0, 0] read: a different rank yields the wrong shape, and a
+                # field that did not land on the first level reads back as
+                # NaN. Treat both as absent rather than poisoning the
+                # integration.
                 z_surface = None
             lats = block['latitude'].values
             lons = block['longitude'].values

--- a/tools/RAiDER/models/ecmwf.py
+++ b/tools/RAiDER/models/ecmwf.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -186,10 +187,16 @@ class ECMWF(WeatherModel):
                         dims=ds_t_q['t'].dims,
                         data=np.broadcast_to(z_full, (1, *z_full.shape)),
                     ),
-                    # xarray aligns on the level coordinate, so this lands on the
-                    # first level and is NaN on every other one. _makeDataCubes
-                    # reads it back as lnsp[0, 0] to recover the (lat, lon) field.
+                    # xarray aligns lnsp and z_surface on the level coordinate,
+                    # so they land on the first level and are NaN on every other
+                    # one. _makeDataCubes reads them back as [0, 0] to recover
+                    # the (lat, lon) fields.
                     lnsp=ds_lnsp_z['lnsp'],
+                    # Also keep the downloaded surface geopotential: the loader
+                    # needs it to start the hydrostatic integration at the
+                    # terrain surface rather than at the lowest full level,
+                    # which sits roughly 10 m above it.
+                    z_surface=ds_lnsp_z['z'],
                 )
                 ds_out.to_netcdf(out_path)
 
@@ -232,13 +239,13 @@ class ECMWF(WeatherModel):
 
     def _load_model_level(self, filename, *args, **kwargs) -> None:
         # read data from netcdf file
-        lats, lons, _, _, t, q, lnsp, z = self._makeDataCubes(Path(filename))
+        lats, lons, _, _, t, q, lnsp, z, z_surface = self._makeDataCubes(Path(filename))
 
         # ECMWF appears to give me this backwards
         if lats[0] > lats[1]:
             # z is (level, lat, lon). It needs BOTH axes reversed: the latitude
             # axis to match t/q/lnsp, and the level axis because the surface
-            # geopotential is taken as z[0] below (the stored cube runs
+            # geopotential falls back to z[0] below (the stored cube runs
             # top-of-atmosphere -> surface). Reversing only axis 0, as this
             # previously did, left the height field mirrored north-south
             # relative to the meteorology.
@@ -247,6 +254,8 @@ class ECMWF(WeatherModel):
             t: FloatArray3D = t[:, ::-1]
             q: FloatArray3D = q[:, ::-1]
             lats: FloatArray1D = lats[::-1]
+            if z_surface is not None:
+                z_surface = z_surface[::-1]
         # Lons is usually ok, but we'll throw in a check to be safe
         if lons[0] > lons[1]:
             z: FloatArray3D = z[..., ::-1]
@@ -254,12 +263,21 @@ class ECMWF(WeatherModel):
             t: FloatArray3D = t[..., ::-1]
             q: FloatArray3D = q[..., ::-1]
             lons: FloatArray1D = lons[::-1]
+            if z_surface is not None:
+                z_surface = z_surface[..., ::-1]
         # pyproj gets fussy if the latitude is wrong, plus our
         # interpolator isn't clever enough to pick up on the fact that
         # they are the same
         lons[lons > 180] -= 360
 
-        geo_hgt, p, hgt = self._calculategeoh(z[0, :], lnsp, t, q)
+        if z_surface is None:
+            # Files fetched before z_surface was stored only carry the
+            # recomputed full-level cube: fall back to the lowest full level,
+            # which sits roughly 10 m above the terrain, so every column comes
+            # out shifted up by that amount.
+            z_surface = z[0]
+
+        geo_hgt, p, hgt = self._calculategeoh(z_surface, lnsp, t, q)
 
         self._lons, self._lats = np.meshgrid(lons, lats)
 
@@ -343,7 +361,17 @@ class ECMWF(WeatherModel):
         self,
         path: Path,
         verbose: bool = False,
-    ) -> WeatherModel.DataCubes:
+    ) -> tuple[
+        FloatArray1D,  # lats
+        FloatArray1D,  # lons
+        FloatArray1D,  # xs
+        FloatArray1D,  # ys
+        FloatArray3D,  # t
+        FloatArray3D,  # q
+        FloatArray2D,  # lnsp
+        FloatArray3D,  # z - full model-level geopotential cube
+        Optional[FloatArray2D],  # z_surface - surface geopotential, None for files fetched before it was stored
+    ]:
         """
         Create a cube of data representing temperature and relative humidity
         at specified pressure levels.
@@ -364,10 +392,15 @@ class ECMWF(WeatherModel):
             q = block['q'].values.squeeze()
             lnsp = block['lnsp'].values[0, 0]
             z = block['z'].values.squeeze()
+            # Surface geopotential is only present in files fetched since it
+            # was preserved alongside the recomputed full-level cube; like
+            # lnsp, it is aligned on the level coordinate and read back from
+            # the first level.
+            z_surface = block['z_surface'].values[0, 0] if 'z_surface' in block else None
             lats = block['latitude'].values
             lons = block['longitude'].values
 
         if z.size == 0:
             raise RuntimeError('There is no data in z, you may have a problem with your mask')
 
-        return lats, lons, lats, lons, t, q, lnsp, z
+        return lats, lons, lats, lons, t, q, lnsp, z, z_surface


### PR DESCRIPTION
## Description

Before this change, `_get_from_cds` computed the full-model-level geopotential cube from the downloaded surface geopotential and then discarded that surface field. `_load_model_level` therefore had to start the hydrostatic integration from the lowest *full* model level (`z[0]`), where `_calculategeoh`'s contract is the true surface geopotential, so every reconstructed column sat a near-uniform +9.4 to +10.2 m too high (the height of the lowest full level above ground).

This PR:

* keeps the downloaded surface geopotential in the fetched file as its own `z_surface` variable, aligned on the level coordinate exactly like `lnsp` (fetch side);
* returns it from `_makeDataCubes` (`None` when absent, or when the stored variable does not match the layout the fetch writes) and prefers it in `_load_model_level`, falling back to the previous `z[0]` behavior for files fetched before this change — HRES files, which share this loader, continue through the same fallback path (HRES itself was not independently exercised).

## Motivation and Context

Fixes #812; follow-up to #811 as discussed there and in #806.

Relation to #805: that rework of the ML fetch also replaces the downloaded surface z with the recomputed cube. If it lands first, the fetch-side change here is a small rebase onto its fetch path (the acceptance criterion is the same: fetched files retain the true surface geopotential as a separate variable); the loader-side change is independent of it.

## How Has This Been Tested?

Measured on real archived CDS responses (the raw `lnsp/z` and `t/q` files CDS served for a Kanto scene, 2026-03-01 00:00 UTC), replayed through `_get_from_cds` with a mocked `cdsapi.Client` so the exact post-processing of this branch runs on the exact bytes CDS delivered. Full report with commit-pinned RAiDER builds and package versions: <https://github.com/s-sasaki-earthsea-wizard/raider-arco-era5/blob/8576fbb0585e42ee05f9a206f16b6dd139d61562/reports/ml_offset_regression_812_fix.md>

| | z_surface passed to `_calculategeoh` (bitwise identity) | column offset | columns |
|---|---|---|---|
| `dev`@c80cf1e, pre-fix file | lowest full level | +9.46 to +10.19 m | n=575 |
| fix, pre-fix file | lowest full level | +9.46 to +10.19 m (identical to the last digit) | n=575 |
| fix, file written by the fixed fetch | **the surface z CDS delivered** | **+0.04 to +0.35 m** | n=441 |

(The last row uses the replayed file's own grid, hence the different column count.) The remaining +0.04 to +0.35 m is reproduced quantitatively by a separate pre-existing defect — the fetch stores virtual temperature in `t` because `calcgeoh` mutates its argument in place — filed as #819; the surface field itself arrives bitwise intact.

Unit tests (all pass locally, `pytest test/test_ecmwf_fetch.py test/test_ecmwf_levels.py`):

* `test_ecmwf_fetch.py`: the fetched file carries `z_surface` bitwise in the same layout as `lnsp`; the loader reproduces the fetch-time lowest-level height (0.02 m tolerance, which the ~10 m pre-fix behavior exceeds with ample margin); a file with `z_surface` stripped falls back to the pre-fix behavior, sitting higher by the lowest level's height above ground (to within 0.01 m); a `z_surface` stored in a foreign layout is ignored rather than misread.
* `test_ecmwf_levels.py`: the descending-latitude fixture now runs in both layouts (with and without `z_surface`), guarding the orientation of both the z cube and the stored surface field; a new per-column check pins the reconstruction to the stored cube at 1e-3 m.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added an explanation of what your changes do and why you'd like us to include them.
- [x] I have written new tests for your core changes, as applicable.
- [x] I have successfully ran tests with your changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
